### PR TITLE
Fix spelling

### DIFF
--- a/lib/data/countries.yaml
+++ b/lib/data/countries.yaml
@@ -1498,7 +1498,7 @@ BY:
     es: Bielorrusia
     ja: ベラルーシ
     nl: Wit-Rusland
-    ru: Белоруссия
+    ru: Беларусь
   national_destination_code_lengths:
   - 2
   national_number_lengths:


### PR DESCRIPTION
`Белоруссия` is wrong country name. The right official name is 'Респулика Беларусь' or in short 'Беларусь'.