### PR TITLE
Added VAT rates to EU countries

### DIFF
--- a/lib/countries/country.rb
+++ b/lib/countries/country.rb
@@ -28,7 +28,8 @@ class ISO3166::Country
     :un_locode,
     :languages,
     :nationality,
-    :eu_member
+    :eu_member,
+    :vat_rates
   ]
 
   AttrReaders.each do |meth|

--- a/lib/data/countries.yaml
+++ b/lib/data/countries.yaml
@@ -532,6 +532,12 @@ AT:
   - de
   nationality: Austrian
   eu_member: true
+  vat_rates:
+    standard: 20
+    reduced:
+    - 10
+    super_reduced:
+    parking: 12
 AU:
   continent: Australia
   address_format: ! '{{recipient}}
@@ -858,6 +864,13 @@ BE:
   - de
   nationality: Belgian
   eu_member: true
+  vat_rates:
+    standard: 21
+    reduced:
+    - 6
+    - 12
+    super_reduced:
+    parking: 12
 BF:
   continent: Africa
   alpha2: BF
@@ -942,6 +955,12 @@ BG:
   - bg
   nationality: Bulgarian
   eu_member: true
+  vat_rates:
+    standard: 20
+    reduced:
+    - 9
+    super_reduced:
+    parking:
 BH:
   continent: Asia
   address_format: ! '{{recipient}}
@@ -2211,6 +2230,13 @@ CY:
   - hy
   nationality: Cypriot
   eu_member: true
+  vat_rates:
+    standard: 19
+    reduced:
+    - 5
+    - 9
+    super_reduced:
+    parking:
 CZ:
   continent: Europe
   address_format: ! '{{recipient}}
@@ -2259,6 +2285,12 @@ CZ:
   - sk
   nationality: Czech
   eu_member: true
+  vat_rates:
+    standard: 21
+    reduced:
+    - 15
+    super_reduced:
+    parking:
 DE:
   continent: Europe
   address_format: ! '{{recipient}}
@@ -2314,6 +2346,12 @@ DE:
   - de
   nationality: German
   eu_member: true
+  vat_rates:
+    standard: 19
+    reduced:
+    - 7
+    super_reduced:
+    parking:
 DJ:
   continent: Africa
   alpha2: DJ
@@ -2400,6 +2438,11 @@ DK:
   - da
   nationality: Danish
   eu_member: true
+  vat_rates:
+    standard: 25
+    reduced: []
+    super_reduced:
+    parking:
 DM:
   continent: North America
   alpha2: DM
@@ -2589,6 +2632,12 @@ EE:
   - et
   nationality: Estonian
   eu_member: true
+  vat_rates:
+    standard: 20
+    reduced:
+    - 9
+    super_reduced:
+    parking:
 EG:
   continent: Africa
   address_format: ! '{{recipient}}
@@ -2757,6 +2806,12 @@ ES:
   - es
   nationality: Spanish
   eu_member: true
+  vat_rates:
+    standard: 21
+    reduced:
+    - 10
+    super_reduced: 4
+    parking:
 ET:
   continent: Africa
   alpha2: ET
@@ -2843,6 +2898,13 @@ FI:
   - sv
   nationality: Finnish
   eu_member: true
+  vat_rates:
+    standard: 24
+    reduced:
+    - 10
+    - 14
+    super_reduced:
+    parking:
 FJ:
   continent: Australia
   alpha2: FJ
@@ -3047,6 +3109,13 @@ FR:
   - fr
   nationality: French
   eu_member: true
+  vat_rates:
+    standard: 20
+    reduced:
+    - 5.5
+    - 10
+    super_reduced: 2.1
+    parking:
 GA:
   continent: Africa
   alpha2: GA
@@ -3138,6 +3207,12 @@ GB:
   - en
   nationality: British
   eu_member: true
+  vat_rates:
+    standard: 20
+    reduced:
+    - 5
+    super_reduced:
+    parking:
 GD:
   continent: North America
   alpha2: GD
@@ -3600,6 +3675,13 @@ GR:
   - el
   nationality: Greek
   eu_member: true
+  vat_rates:
+    standard: 23
+    reduced:
+    - 6.5
+    - 13
+    super_reduced:
+    parking:
 GS:
   continent: Antarctica
   alpha2: GS
@@ -3942,6 +4024,13 @@ HR:
   - hr
   nationality: Croatian
   eu_member: true
+  vat_rates:
+    standard: 25
+    reduced:
+    - 5
+    - 13
+    super_reduced:
+    parking:
 HT:
   continent: North America
   alpha2: HT
@@ -4029,6 +4118,13 @@ HU:
   - hu
   nationality: Hungarian
   eu_member: true
+  vat_rates:
+    standard: 27
+    reduced:
+    - 5
+    - 18
+    super_reduced:
+    parking:
 ID:
   continent: Asia
   address_format: ! '{{recipient}}
@@ -4127,6 +4223,13 @@ IE:
   - ga
   nationality: Irish
   eu_member: true
+  vat_rates:
+    standard: 23
+    reduced:
+    - 9
+    - 13.5
+    super_reduced: 4.8
+    parking: 13.5
 IL:
   continent: Asia
   address_format: ! '{{recipient}}
@@ -4460,6 +4563,12 @@ IT:
   - it
   nationality: Italian
   eu_member: true
