### PR TITLE
Fix address format for Spain

### DIFF
--- a/lib/data/countries/ES.yaml
+++ b/lib/data/countries/ES.yaml
@@ -4,7 +4,8 @@ ES:
   address_format: |-
     {{recipient}}
     {{street}}
-    {{postalcode}} {{city}} {{region}}
+    {{postalcode}} {{city}}
+    {{region}}
     {{country}}
   alpha2: ES
   alpha3: ESP


### PR DESCRIPTION
According to this document the region for address labels in Spain has to
be printed in a separate line:

http://www.upu.int/fileadmin/documentsFiles/activities/addressingUnit/espEn.pdf
