### PR TITLE
Add country names used by Stripe as alternate names

### DIFF
--- a/lib/data/countries.yaml
+++ b/lib/data/countries.yaml
@@ -721,6 +721,7 @@ BA:
   - Bosnia y Herzegovina
   - ボスニア・ヘルツェゴビナ
   - Bosnië en Herzegovina
+  - Bosnia Herzegovina
   translations:
     en: Bosnia and Herzegovina
     it: Bosnia ed Erzegovina
@@ -1613,6 +1614,7 @@ CD:
   - Congo (Rep. Dem.)
   - コンゴ民主共和国
   - Congo [DRC]
+  - Congo (The Democratic Republic Of The)
   translations:
     en: Congo (Dem. Rep.)
     it: Congo (Rep. Dem.)
@@ -1781,6 +1783,7 @@ CI:
   - Elfenbeinküste
   - コートジボワール
   - Ivoorkust
+  - Cote d Ivoire (Ivory Coast)
   translations:
     en: Côte D'Ivoire
     it: Costa D'Avorio
@@ -3869,6 +3872,7 @@ HM:
   - Heard und die McDonaldinseln
   - ハード島とマクドナルド諸島
   - Heard- en McDonaldeilanden
+  - Heard Island and McDonald Islands
   translations:
     en: Heard and McDonald Islands
     it: Isole Heard e McDonald
@@ -4378,6 +4382,7 @@ IR:
   - Iran
   - Irán
   - イラン・イスラム共和国
+  - Islamic Republic of Iran
   translations:
     en: Iran
     de: Iran
@@ -4714,6 +4719,7 @@ KG:
   - Kirguizistán
   - キルギス
   - Kirgizië
+  - Kyrgzstan
   translations:
     en: Kyrgyzstan
     it: Kirghizistan
@@ -4906,6 +4912,7 @@ KP:
   - Corea del Norte
   - 朝鮮民主主義人民共和国
   - Noord-Korea
+  - Korea (Democratic People s Republic of)
   translations:
     en: Korea (North)
     it: Corea del Nord
@@ -4956,6 +4963,7 @@ KR:
   - Corea del Sur
   - 大韓民国
   - Zuid-Korea
+  - Korea (Republic of)
   translations:
     en: Korea (South)
     it: Corea del Sud
@@ -5119,6 +5127,7 @@ LA:
   names:
   - Laos
   - ラオス人民民主共和国
+  - Lao People s Democratic Republic
   translations:
     en: Laos
     it: Laos
@@ -5516,6 +5525,7 @@ LY:
   - Libia
   - リビア
   - Libië
+  - Libyan Arab Jamahiriya
   translations:
     en: Libya
     it: Libia
@@ -5832,6 +5842,7 @@ MK:
   - Macédoine
   - マケドニア旧ユーゴスラビア共和国
   - Macedonië [FYROM]
+  - Macedonia (The Former Yugoslav Republic of)
   translations:
     en: Macedonia
     it: Macedonia
@@ -7562,6 +7573,7 @@ RE:
   - Réunion
   - Reunión
   - レユニオン
+  - Reunion
   translations:
     en: Réunion
     it: Riunione
@@ -8815,6 +8827,7 @@ TJ:
   - Tayikistán
   - タジキスタン
   - Tadzjikistan
+  - Tajikstan
   translations:
     en: Tajikistan
     it: Tagikistan
@@ -9216,6 +9229,7 @@ TZ:
   - Tansania
   - Tanzanie
   - タンザニア
+  - Tanzania United Republic
   translations:
     en: Tanzania
     it: Tanzania


### PR DESCRIPTION
We use the countries gem to look up information for addresses we get from Stripe, which sometimes has funny punctuation (or lack of) or misspellings in the country names; this PR adds all the country names that Stripe uses as alternate names in the appropriate entries.