### PR TITLE
Add provinces as an alias for subdivisions

### DIFF
--- a/lib/countries/country.rb
+++ b/lib/countries/country.rb
@@ -81,6 +81,7 @@ class ISO3166::Country
   end
 
   alias :states :subdivisions
+  alias :provinces :subdivisions
 
   def subdivisions?
     File.exist?(File.join(File.dirname(__FILE__), '..', 'data', 'subdivisions', "#{alpha2}.yaml"))

--- a/spec/country_spec.rb
+++ b/spec/country_spec.rb
@@ -146,7 +146,11 @@ describe ISO3166::Country do
     end
 
     it 'should be available through states' do
-      country.states.should have(60).states
+      country.states.should have(60).subdivisions
+    end
+
+    it 'should be available through provinces' do
+      country.provinces.should have(60).subdivisions
     end
   end
 


### PR DESCRIPTION
There already exists an alias for `.subdivisions` as `.states` 

I think there should be `.provinces` as well!

I added a test for this, and also fixed the existing test for `.states` (I think... It used to test against itself)