### PR TITLE
Fix Barbados english name

### DIFF
--- a/lib/data/countries.yaml
+++ b/lib/data/countries.yaml
@@ -752,7 +752,7 @@ BB:
   - Barbados
   - バルバドス
   translations:
-    en: Barbade
+    en: Barbados
     it: Barbados
     de: Barbados
     fr: Barbade


### PR DESCRIPTION
Barbados/Barbade english name should be "Barbados"