### PR TITLE
Corrected English spelling of Barbados

### DIFF
--- a/lib/data/countries.yaml
+++ b/lib/data/countries.yaml
@@ -752,7 +752,7 @@ BB:
   - Barbados
   - バルバドス
   translations:
-    en: Barbade
+    en: Barbados
     it: Barbados
     de: Barbados
     fr: Barbade


### PR DESCRIPTION
I recently had a user of my app from Barbados notice that the English version of Barbados was displayed as the French spelling. I'm just committing with the spelling they preferred and as it was listed in the official ISO document. Thanks. :)