+  vat_rates:
+    standard: 22
+    reduced:
+    - 10
+    super_reduced: 4
+    parking:
 JE:
   continent: Europe
   alpha2: JE
@@ -5368,6 +5477,13 @@ LT:
   - lt
   nationality: Lithuanian
   eu_member: true
+  vat_rates:
+    standard: 21
+    reduced:
+    - 5
+    - 9
+    super_reduced:
+    parking:
 LU:
   continent: Europe
   address_format: ! '{{recipient}}
@@ -5415,6 +5531,13 @@ LU:
   - lb
   nationality: Luxembourger
   eu_member: true
+  vat_rates:
+    standard: 15
+    reduced:
+    - 6
+    - 12
+    super_reduced: 3
+    parking: 12
 LV:
   continent: Europe
   alpha2: LV
@@ -5455,6 +5578,12 @@ LV:
   - lv
   nationality: Latvian
   eu_member: true
+  vat_rates:
+    standard: 21
+    reduced:
+    - 12
+    super_reduced:
+    parking:
 LY:
   continent: Africa
   alpha2: LY
@@ -6145,6 +6274,13 @@ MT:
   - en
   nationality: Maltese
   eu_member: true
+  vat_rates:
+    standard: 18
+    reduced:
+    - 5
+    - 7
+    super_reduced:
+    parking:
 MU:
   continent: Africa
   alpha2: MU
@@ -6653,6 +6789,12 @@ NL:
   - nl
   nationality: Dutch
   eu_member: true
+  vat_rates:
+    standard: 21
+    reduced:
+    - 6
+    super_reduced:
+    parking:
 'NO':
   continent: Europe
   address_format: ! '{{recipient}}
@@ -7189,6 +7331,13 @@ PL:
   - pl
   nationality: Polish
   eu_member: true
+  vat_rates:
+    standard: 23
+    reduced:
+    - 6
+    - 13
+    super_reduced:
+    parking: 13
 PM:
   continent: North America
   alpha2: PM
@@ -7383,6 +7532,13 @@ PT:
   - pt
   nationality: Portuguese
   eu_member: true
+  vat_rates:
+    standard: 23
+    reduced:
+    - 6
+    - 13
+    super_reduced:
+    parking: 13
 PW:
   continent: Australia
   alpha2: PW
@@ -7580,6 +7736,13 @@ RO:
   - ro
   nationality: Romanian
   eu_member: true
+  vat_rates:
+    standard: 24
+    reduced:
+    - 5
+    - 9
+    super_reduced:
+    parking:
 RS:
   continent: Europe
   alpha2: RS
@@ -7912,6 +8075,13 @@ SE:
   - sv
   nationality: Swedish
   eu_member: true
+  vat_rates:
+    standard: 25
+    reduced:
+    - 6
+    - 12
+    super_reduced:
+    parking:
 SG:
   continent: Asia
   address_format: ! '{{recipient}}
@@ -8045,6 +8215,12 @@ SI:
   - sl
   nationality: Slovene
   eu_member: true
+  vat_rates:
+    standard: 22
+    reduced:
+    - 9.5
+    super_reduced:
+    parking:
 SJ:
   continent: Europe
   alpha2: SJ
@@ -8131,6 +8307,12 @@ SK:
   - sk
   nationality: Slovak
   eu_member: true
+  vat_rates:
+    standard: 20
+    reduced:
+    - 10
+    super_reduced:
+    parking:
 SL:
   continent: Africa
   alpha2: SL

--- a/lib/data/countries.yaml
+++ b/lib/data/countries.yaml
@@ -5709,10 +5709,10 @@ LU:
   nationality: Luxembourger
   eu_member: true
   vat_rates:
-    standard: 15
+    standard: 17
     reduced:
-    - 6
-    - 12
+    - 8
+    - 14
     super_reduced: 3
     parking: 12
   postal_code: true
@@ -7558,10 +7558,10 @@ PL:
   vat_rates:
     standard: 23
     reduced:
-    - 6
-    - 13
+    - 5
+    - 8
     super_reduced:
-    parking: 13
+    parking: 
   postal_code: true
 PM:
   continent: North America

--- a/spec/country_spec.rb
+++ b/spec/country_spec.rb
@@ -412,4 +412,22 @@ describe ISO3166::Country do
     end
   end
 
+  describe 'VAT rates' do
+    let(:belgium) { ISO3166::Country.search('BE') }
+
+    it 'should not return a vat_rate for countries without federal VAT' do
+      country.vat_rates.should == nil
+    end
+
+    it 'should contain all keys for vat_rates' do
+      belgium.vat_rates.should be_a(Hash)
+      belgium.vat_rates.keys.should == ["standard", "reduced", "super_reduced", "parking"]
+    end
+
+    it 'should return an array of reduced vat rates' do
+      belgium.vat_rates["reduced"].should be_an(Array)
+      belgium.vat_rates["reduced"].should == [6, 12]
+    end
+  end
+
 end


### PR DESCRIPTION
I've added the VAT rates for all countries in the European Union[1].

Most important rate is usually the standard rate, reduced/parking rates are merely informational.

The reason why I'm adding these is that, from 1 January 2015, EU businesses will have to use the VAT rate of the (EU) country of residence of the private customer, instead of the country where the business is located.

[1] Source: http://ec.europa.eu/taxation_customs/resources/documents/taxation/vat/how_vat_works/rates/vat_rates_en.pdf
