### PR TITLE
Lithuania adopted the Euro on 2015-01-01

### DIFF
--- a/lib/data/countries.yaml
+++ b/lib/data/countries.yaml
@@ -5509,7 +5509,7 @@ LT:
   alpha2: LT
   alpha3: LTU
   country_code: '370'
-  currency: LTL
+  currency: EUR
   international_prefix: '00'
   ioc: LTU
   latitude: 56 00 N


### PR DESCRIPTION
http://en.wikipedia.org/wiki/Lithuania_and_the_euro