### PR TITLE
adding 11 to national_number_lengths on Brazil because Sao Paulo city us...

### DIFF
--- a/lib/data/countries.yaml
+++ b/lib/data/countries.yaml
@@ -1274,6 +1274,7 @@ BR:
   - 2
   national_number_lengths:
   - 10
+  - 11
   national_prefix: '014'
   number: '076'
   region: Americas


### PR DESCRIPTION
In São Paulo (Brazil) the telephone number has one more digit than in other cities. 