### PR TITLE
Update Singapore subdivisions to reflect ISO-3166-2:SG

### DIFF
--- a/lib/data/subdivisions/SG.yaml
+++ b/lib/data/subdivisions/SG.yaml
@@ -1,4 +1,16 @@
 ---
-X1~:
-  name: "Singapore - No State"
-  names: "Singapore - No State"
+SG-01:
+  name: "Central Singapore"
+  names: "Central Singapore"
+SG-02:
+  name: "North East"
+  names: "North East"
+SG-03:
+  name: "North West"
+  names: "North West"
+SG-04:
+  name: "South East"
+  names: "South East"
+SG-05:
+  name: "South West"
+  names: "South West"


### PR DESCRIPTION
Updates Singapore subdivisions according to https://www.iso.org/obp/ui/#iso:code:3166:SG