### PR TITLE
Added World Regions (APAC, EMEA, AMER) to countries.

### DIFF
--- a/lib/countries/country.rb
+++ b/lib/countries/country.rb
@@ -18,6 +18,7 @@ class ISO3166::Country
     :continent,
     :region,
     :subregion,
+    :world_region,
     :country_code,
     :national_destination_code_lengths,
     :national_number_lengths,
@@ -47,7 +48,7 @@ class ISO3166::Country
   def valid?
     not (@data.nil? or @data.empty?)
   end
-  
+
   alias_method :zip, :postal_code
   alias_method :zip?, :postal_code
   alias_method :postal_code?, :postal_code

--- a/lib/data/countries.yaml
+++ b/lib/data/countries.yaml
@@ -35,6 +35,7 @@ AD:
   number: '020'
   region: Europe
   subregion: Southern Europe
+  world_region: EMEA
   un_locode: AD
   languages:
   - ca
@@ -85,6 +86,7 @@ AE:
   number: '784'
   region: Asia
   subregion: Western Asia
+  world_region: EMEA
   un_locode: AE
   languages:
   - ar
@@ -124,6 +126,7 @@ AF:
   number: '004'
   region: Asia
   subregion: Southern Asia
+  world_region: APAC
   un_locode: AF
   languages:
   - ps
@@ -166,6 +169,7 @@ AG:
   number: 028
   region: Americas
   subregion: Caribbean
+  world_region: AMER
   un_locode: AG
   languages:
   - en
@@ -202,6 +206,7 @@ AI:
   number: '660'
   region: Americas
   subregion: Caribbean
+  world_region: AMER
   un_locode: AI
   languages:
   - en
@@ -244,6 +249,7 @@ AL:
   number: 008
   region: Europe
   subregion: Southern Europe
+  world_region: EMEA
   un_locode: AL
   languages:
   - sq
@@ -284,6 +290,7 @@ AM:
   number: '051'
   region: Asia
   subregion: Western Asia
+  world_region: APAC
   un_locode: AM
   languages:
   - hy
@@ -325,6 +332,7 @@ AN:
   number: '530'
   region: Americas
   subregion: Caribbean
+  world_region: AMER
   un_locode: AN
   languages:
   - nl
@@ -364,6 +372,7 @@ AO:
   number: '024'
   region: Africa
   subregion: Middle Africa
+  world_region: EMEA
   un_locode: AO
   languages:
   - pt
@@ -450,6 +459,7 @@ AR:
   number: '032'
   region: Americas
   subregion: South America
+  world_region: AMER
   un_locode: AR
   languages:
   - es
@@ -491,6 +501,7 @@ AS:
   number: '016'
   region: Oceania
   subregion: Polynesia
+  world_region: APAC
   un_locode: AS
   languages:
   - en
@@ -547,6 +558,7 @@ AT:
   number: '040'
   region: Europe
   subregion: Western Europe
+  world_region: EMEA
   un_locode: AT
   languages:
   - de
@@ -594,6 +606,7 @@ AU:
   number: '036'
   region: Oceania
   subregion: Australia and New Zealand
+  world_region: APAC
   un_locode: AU
   languages:
   - en
@@ -630,6 +643,7 @@ AW:
   number: '533'
   region: Americas
   subregion: Caribbean
+  world_region: AMER
   un_locode: AW
   languages:
   - nl
@@ -666,6 +680,7 @@ AX:
   number: '248'
   region: Europe
   subregion: Northern Europe
+  world_region: EMEA
   un_locode:
   languages:
   - sv
@@ -707,6 +722,7 @@ AZ:
   number: '031'
   region: Asia
   subregion: Western Asia
+  world_region: APAC
   un_locode: AZ
   languages:
   - az
@@ -755,6 +771,7 @@ BA:
   number: '070'
   region: Europe
   subregion: Southern Europe
+  world_region: EMEA
   un_locode: BA
   languages:
   - bs
@@ -782,7 +799,7 @@ BB:
     it: Barbados
     de: Barbados
     fr: Barbade
-    es: 
+    es:
     ja: バルバドス
     nl: Barbados
     ru: Барбадос
@@ -794,6 +811,7 @@ BB:
   number: '052'
   region: Americas
   subregion: Caribbean
+  world_region: AMER
   un_locode: BB
   languages:
   - en
@@ -819,7 +837,7 @@ BD:
     it: Bangladesh
     de: Bangladesch
     fr: Bangladesh
-    es: 
+    es:
     ja: バングラデシュ
     nl: Bangladesh
     ru: Бангладеш
@@ -831,6 +849,7 @@ BD:
   number: '050'
   region: Asia
   subregion: Southern Asia
+  world_region: APAC
   un_locode: BD
   languages:
   - bn
@@ -879,6 +898,7 @@ BE:
   number: '056'
   region: Europe
   subregion: Western Europe
+  world_region: EMEA
   un_locode: BE
   languages:
   - nl
@@ -918,6 +938,7 @@ BF:
   number: '854'
   region: Africa
   subregion: Western Africa
+  world_region: EMEA
   un_locode: BF
   languages:
   - fr
@@ -953,7 +974,7 @@ BG:
     it: Bulgaria
     de: Bulgarien
     fr: Bulgarie
-    es: 
+    es:
     ja: ブルガリア
     nl: Bulgarije
     ru: Болгария
@@ -967,6 +988,7 @@ BG:
   number: '100'
   region: Europe
   subregion: Eastern Europe
+  world_region: EMEA
   un_locode: BG
   languages:
   - bg
@@ -1013,6 +1035,7 @@ BH:
   number: 048
   region: Asia
   subregion: Western Asia
+  world_region: APAC
   un_locode: BH
   languages:
   - ar
@@ -1049,6 +1072,7 @@ BI:
   number: '108'
   region: Africa
   subregion: Eastern Africa
+  world_region: EMEA
   un_locode: BI
   languages:
   - fr
@@ -1087,6 +1111,7 @@ BJ:
   number: '204'
   region: Africa
   subregion: Western Africa
+  world_region: EMEA
   un_locode: BJ
   languages:
   - fr
@@ -1122,6 +1147,7 @@ BL:
   number: '652'
   region: Americas
   subregion: Caribbean
+  world_region: AMER
   un_locode:
   languages:
   - fr
@@ -1160,6 +1186,7 @@ BM:
   number: '060'
   region: Americas
   subregion: Northern America
+  world_region: AMER
   un_locode: BM
   languages:
   - en
@@ -1196,6 +1223,7 @@ BN:
   number: 096
   region: Asia
   subregion: South-Eastern Asia
+  world_region: APAC
   un_locode: BN
   languages:
   - ms
@@ -1234,6 +1262,7 @@ BO:
   number: 068
   region: Americas
   subregion: South America
+  world_region: AMER
   un_locode: BO
   languages:
   - es
@@ -1270,6 +1299,7 @@ BQ:
   number: '535'
   region: Americas
   subregion: Caribbean
+  world_region: AMER
   un_locode: BQ
   languages:
   - nl
@@ -1319,6 +1349,7 @@ BR:
   number: '076'
   region: Americas
   subregion: South America
+  world_region: AMER
   un_locode: BR
   languages:
   - pt
@@ -1356,6 +1387,7 @@ BS:
   number: '044'
   region: Americas
   subregion: Caribbean
+  world_region: AMER
   un_locode: BS
   languages:
   - en
@@ -1395,6 +1427,7 @@ BT:
   number: '064'
   region: Asia
   subregion: Southern Asia
+  world_region: APAC
   un_locode: BT
   languages:
   - dz
