### PR TITLE
Add Cuban Subdivisions - Artemisa and Mayabeque

### DIFF
--- a/lib/data/subdivisions/CU.yaml
+++ b/lib/data/subdivisions/CU.yaml
@@ -53,6 +53,14 @@
 :
   name: Guantánamo
   names: Guantánamo
+? "15"
+:
+  name: Artemisa
+  names: Artemisa
+? "16"
+:
+  name: Mayabeque
+  names: Mayabeque
 ? "99"
 :
   name: "Isla de la Juventud"


### PR DESCRIPTION
In partial response to #208 

Note: This PR only adds `CU-15` and `CU-16`, since that's the bare minimum of what should be done. It doesn't touch `CU-02` or `CU-03`, though something will need to be done with those too.