### PR TITLE
Mute changing constant in ActionView

### DIFF
--- a/lib/iso3166.rb
+++ b/lib/iso3166.rb
@@ -4,7 +4,7 @@ require 'iso4217'
 require 'countries/country'
 
 if defined?(ActionView::Helpers::FormOptionsHelper)
-  Kerner.silence_warnings do
+  Kernel.silence_warnings do
     ActionView::Helpers::FormOptionsHelper::COUNTRIES = ISO3166::Country::Names.map{ |(name,alpha2)| [name.html_safe,alpha2] }
   end
 end

--- a/lib/iso3166.rb
+++ b/lib/iso3166.rb
@@ -4,5 +4,7 @@ require 'iso4217'
 require 'countries/country'
 
 if defined?(ActionView::Helpers::FormOptionsHelper)
-  ActionView::Helpers::FormOptionsHelper::COUNTRIES = ISO3166::Country::Names.map{ |(name,alpha2)| [name.html_safe,alpha2] }
+  Kerner.silence_warnings do
+    ActionView::Helpers::FormOptionsHelper::COUNTRIES = ISO3166::Country::Names.map{ |(name,alpha2)| [name.html_safe,alpha2] }
+  end
 end


### PR DESCRIPTION
I had problems with gem cause it always shouted with warning about changing constant in ActionView when I loaded my project. I've made a change that mute this. 