@@ -1466,6 +1499,7 @@ BW:
   number: '072'
   region: Africa
   subregion: Southern Africa
+  world_region: EMEA
   un_locode: BW
   languages:
   - en
@@ -1507,6 +1541,7 @@ BY:
   number: '112'
   region: Europe
   subregion: Eastern Europe
+  world_region: EMEA
   un_locode: BY
   languages:
   - be
@@ -1545,6 +1580,7 @@ BZ:
   number: 084
   region: Americas
   subregion: Central America
+  world_region: AMER
   un_locode: BZ
   languages:
   - en
@@ -1592,6 +1628,7 @@ CA:
   number: '124'
   region: Americas
   subregion: Northern America
+  world_region: AMER
   un_locode: CA
   languages:
   - en
@@ -1631,6 +1668,7 @@ CC:
   number: '166'
   region: Oceania
   subregion: Australia and New Zealand
+  world_region: APAC
   un_locode: CC
   languages:
   - en
@@ -1670,6 +1708,7 @@ CD:
   number: '180'
   region: Africa
   subregion: Middle Africa
+  world_region: EMEA
   un_locode: CD
   languages:
   - fr
@@ -1714,6 +1753,7 @@ CF:
   number: '140'
   region: Africa
   subregion: Middle Africa
+  world_region: EMEA
   un_locode: CF
   languages:
   - fr
@@ -1753,6 +1793,7 @@ CG:
   number: '178'
   region: Africa
   subregion: Middle Africa
+  world_region: EMEA
   un_locode: CG
   languages:
   - fr
@@ -1802,6 +1843,7 @@ CH:
   number: '756'
   region: Europe
   subregion: Western Europe
+  world_region: EMEA
   un_locode: CH
   languages:
   - de
@@ -1842,6 +1884,7 @@ CI:
   number: '384'
   region: Africa
   subregion: Western Africa
+  world_region: EMEA
   un_locode: CI
   languages:
   - fr
@@ -1882,6 +1925,7 @@ CK:
   number: '184'
   region: Oceania
   subregion: Polynesia
+  world_region: APAC
   un_locode: CK
   languages:
   - en
@@ -1921,6 +1965,7 @@ CL:
   number: '152'
   region: Americas
   subregion: South America
+  world_region: AMER
   un_locode: CL
   languages:
   - es
@@ -1962,6 +2007,7 @@ CM:
   number: '120'
   region: Africa
   subregion: Middle Africa
+  world_region: EMEA
   un_locode: CM
   languages:
   - en
@@ -2012,6 +2058,7 @@ CN:
   number: '156'
   region: Asia
   subregion: Eastern Asia
+  world_region: APAC
   un_locode: CN
   languages:
   - zh
@@ -2052,6 +2099,7 @@ CO:
   number: '170'
   region: Americas
   subregion: South America
+  world_region: AMER
   un_locode: CO
   languages:
   - es
@@ -2088,6 +2136,7 @@ CR:
   number: '188'
   region: Americas
   subregion: Central America
+  world_region: AMER
   un_locode: CR
   languages:
   - es
@@ -2125,6 +2174,7 @@ CU:
   number: '192'
   region: Americas
   subregion: Caribbean
+  world_region: AMER
   un_locode: CU
   languages:
   - es
@@ -2165,6 +2215,7 @@ CV:
   number: '132'
   region: Africa
   subregion: Western Africa
+  world_region: EMEA
   un_locode: CV
   languages:
   - pt
@@ -2198,6 +2249,7 @@ CW:
   number: '531'
   region: Americas
   subregion: Caribbean
+  world_region: AMER
   un_locode: CW
   languages:
   - nl
@@ -2234,6 +2286,7 @@ CX:
   number: '162'
   region: Oceania
   subregion: Australia and New Zealand
+  world_region: APAC
   un_locode: CX
   languages:
   - en
@@ -2275,6 +2328,7 @@ CY:
   number: '196'
   region: Asia
   subregion: Western Asia
+  world_region: EMEA
   un_locode: CY
   languages:
   - el
@@ -2325,6 +2379,7 @@ CZ:
   number: '203'
   region: Europe
   subregion: Eastern Europe
+  world_region: EMEA
   un_locode: CZ
   languages:
   - cs
@@ -2383,6 +2438,7 @@ DE:
   number: '276'
   region: Europe
   subregion: Western Europe
+  world_region: EMEA
   un_locode: DE
   languages:
   - de
@@ -2421,6 +2477,7 @@ DJ:
   number: '262'
   region: Africa
   subregion: Eastern Africa
+  world_region: EMEA
   un_locode: DJ
   languages:
   - ar
@@ -2472,6 +2529,7 @@ DK:
   number: '208'
   region: Europe
   subregion: Northern Europe
+  world_region: EMEA
   un_locode: DK
   languages:
   - da
@@ -2510,6 +2568,7 @@ DM:
   number: '212'
   region: Americas
   subregion: Caribbean
+  world_region: AMER
   un_locode: DM
   languages:
   - en
@@ -2550,6 +2609,7 @@ DO:
   number: '214'
   region: Americas
   subregion: Caribbean
+  world_region: AMER
   un_locode: DO
   languages:
   - es
@@ -2591,6 +2651,7 @@ DZ:
   number: '012'
   region: Africa
   subregion: Northern Africa
+  world_region: EMEA
   un_locode: DZ
   languages:
   - ar
@@ -2630,6 +2691,7 @@ EC:
   number: '218'
   region: Americas
   subregion: South America
+  world_region: AMER
   un_locode: EC
   languages:
   - es
@@ -2669,6 +2731,7 @@ EE:
   number: '233'
   region: Europe
   subregion: Northern Europe
+  world_region: EMEA
   un_locode: EE
   languages:
   - et
@@ -2718,6 +2781,7 @@ EG:
   number: '818'
   region: Africa
   subregion: Northern Africa
+  world_region: EMEA
   un_locode: EG
   languages:
   - ar
@@ -2755,6 +2819,7 @@ EH:
   number: '732'
   region: Africa
   subregion: Northern Africa
+  world_region: EMEA
   un_locode: EH
   languages:
   - es
@@ -2794,6 +2859,7 @@ ER:
   number: '232'
   region: Africa
   subregion: Eastern Africa
+  world_region: EMEA
   un_locode: ER
   languages:
   - en
@@ -2844,6 +2910,7 @@ ES:
   number: '724'
   region: Europe
   subregion: Southern Europe
+  world_region: EMEA
   un_locode: ES
   languages:
   - es
@@ -2886,6 +2953,7 @@ ET:
   number: '231'
   region: Africa
   subregion: Eastern Africa
+  world_region: EMEA
   un_locode: ET
   languages:
   - am
@@ -2933,7 +3001,8 @@ FI:
   number: '246'
   region: Europe
   subregion: Northern Europe
-  un_locode: 
+  world_region: EMEA
+  un_locode:
   languages:
   - fi
   - sv
@@ -2974,6 +3043,7 @@ FJ:
   number: '242'
   region: Oceania
   subregion: Melanesia
+  world_region: APAC
   un_locode: FJ
   languages:
   - en
@@ -2989,7 +3059,7 @@ FK:
   country_code: '500'
   currency: FKP
   international_prefix: '00'
-  ioc: 
+  ioc:
   latitude: 51 45 S
   longitude: 59 00 W
   name: Falkland Islands (Malvinas)
@@ -3017,6 +3087,7 @@ FK:
   number: '238'
   region: Americas
   subregion: South America
+  world_region: AMER
   un_locode: FK
   languages:
   - en
