### PR TITLE
Add Russian as Estonian language

### DIFF
--- a/lib/data/countries.yaml
+++ b/lib/data/countries.yaml
@@ -2672,6 +2672,7 @@ EE:
   un_locode: EE
   languages:
   - et
+  - ru
   nationality: Estonian
   eu_member: true
   postal_code: true


### PR DESCRIPTION
Russian is very common in Estonia. 