### PR TITLE
Rename CU-02 to 'Provincia de la Habana' and CU-03 to 'La Habana'

### DIFF
--- a/lib/data/subdivisions/CU.yaml
+++ b/lib/data/subdivisions/CU.yaml
@@ -5,8 +5,8 @@
   names: "Pinar del Río"
 ? "02"
 :
-  name: "Provincia de La Habana"
-  names: "Provincia de La Habana"
+  name: "Antigua provincia de La Habana"
+  names: "Antigua provincia de La Habana"
 ? "03"
 :
   name: "La Habana"

--- a/lib/data/subdivisions/CU.yaml
+++ b/lib/data/subdivisions/CU.yaml
@@ -5,12 +5,12 @@
   names: "Pinar del Río"
 ? "02"
 :
-  name: "La Habana"
-  names: "La Habana"
+  name: "Provincia de La Habana"
+  names: "Provincia de La Habana"
 ? "03"
 :
-  name: "Ciudad de La Habana"
-  names: "Ciudad de La Habana"
+  name: "La Habana"
+  names: "La Habana"
 ? "04"
 :
   name: Matanzas


### PR DESCRIPTION
`CU-02`: La Habana ==> Provincia de La Habana
`CU-03`: Ciudad de La Habana ==> La Habana

Note: `CU-02` no longer exists and is being renamed because of the potential conflict with CU-03's name