@@ -3056,6 +3127,7 @@ FM:
   number: '583'
   region: Oceania
   subregion: Micronesia
+  world_region: APAC
   un_locode: FM
   languages:
   - en
@@ -3096,6 +3168,7 @@ FO:
   number: '234'
   region: Europe
   subregion: Northern Europe
+  world_region: EMEA
   un_locode: FO
   languages:
   - fo
@@ -3145,6 +3218,7 @@ FR:
   number: '250'
   region: Europe
   subregion: Western Europe
+  world_region: EMEA
   un_locode: FR
   languages:
   - fr
@@ -3186,6 +3260,7 @@ GA:
   number: '266'
   region: Africa
   subregion: Middle Africa
+  world_region: EMEA
   un_locode: GA
   languages:
   - fr
@@ -3239,6 +3314,7 @@ GB:
   number: '826'
   region: Europe
   subregion: Northern Europe
+  world_region: EMEA
   un_locode:
   languages:
   - en
@@ -3276,6 +3352,7 @@ GD:
   number: '308'
   region: Americas
   subregion: Caribbean
+  world_region: AMER
   un_locode: GD
   languages:
   - en
@@ -3315,6 +3392,7 @@ GE:
   number: '268'
   region: Asia
   subregion: Western Asia
+  world_region: EMEA
   un_locode: GE
   languages:
   - ka
@@ -3327,7 +3405,7 @@ GF:
   country_code: '594'
   currency: EUR
   international_prefix: '00'
-  ioc: 
+  ioc:
   latitude: 4 00 N
   longitude: 53 00 W
   name: French Guiana
@@ -3354,6 +3432,7 @@ GF:
   number: '254'
   region: Americas
   subregion: South America
+  world_region: AMER
   un_locode: GF
   languages:
   - fr
@@ -3391,6 +3470,7 @@ GG:
   number: '831'
   region: Europe
   subregion: Northern Europe
+  world_region: EMEA
   un_locode:
   languages:
   - en
@@ -3431,6 +3511,7 @@ GH:
   number: '288'
   region: Africa
   subregion: Western Africa
+  world_region: EMEA
   un_locode: GH
   languages:
   - en
@@ -3467,6 +3548,7 @@ GI:
   number: '292'
   region: Europe
   subregion: Southern Europe
+  world_region: EMEA
   un_locode: GI
   languages:
   - en
@@ -3513,6 +3595,7 @@ GL:
   number: '304'
   region: Americas
   subregion: Northern America
+  world_region: EMEA
   un_locode: GL
   languages:
   - kl
@@ -3549,6 +3632,7 @@ GM:
   number: '270'
   region: Africa
   subregion: Western Africa
+  world_region: EMEA
   un_locode: GM
   languages:
   - en
@@ -3587,6 +3671,7 @@ GN:
   number: '324'
   region: Africa
   subregion: Western Africa
+  world_region: EMEA
   un_locode: GN
   languages:
   - fr
@@ -3625,6 +3710,7 @@ GP:
   number: '312'
   region: Americas
   subregion: Caribbean
+  world_region: AMER
   un_locode: GP
   languages:
   - fr
@@ -3665,6 +3751,7 @@ GQ:
   number: '226'
   region: Africa
   subregion: Middle Africa
+  world_region: EMEA
   un_locode: GQ
   languages:
   - es
@@ -3713,6 +3800,7 @@ GR:
   number: '300'
   region: Europe
   subregion: Southern Europe
+  world_region: EMEA
   un_locode: GR
   languages:
   - el
@@ -3750,6 +3838,7 @@ GS:
   number: '239'
   region: Americas
   subregion: South America
+  world_region: AMER
   un_locode: GS
   languages:
   - en
@@ -3786,6 +3875,7 @@ GT:
   number: '320'
   region: Americas
   subregion: Central America
+  world_region: AMER
   un_locode: GT
   languages:
   - es
@@ -3822,6 +3912,7 @@ GU:
   number: '316'
   region: Oceania
   subregion: Micronesia
+  world_region: APAC
   un_locode: GU
   languages:
   - en
@@ -3862,6 +3953,7 @@ GW:
   number: '624'
   region: Africa
   subregion: Western Africa
+  world_region: EMEA
   un_locode: GW
   languages:
   - pt
@@ -3899,6 +3991,7 @@ GY:
   number: '328'
   region: Americas
   subregion: South America
+  world_region: AMER
   un_locode: GY
   languages:
   - en
@@ -3943,6 +4036,7 @@ HK:
   number: '344'
   region: Asia
   subregion: Eastern Asia
+  world_region: APAC
   un_locode: HK
   languages:
   - en
@@ -4017,6 +4111,7 @@ HN:
   number: '340'
   region: Americas
   subregion: Central America
+  world_region: AMER
   un_locode: HN
   languages:
   - es
@@ -4064,6 +4159,7 @@ HR:
   number: '191'
   region: Europe
   subregion: Southern Europe
+  world_region: EMEA
   un_locode: HR
   languages:
   - hr
@@ -4102,6 +4198,7 @@ HT:
   number: '332'
   region: Americas
   subregion: Caribbean
+  world_region: AMER
   un_locode: HT
   languages:
   - fr
@@ -4153,6 +4250,7 @@ HU:
   number: '348'
   region: Europe
   subregion: Eastern Europe
+  world_region: EMEA
   un_locode: HU
   languages:
   - hu
@@ -4205,6 +4303,7 @@ ID:
   number: '360'
   region: Asia
   subregion: South-Eastern Asia
+  world_region: APAC
   un_locode: ID
   languages:
   - id
@@ -4253,6 +4352,7 @@ IE:
   number: '372'
   region: Europe
   subregion: Northern Europe
+  world_region: EMEA
   un_locode: IE
   languages:
   - en
@@ -4302,6 +4402,7 @@ IL:
   number: '376'
   region: Asia
   subregion: Western Asia
+  world_region: EMEA
   un_locode: IL
   languages:
   - he
@@ -4340,6 +4441,7 @@ IM:
   number: '833'
   region: Europe
   subregion: Northern Europe
+  world_region: EMEA
   un_locode:
   languages:
   - en
@@ -4389,6 +4491,7 @@ IN:
   number: '356'
   region: Asia
   subregion: Southern Asia
+  world_region: APAC
   un_locode: IN
   languages:
   - hi
@@ -4402,7 +4505,7 @@ IO:
   country_code: '246'
   currency: USD
   international_prefix: ''
-  ioc: 
+  ioc:
   latitude: 6 00 S
   longitude: 71 30 E
   name: British Indian Ocean Territory
@@ -4426,6 +4529,7 @@ IO:
   number: 086
   region: Africa
   subregion: Eastern Africa
+  world_region: EMEA
   un_locode: IO
   languages:
   - en
@@ -4466,6 +4570,7 @@ IQ:
   number: '368'
   region: Asia
   subregion: Western Asia
+  world_region: EMEA
   un_locode: IQ
   languages:
   - ar
@@ -4502,6 +4607,7 @@ IR:
   number: '364'
   region: Asia
   subregion: Southern Asia
+  world_region: EMEA
   un_locode: IR
   languages:
   - fa
@@ -4551,6 +4657,7 @@ IS:
   number: '352'
   region: Europe
   subregion: Northern Europe
+  world_region: EMEA
   un_locode: IS
   languages:
   - is
@@ -4599,6 +4706,7 @@ IT:
   number: '380'
   region: Europe
   subregion: Southern Europe
+  world_region: EMEA
   un_locode: IT
   languages:
   - it
