### PR TITLE
Fix mongoid field behavior

### DIFF
--- a/lib/countries/mongoid.rb
+++ b/lib/countries/mongoid.rb
@@ -1,7 +1,6 @@
 module ISO3166; end
 
 class ISO3166::Country
-  class BadMongoidTypeError < StandardError; end
 
   def mongoize
     ISO3166::Country.mongoize(self)
@@ -15,7 +14,7 @@ class ISO3166::Country
       elsif self.send(:valid_alpha2?, country)
         new(country).alpha2
       else
-        raise BadMongoidTypeError.new('Given value is neither a valid country object nor a valid alpha2 code')
+        nil
       end
     end
 
@@ -30,13 +29,7 @@ class ISO3166::Country
     private
 
     def valid_alpha2?(country)
-      return false unless country.is_a?(String)
-
-      if ISO3166::Country.new(country).nil?
-        raise BadMongoidTypeError.new('Given string is not a valid alpha2 code.')
-      else
-        true
-      end
+      country.is_a?(String) && !ISO3166::Country.new(country).nil?
     end
   end
 end

--- a/spec/mongoid_spec.rb
+++ b/spec/mongoid_spec.rb
@@ -24,23 +24,19 @@ describe 'Mongoid support' do
         ISO3166::Country.mongoize('GB').should eql britain.alpha2
       end
 
-      it 'should raise BadMongoidTypeError given an invalid object' do
+      it 'should store nil given an invalid object' do
         bad_types = [[], Time.now, {}, Date.today]
         bad_types.each do |type|
-          expect { ISO3166::Country.mongoize(type) }
-          .to raise_error(ISO3166::Country::BadMongoidTypeError, /neither/)
+          ISO3166::Country.mongoize(type).should eql nil
         end
       end
 
-      it 'should raise BadMongoidTypeError given an empty country object' do
-        expect { ISO3166::Country.mongoize(ISO3166::Country.new('')) }
-        .to raise_error(ISO3166::Country::BadMongoidTypeError, /neither/)
+      it 'should store nil given an empty country object' do
+        ISO3166::Country.mongoize(ISO3166::Country.new('')).should eql nil
       end
 
-      it 'should raise BadMongoidTypeError given a bad alpha2' do
-        expect { ISO3166::Country.mongoize('bad_alpha_2') }
-        .to raise_error(ISO3166::Country::BadMongoidTypeError,
-                        /not a valid alpha2/)
+      it 'should store nil given a bad alpha2' do
+        ISO3166::Country.mongoize('bad_alpha_2').should eql nil
       end
 
     end


### PR DESCRIPTION
Current mongoid Country field type behavior makes invalid country values raise a `BadMongoidTypeError` exception on assignation.
This is not the behavior of other Mongoid types ; actually `BadMongoidTypeError` error only exists in this country gem...
When you assign invalid values on base Mongoid types, like `Integer`, no exception is raised. The value is just set to the closest approximation: an integer field is just set to zero when assigning a string.

This PR brings this standard behavior to the Country field: when an invalid value is assigned, the field is set to `nil`, with no exception.

If you want to ensure the validity of the field content, just validate the field presence: if it's not empty, then it's a valid country !