### PR TITLE
Fixed Country#== method

### DIFF
--- a/lib/countries/country.rb
+++ b/lib/countries/country.rb
@@ -48,6 +48,7 @@ class ISO3166::Country
   end
 
   def ==(other)
+    return false unless other.respond_to?(:data)
     self.data == other.data
   end
 


### PR DESCRIPTION
It should return false if the other object does not respond to 'data'.

This was actually causing error on the pry console with awesome_print.
It would trow an error every time it tried to print the object

```ruby
2.1.1 (main):0 > c = ISO3166::Country.new 'US'
(pry) output error: #<NoMethodError: undefined method `data' for #<Object:0x007ffc59071540>>
``` 

Now it's working fine
```ruby
2.1.1 (main):0 > c = ISO3166::Country.new 'US'
=> #<ISO3166::Country:0x007fa6dd89c4f8 @data={"continent"=>"North America", "address_format"=>"{{recipient}}\n{{street}}\n{{city}} {{region}} {{postalcode}}\n{{country}}", "alpha2"=>"US", "alpha3"=>"USA", "country_code"=>"1", "currency"=>"USD", "international_prefix"=>"011", "ioc"=>"USA", "latitude"=>"38 00 N", "longitude"=>"97 00 W", "name"=>"United States", "names"=>["United States of America", "Vereinigte Staaten von Amerika", "États-Unis", "Estados Unidos", "アメリカ合衆国", "Verenigde Staten"], "translations"=>{"en"=>"United States of America", "it"=>"Stati Uniti D'America", "de"=>"Vereinigte Staaten von Amerika", "fr"=>"États-Unis", "es"=>"Estados Unidos", "ja"=>"アメリカ合衆国", "nl"=>"Verenigde Staten"}, "national_destination_code_lengths"=>[3], "national_number_lengths"=>[10], "national_prefix"=>"1", "number"=>"840", "region"=>"Americas", "subregion"=>"Northern America", "un_locode"=>"US", "languages"=>["en"], "nationality"=>"American"}>
```