@@ -4612,7 +4720,7 @@ JE:
   country_code: '44'
   currency: JEP
   international_prefix: ''
-  ioc: 
+  ioc:
   latitude: 49 15 N
   longitude: 2 10 W
   name: Jersey
@@ -4634,7 +4742,8 @@ JE:
   number: '832'
   region: Europe
   subregion: Northern Europe
-  un_locode: 
+  world_region: EMEA
+  un_locode:
   languages:
   - en
   - fr
@@ -4673,6 +4782,7 @@ JM:
   number: '388'
   region: Americas
   subregion: Caribbean
+  world_region: AMER
   un_locode: JM
   languages:
   - en
@@ -4722,6 +4832,7 @@ JO:
   number: '400'
   region: Asia
   subregion: Western Asia
+  world_region: EMEA
   un_locode: JO
   languages:
   - ar
@@ -4769,6 +4880,7 @@ JP:
   number: '392'
   region: Asia
   subregion: Eastern Asia
+  world_region: APAC
   un_locode: JP
   languages:
   - ja
@@ -4806,6 +4918,7 @@ KE:
   number: '404'
   region: Africa
   subregion: Eastern Africa
+  world_region: EMEA
   un_locode: KE
   languages:
   - en
@@ -4847,6 +4960,7 @@ KG:
   number: '417'
   region: Asia
   subregion: Central Asia
+  world_region: APAC
   un_locode: KG
   languages:
   - ky
@@ -4888,6 +5002,7 @@ KH:
   number: '116'
   region: Asia
   subregion: South-Eastern Asia
+  world_region: APAC
   un_locode: KH
   languages:
   - km
@@ -4924,6 +5039,7 @@ KI:
   number: '296'
   region: Oceania
   subregion: Micronesia
+  world_region: APAC
   un_locode: KI
   languages:
   - en
@@ -4963,6 +5079,7 @@ KM:
   number: '174'
   region: Africa
   subregion: Eastern Africa
+  world_region: EMEA
   un_locode: KM
   languages:
   - ar
@@ -5004,6 +5121,7 @@ KN:
   number: '659'
   region: Americas
   subregion: Caribbean
+  world_region: AMER
   un_locode: KN
   languages:
   - en
@@ -5046,6 +5164,7 @@ KP:
   number: '408'
   region: Asia
   subregion: Eastern Asia
+  world_region: APAC
   un_locode: KP
   languages:
   - ko
@@ -5097,6 +5216,7 @@ KR:
   number: '410'
   region: Asia
   subregion: Eastern Asia
+  world_region: APAC
   un_locode: KR
   languages:
   - ko
@@ -5145,6 +5265,7 @@ KW:
   number: '414'
   region: Asia
   subregion: Western Asia
+  world_region: EMEA
   un_locode: KW
   languages:
   - ar
@@ -5185,6 +5306,7 @@ KY:
   number: '136'
   region: Americas
   subregion: Caribbean
+  world_region: AMER
   un_locode: KY
   languages:
   - en
@@ -5225,6 +5347,7 @@ KZ:
   number: '398'
   region: Asia
   subregion: Central Asia
+  world_region: APAC
   un_locode: KZ
   languages:
   - kk
@@ -5263,6 +5386,7 @@ LA:
   number: '418'
   region: Asia
   subregion: South-Eastern Asia
+  world_region: APAC
   un_locode: LA
   languages:
   - lo
@@ -5310,6 +5434,7 @@ LB:
   number: '422'
   region: Asia
   subregion: Western Asia
+  world_region: EMEA
   un_locode: LB
   languages:
   - ar
@@ -5349,6 +5474,7 @@ LC:
   number: '662'
   region: Americas
   subregion: Caribbean
+  world_region: AMER
   un_locode: LC
   languages:
   - en
@@ -5385,6 +5511,7 @@ LI:
   number: '438'
   region: Europe
   subregion: Western Europe
+  world_region: EMEA
   un_locode: LI
   languages:
   - de
@@ -5422,6 +5549,7 @@ LK:
   number: '144'
   region: Asia
   subregion: Southern Asia
+  world_region: APAC
   un_locode: LK
   languages:
   - si
@@ -5461,6 +5589,7 @@ LR:
   number: '430'
   region: Africa
   subregion: Western Africa
+  world_region: EMEA
   un_locode: LR
   languages:
   - en
@@ -5498,6 +5627,7 @@ LS:
   number: '426'
   region: Africa
   subregion: Southern Africa
+  world_region: EMEA
   un_locode: LS
   languages:
   - en
@@ -5539,6 +5669,7 @@ LT:
   number: '440'
   region: Europe
   subregion: Northern Europe
+  world_region: EMEA
   un_locode: LT
   languages:
   - lt
@@ -5585,6 +5716,7 @@ LU:
   number: '442'
   region: Europe
   subregion: Western Europe
+  world_region: EMEA
   un_locode: LU
   languages:
   - fr
@@ -5628,6 +5760,7 @@ LV:
   number: '428'
   region: Europe
   subregion: Northern Europe
+  world_region: EMEA
   un_locode: LV
   languages:
   - lv
@@ -5671,6 +5804,7 @@ LY:
   number: '434'
   region: Africa
   subregion: Northern Africa
+  world_region: EMEA
   un_locode: LY
   languages:
   - ar
@@ -5711,6 +5845,7 @@ MA:
   number: '504'
   region: Africa
   subregion: Northern Africa
+  world_region: EMEA
   un_locode: MA
   languages:
   - ar
@@ -5749,6 +5884,7 @@ MC:
   number: '492'
   region: Europe
   subregion: Western Europe
+  world_region: EMEA
   un_locode: MC
   languages:
   - fr
@@ -5790,6 +5926,7 @@ MD:
   number: '498'
   region: Europe
   subregion: Eastern Europe
+  world_region: EMEA
   un_locode: MD
   languages:
   - ro
@@ -5827,6 +5964,7 @@ ME:
   number: '499'
   region: Europe
   subregion: Southern Europe
+  world_region: EMEA
   un_locode: ME
   languages:
   - sr
@@ -5842,7 +5980,7 @@ MF:
   country_code: '590'
   currency: EUR
   international_prefix: ''
-  ioc: 
+  ioc:
   latitude: 18 05 N
   longitude: 63 57 W
   name: Saint Martin
@@ -5865,7 +6003,8 @@ MF:
   number: '663'
   region: Americas
   subregion: Caribbean
-  un_locode: 
+  world_region: AMER
+  un_locode:
   languages:
   - en
   - fr
@@ -5877,7 +6016,7 @@ MG:
   alpha2: MG
   alpha3: MDG
   country_code: '261'
-  currency: 
+  currency:
   international_prefix: '00'
   ioc: MAD
   latitude: 20 00 S
@@ -5905,6 +6044,7 @@ MG:
   number: '450'
   region: Africa
   subregion: Eastern Africa
+  world_region: EMEA
   un_locode: MG
   languages:
   - fr
@@ -5946,6 +6086,7 @@ MH:
   number: '584'
   region: Oceania
   subregion: Micronesia
+  world_region: APAC
   un_locode: MH
   languages:
   - en
@@ -5994,6 +6135,7 @@ MK:
   number: '807'
   region: Europe
   subregion: Southern Europe
+  world_region: EMEA
   un_locode: MK
   languages:
   - mk
@@ -6030,6 +6172,7 @@ ML:
   number: '466'
   region: Africa
   subregion: Western Africa
+  world_region: EMEA
   un_locode: ML
   languages:
   - fr
@@ -6067,6 +6210,7 @@ MM:
   number: '104'
   region: Asia
   subregion: South-Eastern Asia
