### PR TITLE
Correct translation of Afghanistan for fr and es

### DIFF
--- a/lib/data/countries.yaml
+++ b/lib/data/countries.yaml
@@ -109,8 +109,8 @@ AF:
     en: Afghanistan
     it: Afghanistan
     de: Afghanistan
-    fr: Afganistán
-    es:
+    fr: Afghanistan
+    es: Afganistán
     ja: アフガニスタン
     nl: Afghanistan
     ru: Афганистан

--- a/spec/country_spec.rb
+++ b/spec/country_spec.rb
@@ -172,7 +172,7 @@ describe ISO3166::Country do
       countries = ISO3166::Country.all_translated('fr')
       countries.should be_an(Array)
       countries.first.should be_a(String)
-      countries.first.should eq('Afganistán')
+      countries.first.should eq('Afghanistan')
       # countries missing the desired locale will not be added to the list
       # so all 250 countries may not be returned, 'fr' returns 249, for example
       countries.should have(249).countries


### PR DESCRIPTION
The french translation had the spanish one, so I put it right together.