### PR TITLE
Add conversion method ISO3166::Country()

### DIFF
--- a/lib/countries/country.rb
+++ b/lib/countries/country.rb
@@ -147,3 +147,14 @@ class ISO3166::Country
     end
   end
 end
+
+def ISO3166::Country(country_data_or_country)
+  case country_data_or_country
+  when ISO3166::Country
+    country_data_or_country
+  when String, Symbol
+    ISO3166::Country.search(country_data_or_country)
+  else
+    raise TypeError, "can't convert #{country_data_or_country.class.name} into ISO3166::Country"
+  end
+end

--- a/spec/country_spec.rb
+++ b/spec/country_spec.rb
@@ -441,4 +441,19 @@ describe ISO3166::Country do
     end
   end
 
+  describe 'ISO3166::Country()' do
+    it 'should return same object if instance of ISO3166::Country given' do
+      ISO3166::Country(country).should eq country
+    end
+
+    it 'should return country if instance of String given' do
+      ISO3166::Country('us').should eq country
+    end
+
+    it 'should return country if not convertable input given' do
+      expect {
+        ISO3166::Country(42)
+      }.to raise_error(TypeError, "can't convert Fixnum into ISO3166::Country")
+    end
+  end
 end


### PR DESCRIPTION
Implement ruby's [conversion idiom](http://www.ruby-doc.org/core-2.1.3/Kernel.html) for ISO3166::Country class, so:

```ruby 
country = ISO3166::Country.search('US')

ISO3166::Country(country) #=> #<Country:0x007f9c61e0ea20 @data={....}>

ISO3166::Country('us') #=> #<Country:0x007f9c61e0ea20 @data={....}>

ISO3166::Country(42) #=> raises TypeError, "can't convert Fixnum into ISO3166::Country"
```