+  world_region: APAC
   un_locode: MM
   languages:
   - my
@@ -6109,6 +6253,7 @@ MN:
   number: '496'
   region: Asia
   subregion: Eastern Asia
+  world_region: APAC
   un_locode: MN
   languages:
   - mn
@@ -6119,9 +6264,9 @@ MO:
   alpha2: MO
   alpha3: MAC
   country_code: '853'
-  currency: 
+  currency:
   international_prefix: '00'
-  ioc: 
+  ioc:
   latitude: 22 10 N
   longitude: 113 33 E
   name: Macao
@@ -6145,6 +6290,7 @@ MO:
   number: '446'
   region: Asia
   subregion: Eastern Asia
+  world_region: APAC
   un_locode: MO
   languages:
   - zh
@@ -6158,7 +6304,7 @@ MP:
   country_code: '1'
   currency: USD
   international_prefix: '011'
-  ioc: 
+  ioc:
   latitude: 15 12 N
   longitude: 145 45 E
   name: Northern Mariana Islands
@@ -6186,6 +6332,7 @@ MP:
   number: '580'
   region: Oceania
   subregion: Micronesia
+  world_region: APAC
   un_locode: MP
   languages:
   - en
@@ -6199,7 +6346,7 @@ MQ:
   country_code: '596'
   currency: EUR
   international_prefix: '00'
-  ioc: 
+  ioc:
   latitude: ''
   longitude: ''
   name: Martinique
@@ -6224,6 +6371,7 @@ MQ:
   number: '474'
   region: Americas
   subregion: Caribbean
+  world_region: AMER
   un_locode: MQ
   languages:
   - fr
@@ -6263,6 +6411,7 @@ MR:
   number: '478'
   region: Africa
   subregion: Western Africa
+  world_region: EMEA
   un_locode: MR
   languages:
   - ar
@@ -6276,7 +6425,7 @@ MS:
   country_code: '1'
   currency: XCD
   international_prefix: '011'
-  ioc: 
+  ioc:
   latitude: 16 45 N
   longitude: 62 12 W
   name: Montserrat
@@ -6300,6 +6449,7 @@ MS:
   number: '500'
   region: Americas
   subregion: Caribbean
+  world_region: AMER
   un_locode: MS
   languages:
   - en
@@ -6337,6 +6487,7 @@ MT:
   number: '470'
   region: Europe
   subregion: Southern Europe
+  world_region: EMEA
   un_locode: MT
   languages:
   - mt
@@ -6377,6 +6528,7 @@ MU:
   number: '480'
   region: Africa
   subregion: Eastern Africa
+  world_region: EMEA
   un_locode: MU
   languages:
   - en
@@ -6416,6 +6568,7 @@ MV:
   number: '462'
   region: Asia
   subregion: Southern Asia
+  world_region: APAC
   un_locode: MV
   languages:
   - dv
@@ -6452,6 +6605,7 @@ MW:
   number: '454'
   region: Africa
   subregion: Eastern Africa
+  world_region: EMEA
   un_locode: MW
   languages:
   - en
@@ -6501,6 +6655,7 @@ MX:
   number: '484'
   region: Americas
   subregion: Central America
+  world_region: AMER
   un_locode: MX
   languages:
   - es
@@ -6541,6 +6696,7 @@ MY:
   number: '458'
   region: Asia
   subregion: South-Eastern Asia
+  world_region: APAC
   un_locode: MY
   languages:
   - en
@@ -6579,6 +6735,7 @@ MZ:
   number: '508'
   region: Africa
   subregion: Eastern Africa
+  world_region: EMEA
   un_locode: MZ
   languages:
   - pt
@@ -6619,6 +6776,7 @@ NA:
   number: '516'
   region: Africa
   subregion: Southern Africa
+  world_region: EMEA
   un_locode: NA
   languages:
   - en
@@ -6632,7 +6790,7 @@ NC:
   country_code: '687'
   currency: XPF
   international_prefix: '00'
-  ioc: 
+  ioc:
   latitude: 21 30 S
   longitude: 165 30 E
   name: New Caledonia
@@ -6660,6 +6818,7 @@ NC:
   number: '540'
   region: Oceania
   subregion: Melanesia
+  world_region: APAC
   un_locode: NC
   languages:
   - fr
@@ -6697,6 +6856,7 @@ NE:
   number: '562'
   region: Africa
   subregion: Western Africa
+  world_region: EMEA
   un_locode: NE
   languages:
   - fr
@@ -6709,7 +6869,7 @@ NF:
   country_code: '672'
   currency: AUD
   international_prefix: '00'
-  ioc: 
+  ioc:
   latitude: 29 02 S
   longitude: 167 57 E
   name: Norfolk Island
@@ -6737,6 +6897,7 @@ NF:
   number: '574'
   region: Oceania
   subregion: Australia and New Zealand
+  world_region: APAC
   un_locode: NF
   languages:
   - en
@@ -6776,6 +6937,7 @@ NG:
   number: '566'
   region: Africa
   subregion: Western Africa
+  world_region: EMEA
   un_locode: NG
   languages:
   - en
@@ -6812,6 +6974,7 @@ NI:
   number: '558'
   region: Americas
   subregion: Central America
+  world_region: AMER
   un_locode: NI
   languages:
   - es
@@ -6859,6 +7022,7 @@ NL:
   number: '528'
   region: Europe
   subregion: Western Europe
+  world_region: EMEA
   un_locode: NL
   languages:
   - nl
@@ -6907,6 +7071,7 @@ NL:
   number: '578'
   region: Europe
   subregion: Northern Europe
+  world_region: EMEA
   un_locode: NL
   languages:
   - 'no'
@@ -6946,6 +7111,7 @@ NP:
   number: '524'
   region: Asia
   subregion: Southern Asia
+  world_region: APAC
   un_locode: NP
   languages:
   - ne
@@ -6982,6 +7148,7 @@ NR:
   number: '520'
   region: Oceania
   subregion: Micronesia
+  world_region: APAC
   un_locode: NR
   languages:
   - en
@@ -6993,9 +7160,9 @@ NU:
   alpha2: NU
   alpha3: NIU
   country_code: '683'
-  currency: 
+  currency:
   international_prefix: '00'
-  ioc: 
+  ioc:
   latitude: 19 02 S
   longitude: 169 52 W
   name: Niue
@@ -7019,6 +7186,7 @@ NU:
   number: '570'
   region: Oceania
   subregion: Polynesia
+  world_region: APAC
   un_locode: NU
   languages:
   - en
@@ -7069,6 +7237,7 @@ NZ:
   number: '554'
   region: Oceania
   subregion: Australia and New Zealand
+  world_region: APAC
   un_locode: NZ
   languages:
   - en
@@ -7115,6 +7284,7 @@ OM:
   number: '512'
   region: Asia
   subregion: Western Asia
+  world_region: EMEA
   un_locode: OM
   languages:
   - ar
@@ -7153,6 +7323,7 @@ PA:
   number: '591'
   region: Americas
   subregion: Central America
+  world_region: AMER
   un_locode: PA
   languages:
   - es
@@ -7192,6 +7363,7 @@ PE:
   number: '604'
   region: Americas
   subregion: South America
+  world_region: AMER
   un_locode: PE
   languages:
   - es
@@ -7204,7 +7376,7 @@ PF:
   country_code: '689'
   currency: XPF
   international_prefix: '00'
-  ioc: 
+  ioc:
   latitude: 15 00 S
   longitude: 140 00 W
   name: French Polynesia
