### PR TITLE
Fix "warning: already initialized constant COUNTRIES"

### DIFF
--- a/lib/iso3166.rb
+++ b/lib/iso3166.rb
@@ -4,5 +4,7 @@ require 'iso4217'
 require 'countries/country'
 
 if defined?(ActionView::Helpers::FormOptionsHelper)
-  ActionView::Helpers::FormOptionsHelper::COUNTRIES = ISO3166::Country::Names.map{ |(name,alpha2)| [name.html_safe,alpha2] }
+  unless defined? ActionView::Helpers::FormOptionsHelper::COUNTRIES
+    ActionView::Helpers::FormOptionsHelper::COUNTRIES = ISO3166::Country::Names.map{ |(name,alpha2)| [name.html_safe,alpha2] }
+  end
 end


### PR DESCRIPTION
This should not harm the gem in anyway, its actually to prevent the following warning:

```shell
countries-0.9.3/lib/iso3166.rb:7: warning: already initialized constant COUNTRIES
```