@@ -7232,6 +7404,7 @@ PF:
   number: '258'
   region: Oceania
   subregion: Polynesia
+  world_region: APAC
   un_locode: PF
   languages:
   - fr
@@ -7272,6 +7445,7 @@ PG:
   number: '598'
   region: Oceania
   subregion: Melanesia
+  world_region: APAC
   un_locode: PG
   languages:
   - en
@@ -7320,6 +7494,7 @@ PH:
   number: '608'
   region: Asia
   subregion: South-Eastern Asia
+  world_region: APAC
   un_locode: PH
   languages:
   - tl
@@ -7359,6 +7534,7 @@ PK:
   number: '586'
   region: Asia
   subregion: Southern Asia
+  world_region: APAC
   un_locode: PK
   languages:
   - en
@@ -7408,6 +7584,7 @@ PL:
   number: '616'
   region: Europe
   subregion: Eastern Europe
+  world_region: EMEA
   un_locode: PL
   languages:
   - pl
@@ -7421,7 +7598,7 @@ PM:
   country_code: '508'
   currency: EUR
   international_prefix: '00'
-  ioc: 
+  ioc:
   latitude: 46 50 N
   longitude: 56 20 W
   name: Saint Pierre And Miquelon
@@ -7449,6 +7626,7 @@ PM:
   number: '666'
   region: Americas
   subregion: Northern America
+  world_region: AMER
   un_locode: PM
   languages:
   - fr
@@ -7461,7 +7639,7 @@ PN:
   country_code: ''
   currency: NZD
   international_prefix: '00'
-  ioc: 
+  ioc:
   latitude: 25 04 S
   longitude: 130 06 W
   name: Pitcairn
@@ -7485,6 +7663,7 @@ PN:
   number: '612'
   region: Oceania
   subregion: Polynesia
+  world_region: APAC
   un_locode: PN
   languages:
   - en
@@ -7522,6 +7701,7 @@ PR:
   number: '630'
   region: Americas
   subregion: Caribbean
+  world_region: AMER
   un_locode: PR
   languages:
   - es
@@ -7533,7 +7713,7 @@ PS:
   alpha2: PS
   alpha3: PSE
   country_code: '970'
-  currency: 
+  currency:
   international_prefix: '00'
   ioc: PLE
   latitude: ''
@@ -7564,7 +7744,8 @@ PS:
   number: '275'
   region: Asia
   subregion: Western Asia
-  un_locode: 
+  world_region: EMEA
+  un_locode:
   languages:
   - ar
   - he
@@ -7610,6 +7791,7 @@ PT:
   number: '620'
   region: Europe
   subregion: Southern Europe
+  world_region: EMEA
   un_locode: PT
   languages:
   - pt
@@ -7647,6 +7829,7 @@ PW:
   number: '585'
   region: Oceania
   subregion: Micronesia
+  world_region: APAC
   un_locode: PW
   languages:
   - en
@@ -7684,6 +7867,7 @@ PY:
   number: '600'
   region: Americas
   subregion: South America
+  world_region: AMER
   un_locode: PY
   languages:
   - es
@@ -7730,6 +7914,7 @@ QA:
   number: '634'
   region: Asia
   subregion: Western Asia
+  world_region: EMEA
   un_locode: QA
   languages:
   - ar
@@ -7742,7 +7927,7 @@ RE:
   country_code: '262'
   currency: EUR
   international_prefix: '00'
-  ioc: 
+  ioc:
   latitude: ''
   longitude: ''
   name: Réunion
@@ -7767,6 +7952,7 @@ RE:
   number: '638'
   region: Africa
   subregion: Eastern Africa
+  world_region: EMEA
   un_locode: RE
   languages:
   - fr
@@ -7814,6 +8000,7 @@ RO:
   number: '642'
   region: Europe
   subregion: Eastern Europe
+  world_region: EMEA
   un_locode: RO
   languages:
   - ro
@@ -7854,6 +8041,7 @@ RS:
   number: '688'
   region: Europe
   subregion: Southern Europe
+  world_region: EMEA
   un_locode: RS
   languages:
   - sr
@@ -7903,6 +8091,7 @@ RU:
   number: '643'
   region: Europe
   subregion: Eastern Europe
+  world_region: APAC
   un_locode: RU
   languages:
   - ru
@@ -7942,6 +8131,7 @@ RW:
   number: '646'
   region: Africa
   subregion: Eastern Africa
+  world_region: EMEA
   un_locode: RW
   languages:
   - rw
@@ -7993,6 +8183,7 @@ SA:
   number: '682'
   region: Asia
   subregion: Western Asia
+  world_region: EMEA
   un_locode: SA
   languages:
   - ar
@@ -8033,6 +8224,7 @@ SB:
   number: 090
   region: Oceania
   subregion: Melanesia
+  world_region: APAC
   un_locode: SB
   languages:
   - en
@@ -8070,6 +8262,7 @@ SC:
   number: '690'
   region: Africa
   subregion: Eastern Africa
+  world_region: EMEA
   un_locode: SC
   languages:
   - fr
@@ -8111,6 +8304,7 @@ SD:
   number: '729'
   region: Africa
   subregion: Northern Africa
+  world_region: EMEA
   un_locode: SD
   languages:
   - ar
@@ -8160,6 +8354,7 @@ SE:
   number: '752'
   region: Europe
   subregion: Northern Europe
+  world_region: EMEA
   un_locode: SE
   languages:
   - sv
@@ -8208,6 +8403,7 @@ SG:
   number: '702'
   region: Asia
   subregion: South-Eastern Asia
+  world_region: APAC
   un_locode: SG
   languages:
   - en
@@ -8222,7 +8418,7 @@ SH:
   country_code: '290'
   currency: SHP
   international_prefix: '00'
-  ioc: 
+  ioc:
   latitude: 15 57 S
   longitude: 5 42 W
   name: Saint Helena
@@ -8250,6 +8446,7 @@ SH:
   number: '654'
   region: Africa
   subregion: Western Africa
+  world_region: EMEA
   un_locode: SH
   languages:
   - en
@@ -8298,6 +8495,7 @@ SI:
   number: '705'
   region: Europe
   subregion: Southern Europe
+  world_region: EMEA
   un_locode: SI
   languages:
   - sl
@@ -8311,7 +8509,7 @@ SJ:
   country_code: '47'
   currency: NOK
   international_prefix: '00'
-  ioc: 
+  ioc:
   latitude: 78 00 N
   longitude: 20 00 E
   name: Svalbard And Jan Mayen
@@ -8339,6 +8537,7 @@ SJ:
   number: '744'
   region: Europe
   subregion: Northern Europe
+  world_region: EMEA
   un_locode: SJ
   languages:
   - 'no'
@@ -8387,6 +8586,7 @@ SK:
   number: '703'
   region: Europe
   subregion: Eastern Europe
+  world_region: EMEA
   un_locode: SK
   languages:
   - sk
@@ -8424,6 +8624,7 @@ SL:
   number: '694'
   region: Africa
   subregion: Western Africa
+  world_region: EMEA
   un_locode: SL
   languages:
   - en
@@ -8464,6 +8665,7 @@ SM:
   number: '674'
   region: Europe
   subregion: Southern Europe
+  world_region: EMEA
   un_locode: SM
   languages:
   - it
@@ -8501,6 +8703,7 @@ SN:
   number: '686'
   region: Africa
   subregion: Western Africa
+  world_region: EMEA
   un_locode: SN
   languages:
   - fr
@@ -8540,6 +8743,7 @@ SO:
   number: '706'
   region: Africa
   subregion: Eastern Africa
+  world_region: EMEA
   un_locode: SO
   languages:
   - so
@@ -8578,6 +8782,7 @@ SR:
   number: '740'
   region: Americas
   subregion: South America
+  world_region: AMER
   un_locode: SR
   languages:
   - nl
@@ -8616,6 +8821,7 @@ SS:
   number: '728'
   region: Africa
   subregion: Northern Africa
+  world_region: EMEA
   languages:
   - ar
   - en
@@ -8657,6 +8863,7 @@ ST:
   number: '678'
   region: Africa
   subregion: Middle Africa
+  world_region: EMEA
   un_locode: ST
   languages:
   - pt
@@ -8694,6 +8901,7 @@ SV:
   number: '222'
   region: Americas
   subregion: Central America
+  world_region: AMER
   un_locode: SV
   languages:
   - es
@@ -8726,6 +8934,7 @@ SX:
   number: '534'
   region: Americas
   subregion: Caribbean
+  world_region: AMER
   un_locode: SX
   languages:
   - nl
@@ -8776,6 +8985,7 @@ SY:
   number: '760'
   region: Asia
   subregion: Western Asia
+  world_region: EMEA
   un_locode: SY
   languages:
   - ar
@@ -8814,6 +9024,7 @@ SZ:
   number: '748'
   region: Africa
   subregion: Southern Africa
+  world_region: EMEA
   un_locode: SZ
   languages:
   - en
@@ -8827,7 +9038,7 @@ TC:
   country_code: '1'
   currency: USD
   international_prefix: '011'
-  ioc: 
+  ioc:
   latitude: 21 45 N
   longitude: 71 35 W
   name: Turks and Caicos Islands
@@ -8855,6 +9066,7 @@ TC:
   number: '796'
   region: Americas
   subregion: Caribbean
+  world_region: AMER
   un_locode: TC
   languages:
   - en
@@ -8895,6 +9107,7 @@ TD:
   number: '148'
   region: Africa
   subregion: Middle Africa
+  world_region: EMEA
   un_locode: TD
   languages:
   - ar
@@ -8908,7 +9121,7 @@ TF:
   country_code: ''
   currency: EUR
   international_prefix: ''
-  ioc: 
+  ioc:
   latitude: ''
   longitude: ''
   name: French Southern Territories
@@ -8934,7 +9147,7 @@ TF:
   number: '260'
   region: ''
   subregion: ''
-  un_locode: 
+  un_locode:
   languages:
   - fr
   nationality: French
@@ -8971,6 +9184,7 @@ TG:
   number: '768'
   region: Africa
   subregion: Western Africa
+  world_region: EMEA
   un_locode: TG
   languages:
   - fr
@@ -9011,6 +9225,7 @@ TH:
   number: '764'
   region: Asia
   subregion: South-Eastern Asia
+  world_region: APAC
   un_locode: TH
   languages:
   - th
@@ -9052,6 +9267,7 @@ TJ:
   number: '762'
   region: Asia
   subregion: Central Asia
+  world_region: APAC
   un_locode: TJ
   languages:
   - tg
@@ -9065,7 +9281,7 @@ TK:
   country_code: '690'
   currency: NZD
   international_prefix: '00'
-  ioc: 
+  ioc:
   latitude: 9 00 S
   longitude: 172 00 W
   name: Tokelau
@@ -9091,6 +9307,7 @@ TK:
   number: '772'
   region: Oceania
   subregion: Polynesia
+  world_region: APAC
   un_locode: TK
   languages:
   - en
@@ -9131,7 +9348,8 @@ TL:
   number: '626'
   region: Asia
   subregion: South-Eastern Asia
-  un_locode: 
+  world_region: APAC
+  un_locode:
   languages:
   - pt
   nationality: East Timorese
@@ -9141,7 +9359,7 @@ TM:
   alpha2: TM
   alpha3: TKM
   country_code: '993'
-  currency: 
+  currency:
   international_prefix: '810'
   ioc: TKM
   latitude: 40 00 N
@@ -9170,6 +9388,7 @@ TM:
   number: '795'
   region: Asia
   subregion: Central Asia
+  world_region: APAC
   un_locode: TM
   languages:
   - tk
@@ -9212,6 +9431,7 @@ TN:
   number: '788'
   region: Africa
   subregion: Northern Africa
+  world_region: EMEA
   un_locode: TN
   languages:
   - ar
@@ -9252,6 +9472,7 @@ TO:
   number: '776'
   region: Oceania
   subregion: Polynesia
+  world_region: APAC
   un_locode: TO
   languages:
   - en
@@ -9301,6 +9522,7 @@ TR:
   number: '792'
   region: Asia
   subregion: Western Asia
+  world_region: EMEA
   un_locode: TR
   languages:
   - tr
@@ -9342,6 +9564,7 @@ TT:
   number: '780'
   region: Americas
   subregion: Caribbean
+  world_region: AMER
   un_locode: TT
   languages:
   - en
@@ -9378,6 +9601,7 @@ TV:
   number: '798'
   region: Oceania
   subregion: Polynesia
+  world_region: APAC
   un_locode: TV
   languages:
   - en
@@ -9424,6 +9648,7 @@ TW:
   number: '158'
   region: Asia
   subregion: Eastern Asia
+  world_region: APAC
   un_locode: TW
   languages:
   - zh
@@ -9463,6 +9688,7 @@ TZ:
   number: '834'
   region: Africa
   subregion: Eastern Africa
+  world_region: EMEA
   un_locode: TZ
   languages:
   - sw
@@ -9515,6 +9741,7 @@ UA:
   number: '804'
   region: Europe
   subregion: Eastern Europe
+  world_region: EMEA
   un_locode: UA
   languages:
   - uk
@@ -9552,6 +9779,7 @@ UG:
   number: '800'
   region: Africa
   subregion: Eastern Africa
+  world_region: EMEA
   un_locode: UG
   languages:
   - en
@@ -9565,7 +9793,7 @@ UM:
   country_code: ''
   currency: USD
   international_prefix: ''
-  ioc: 
+  ioc:
   latitude: ''
   longitude: ''
   name: United States Minor Outlying Islands
@@ -9591,6 +9819,7 @@ UM:
   number: '581'
   region: Americas
   subregion: Northern America
+  world_region: AMER
   un_locode: UM
   languages:
   - en
@@ -9639,6 +9868,7 @@ US:
   number: '840'
   region: Americas
   subregion: Northern America
+  world_region: AMER
   un_locode: US
   languages:
   - en
@@ -9677,6 +9907,7 @@ UY:
   number: '858'
   region: Americas
   subregion: South America
+  world_region: AMER
   un_locode: UY
   languages:
   - es
@@ -9718,6 +9949,7 @@ UZ:
   number: '860'
   region: Asia
   subregion: Central Asia
+  world_region: APAC
   un_locode: UZ
   languages:
   - uz
@@ -9760,6 +9992,7 @@ VA:
   number: '336'
   region: Europe
   subregion: Southern Europe
+  world_region: EMEA
   un_locode: VA
   languages:
   - it
@@ -9801,6 +10034,7 @@ VC:
   number: '670'
   region: Americas
   subregion: Caribbean
+  world_region: AMER
   un_locode: VC
   languages:
   - en
@@ -9837,6 +10071,7 @@ VE:
   number: '862'
   region: Americas
   subregion: South America
+  world_region: AMER
   un_locode: VE
   languages:
   - es
@@ -9877,6 +10112,7 @@ VG:
   number: 092
   region: Americas
   subregion: Caribbean
+  world_region: AMER
   un_locode: VG
   languages:
   - en
@@ -9917,6 +10153,7 @@ VI:
   number: '850'
   region: Americas
   subregion: Caribbean
+  world_region: AMER
   un_locode: VI
   languages:
   - en
@@ -9956,6 +10193,7 @@ VN:
   number: '704'
   region: Asia
   subregion: South-Eastern Asia
+  world_region: APAC
   un_locode: VN
   languages:
   - vi
@@ -9994,6 +10232,7 @@ VU:
   number: '548'
   region: Oceania
   subregion: Melanesia
+  world_region: APAC
   un_locode: VU
   languages:
   - bi
@@ -10036,6 +10275,7 @@ WF:
   number: '876'
   region: Oceania
   subregion: Polynesia
+  world_region: APAC
   un_locode: WF
   languages:
   - fr
@@ -10073,6 +10313,7 @@ WS:
   number: '882'
   region: Oceania
   subregion: Polynesia
+  world_region: APAC
   un_locode: WS
   languages:
   - sm
@@ -10121,6 +10362,7 @@ YE:
   number: '887'
   region: Asia
   subregion: Western Asia
+  world_region: EMEA
   un_locode: YE
   languages:
   - ar
@@ -10157,6 +10399,7 @@ YT:
   number: '175'
   region: Africa
   subregion: Eastern Africa
+  world_region: EMEA
   un_locode: YT
   languages:
   - fr
@@ -10209,6 +10452,7 @@ ZA:
   number: '710'
   region: Africa
   subregion: Southern Africa
+  world_region: EMEA
   un_locode: ZA
   languages:
   - af
@@ -10257,6 +10501,7 @@ ZM:
   number: '894'
   region: Africa
   subregion: Eastern Africa
+  world_region: EMEA
   un_locode: ZM
   languages:
   - en
@@ -10299,6 +10544,7 @@ ZW:
   number: '716'
   region: Africa
   subregion: Eastern Africa
+  world_region: EMEA
   un_locode: ZW
   languages:
   - en

--- a/lib/data/countries.yaml
+++ b/lib/data/countries.yaml
@@ -290,7 +290,7 @@ AM:
   number: '051'
   region: Asia
   subregion: Western Asia
-  world_region: APAC
+  world_region: EMEA
   un_locode: AM
   languages:
   - hy
@@ -407,6 +407,7 @@ AQ:
   national_destination_code_lengths: []
   national_number_lengths: []
   national_prefix: ''
+  world_region: AMER
   number: '010'
   region: ''
   subregion: ''
@@ -722,7 +723,7 @@ AZ:
   number: '031'
   region: Asia
   subregion: Western Asia
-  world_region: APAC
+  world_region: EMEA
   un_locode: AZ
   languages:
   - az
@@ -1035,7 +1036,7 @@ BH:
   number: 048
   region: Asia
   subregion: Western Asia
-  world_region: APAC
+  world_region: EMEA
   un_locode: BH
   languages:
   - ar
@@ -1147,7 +1148,7 @@ BL:
   number: '652'
   region: Americas
   subregion: Caribbean
-  world_region: AMER
+  world_region: APAC
   un_locode:
   languages:
   - fr
@@ -1299,7 +1300,7 @@ BQ:
   number: '535'
   region: Americas
   subregion: Caribbean
-  world_region: AMER
+  world_region: APAC
   un_locode: BQ
   languages:
   - nl
@@ -1468,6 +1469,7 @@ BV:
   languages: []
   nationality: ''
   postal_code: true
+  world_region: APAC
 BW:
   continent: Africa
   alpha2: BW
@@ -4079,6 +4081,7 @@ HM:
   - en
   nationality: Heard and McDonald Islander
   postal_code: true
+  world_region: APAC
 HN:
   continent: North America
   alpha2: HN
@@ -4529,7 +4532,7 @@ IO:
   number: 086
   region: Africa
   subregion: Eastern Africa
-  world_region: EMEA
+  world_region: APAC
   un_locode: IO
   languages:
   - en
@@ -4960,7 +4963,7 @@ KG:
   number: '417'
   region: Asia
   subregion: Central Asia
-  world_region: APAC
+  world_region: EMEA
   un_locode: KG
   languages:
   - ky
@@ -5347,7 +5350,7 @@ KZ:
   number: '398'
   region: Asia
   subregion: Central Asia
-  world_region: APAC
+  world_region: EMEA
   un_locode: KZ
   languages:
   - kk
@@ -6449,7 +6452,7 @@ MS:
   number: '500'
   region: Americas
   subregion: Caribbean
-  world_region: AMER
+  world_region: EMEA
   un_locode: MS
   languages:
   - en
@@ -8091,7 +8094,7 @@ RU:
   number: '643'
   region: Europe
   subregion: Eastern Europe
-  world_region: APAC
+  world_region: EMEA
   un_locode: RU
   languages:
   - ru
@@ -8446,7 +8449,7 @@ SH:
   number: '654'
   region: Africa
   subregion: Western Africa
-  world_region: EMEA
+  world_region: APAC
   un_locode: SH
   languages:
   - en
@@ -9066,7 +9069,7 @@ TC:
   number: '796'
   region: Americas
   subregion: Caribbean
-  world_region: AMER
+  world_region: APAC
   un_locode: TC
   languages:
   - en
@@ -9152,6 +9155,7 @@ TF:
   - fr
   nationality: French
   postal_code: false
+  world_region: APAC
 TG:
   continent: Africa
   alpha2: TG
@@ -9267,7 +9271,7 @@ TJ:
   number: '762'
   region: Asia
   subregion: Central Asia
-  world_region: APAC
+  world_region: EMEA
   un_locode: TJ
   languages:
   - tg
@@ -9388,7 +9392,7 @@ TM:
   number: '795'
   region: Asia
   subregion: Central Asia
-  world_region: APAC
+  world_region: EMEA
   un_locode: TM
   languages:
   - tk
@@ -9949,7 +9953,7 @@ UZ:
   number: '860'
   region: Asia
   subregion: Central Asia
-  world_region: APAC
+  world_region: EMEA
   un_locode: UZ
   languages:
   - uz

--- a/spec/country_spec.rb
+++ b/spec/country_spec.rb
@@ -52,11 +52,11 @@ describe ISO3166::Country do
   it "should return continent" do
     country.continent.should == "North America"
   end
-  
+
   it 'knows about whether or not the country uses postal codes' do
     country.zip.should be_true
   end
-  
+
   it 'knows when a country does not require postal codes' do
     ireland = ISO3166::Country.search('IE')
     ireland.postal_code.should == false
@@ -68,6 +68,26 @@ describe ISO3166::Country do
 
   it 'should return subregion' do
     country.subregion.should == 'Northern America'
+  end
+
+  it 'should return world region' do
+    country.world_region.should == 'AMER'
+  end
+
+  context 'with Turkey' do
+    let(:country) { ISO3166::Country.search('TR') }
+
+    it 'should indicate EMEA as the world region' do
+      country.world_region.should == 'EMEA'
+    end
+  end
+
+  context 'with Japan' do
+    let(:country) { ISO3166::Country.search('JP') }
+
+    it 'should indicate APAC as the world region' do
+      country.world_region.should == 'APAC'
+    end
   end
 
   it 'should return ioc code' do


### PR DESCRIPTION
These categories are commonly used in global commerce, but aren't trivial to deduce from existing regional information, specifically in the Middle East, where countries like Israel and Jordan are in the region "Asia / Western Asia" but in the EMEA group.

For reference, the list of countries and their regions: https://support.google.com/richmedia/answer/1381064?hl=en