### PR TITLE
Convert specs to RSpec 2.99.2 syntax with Transpec

### DIFF
--- a/Gemfile
+++ b/Gemfile
@@ -1,6 +1,5 @@
 source 'https://rubygems.org'
-gem "rake"
+gem 'rake'
 
 # Specify your gem's dependencies in countries.gemspec
 gemspec
-

--- a/Rakefile
+++ b/Rakefile
@@ -1,17 +1,17 @@
 #!/usr/bin/env rake
-require "bundler/gem_tasks"
+require 'bundler/gem_tasks'
 
 require 'rake'
 require 'rspec/core/rake_task'
 
-desc "Run all examples"
+desc 'Run all examples'
 RSpec::Core::RakeTask.new(:spec) do |t|
-  t.rspec_opts = %w[--color]
+  t.rspec_opts = %w(--color)
 end
 
-task :default => [:spec]
+task default: [:spec]
 
-desc "Test and Clean YAML files"
+desc 'Test and Clean YAML files'
 task :clean_yaml do
   require 'yaml'
 
@@ -20,9 +20,9 @@ task :clean_yaml do
     begin
       puts "checking : #{file}"
       data = YAML.load_file(file)
-      File.open(file, 'w') {|f| f.write data.to_yaml }
-    rescue Exception
-      puts "failed to read #{file}: #{$!}"
+      File.open(file, 'w') { |f| f.write data.to_yaml }
+    rescue
+      puts "failed to read #{file}: #{$ERROR_INFO}"
     end
   end
 end

--- a/countries.gemspec
+++ b/countries.gemspec
@@ -17,6 +17,6 @@ Gem::Specification.new do |gem|
 
   gem.add_dependency('i18n_data', '~> 0.6.0')
   gem.add_dependency('currencies', '~> 0.4.2')
-  gem.add_development_dependency("rspec", "< 3")
+  gem.add_development_dependency("rspec", ">= 3")
   gem.add_development_dependency "yard"
 end

--- a/countries.gemspec
+++ b/countries.gemspec
@@ -2,21 +2,21 @@
 require File.expand_path('../lib/countries/version', __FILE__)
 
 Gem::Specification.new do |gem|
-  gem.authors       = ["Josh Robinson", "Joe Corcoran"]
-  gem.email         = ["hexorx@gmail.com"]
-  gem.description   = %q{All sorts of useful information about every country packaged as pretty little country objects. It includes data from ISO 3166}
-  gem.summary       = %q{Gives you a country object full of all sorts of useful information.}
-  gem.homepage      = "http://github.com/hexorx/countries"
+  gem.authors       = ['Josh Robinson', 'Joe Corcoran']
+  gem.email         = ['hexorx@gmail.com']
+  gem.description   = 'All sorts of useful information about every country packaged as pretty little country objects. It includes data from ISO 3166'
+  gem.summary       = 'Gives you a country object full of all sorts of useful information.'
+  gem.homepage      = 'http://github.com/hexorx/countries'
 
-  gem.files         = `git ls-files`.split($\)
-  gem.executables   = gem.files.grep(%r{^bin/}).map{ |f| File.basename(f) }
+  gem.files         = `git ls-files`.split($OUTPUT_RECORD_SEPARATOR)
+  gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
-  gem.name          = "countries"
-  gem.require_paths = ["lib"]
+  gem.name          = 'countries'
+  gem.require_paths = ['lib']
   gem.version       = Countries::VERSION
 
   gem.add_dependency('i18n_data', '~> 0.6.0')
   gem.add_dependency('currencies', '~> 0.4.2')
-  gem.add_development_dependency("rspec", ">= 3")
-  gem.add_development_dependency "yard"
+  gem.add_development_dependency('rspec', '>= 3')
+  gem.add_development_dependency 'yard'
 end

--- a/lib/countries.rb
+++ b/lib/countries.rb
@@ -1,10 +1,10 @@
-require "countries/version"
+require 'countries/version'
 
 require 'iso3166'
 require 'countries/mongoid' if defined?(Mongoid)
 
 class Country < ISO3166::Country
   def to_s
-    self.name
+    name
   end
 end

--- a/lib/countries/mongoid.rb
+++ b/lib/countries/mongoid.rb
@@ -1,17 +1,15 @@
 module ISO3166; end
 
 class ISO3166::Country
-
   def mongoize
     ISO3166::Country.mongoize(self)
   end
 
   class << self
-
     def mongoize(country)
       if country.is_a?(self) && !country.data.nil?
         country.alpha2
-      elsif self.send(:valid_alpha2?, country)
+      elsif send(:valid_alpha2?, country)
         new(country).alpha2
       else
         nil

--- a/lib/iso3166.rb
+++ b/lib/iso3166.rb
@@ -5,5 +5,5 @@ require 'i18n_data'
 require 'countries/country'
 
 if defined?(ActionView::Helpers::FormOptionsHelper)
-  ActionView::Helpers::FormOptionsHelper::COUNTRIES = ISO3166::Country::Names.map{ |(name,alpha2)| [name.html_safe,alpha2] }
+  ActionView::Helpers::FormOptionsHelper::COUNTRIES = ISO3166::Country::Names.map { |(name, alpha2)| [name.html_safe, alpha2] }
 end

--- a/spec/country_spec.rb
+++ b/spec/country_spec.rb
@@ -8,85 +8,85 @@ describe ISO3166::Country do
 
   it 'allows to create a country object from a symbol representation of the alpha2 code' do
     country = described_class.new(:us)
-    country.data.should_not be_nil
+    expect(country.data).not_to be_nil
   end
 
   it 'allows to create a country object from a lowercase alpha2 code' do
     country = described_class.new("us")
-    country.data.should_not be_nil
+    expect(country.data).not_to be_nil
   end
 
   it 'should return 3166 number' do
-    country.number.should == '840'
+    expect(country.number).to eq('840')
   end
 
   it 'should return 3166 alpha2 code' do
-    country.alpha2.should == 'US'
+    expect(country.alpha2).to eq('US')
   end
 
   it 'should return 3166 alpha3 code' do
-    country.alpha3.should == 'USA'
+    expect(country.alpha3).to eq('USA')
   end
 
   it 'should return 3166 name' do
-    country.name.should == 'United States'
+    expect(country.name).to eq('United States')
   end
 
   it 'should return alternate names' do
-    country.names.should == ["United States of America", "Vereinigte Staaten von Amerika", "États-Unis", "Estados Unidos", "アメリカ合衆国", "Verenigde Staten"]
+    expect(country.names).to eq(["United States of America", "Vereinigte Staaten von Amerika", "États-Unis", "Estados Unidos", "アメリカ合衆国", "Verenigde Staten"])
   end
 
   it 'should return translations' do
-    country.translations.should be
-    country.translations['en'].should == 'United States'
+    expect(country.translations).to be
+    expect(country.translations['en']).to eq('United States')
   end
 
   it 'should return latitude' do
-    country.latitude.should == '38 00 N'
+    expect(country.latitude).to eq('38 00 N')
   end
 
   it 'should return longitude' do
-    country.longitude.should == '97 00 W'
+    expect(country.longitude).to eq('97 00 W')
   end
 
   it 'should return the decimal Latitude' do
-    country.latitude_dec.should == '39.44325637817383'
+    expect(country.latitude_dec).to eq('39.44325637817383')
   end
 
   it 'should return the decimal Longitude' do
-    country.longitude_dec.should == '-98.95733642578125'
+    expect(country.longitude_dec).to eq('-98.95733642578125')
   end
 
   it "should return continent" do
-    country.continent.should == "North America"
+    expect(country.continent).to eq("North America")
   end
 
   it 'knows about whether or not the country uses postal codes' do
-    country.zip.should be_true
+    expect(country.zip).to be_truthy
   end
 
   it 'knows when a country does not require postal codes' do
     ireland = ISO3166::Country.search('IE')
-    ireland.postal_code.should == false
+    expect(ireland.postal_code).to eq(false)
   end
 
   it 'should return region' do
-    country.region.should == 'Americas'
+    expect(country.region).to eq('Americas')
   end
 
   it 'should return subregion' do
-    country.subregion.should == 'Northern America'
+    expect(country.subregion).to eq('Northern America')
   end
 
   it 'should return world region' do
-    country.world_region.should == 'AMER'
+    expect(country.world_region).to eq('AMER')
   end
 
   context 'with Turkey' do
     let(:country) { ISO3166::Country.search('TR') }
 
     it 'should indicate EMEA as the world region' do
-      country.world_region.should == 'EMEA'
+      expect(country.world_region).to eq('EMEA')
     end
   end
 
@@ -94,192 +94,192 @@ describe ISO3166::Country do
     let(:country) { ISO3166::Country.search('JP') }
 
     it 'should indicate APAC as the world region' do
-      country.world_region.should == 'APAC'
+      expect(country.world_region).to eq('APAC')
     end
   end
 
   it 'should return ioc code' do
-    country.ioc.should == 'USA'
+    expect(country.ioc).to eq('USA')
   end
 
   it 'should return UN/LOCODE' do
-    country.un_locode.should == 'US'
+    expect(country.un_locode).to eq('US')
   end
 
   it 'should be identical to itself' do
-    country.should == ISO3166::Country.search('US')
+    expect(country).to eq(ISO3166::Country.search('US'))
   end
 
   it 'should return language' do
-    country.languages[0].should == 'en'
+    expect(country.languages[0]).to eq('en')
   end
 
   describe 'e164' do
     it 'should return country_code' do
-      country.country_code.should == '1'
+      expect(country.country_code).to eq('1')
     end
 
     it 'should return national_destination_code_lengths' do
-      country.national_destination_code_lengths.should == [3]
+      expect(country.national_destination_code_lengths).to eq([3])
     end
 
     it 'should return national_number_lengths' do
-      country.national_number_lengths.should == [10]
+      expect(country.national_number_lengths).to eq([10])
     end
 
     it 'should return international_prefix' do
-      country.international_prefix.should == '011'
+      expect(country.international_prefix).to eq('011')
     end
 
     it 'should return national_prefix' do
-      country.national_prefix.should == '1'
+      expect(country.national_prefix).to eq('1')
     end
   end
 
   describe 'subdivisions' do
     it 'should return an empty hash for a country with no ISO3166-2' do
-      ISO3166::Country.search('VA').subdivisions.should have(0).subdivisions
+      expect(ISO3166::Country.search('VA').subdivisions.size).to eq(0)
     end
 
     it 'should return a hash with all sub divisions' do
-      country.subdivisions.should have(60).states
+      expect(country.subdivisions.size).to eq(60)
     end
 
     it 'should be available through states' do
-      country.states.should have(60).states
+      expect(country.states.size).to eq(60)
     end
   end
 
   describe 'valid?' do
     it 'should return true if country is valid' do
-      ISO3166::Country.new('US').should be_valid
+      expect(ISO3166::Country.new('US')).to be_valid
     end
 
     it 'should return false if country is invalid' do
-      ISO3166::Country.new({}).should_not be_valid
+      expect(ISO3166::Country.new({})).not_to be_valid
     end
   end
 
   describe 'new' do
     it 'should return new country object when a valid alpha2 string is passed' do
-      ISO3166::Country.new('US').should be_a(ISO3166::Country)
+      expect(ISO3166::Country.new('US')).to be_a(ISO3166::Country)
     end
 
     it 'should return nil when an invalid alpha2 string is passed' do
-      ISO3166::Country.new('fubar').should be_nil
+      expect(ISO3166::Country.new('fubar')).to be_nil
     end
 
     it 'should return new country object when a valid alpha2 symbol is passed' do
-      ISO3166::Country.new(:us).should be_a(ISO3166::Country)
+      expect(ISO3166::Country.new(:us)).to be_a(ISO3166::Country)
     end
 
     it 'should return nil when an invalid alpha2 symbol is passed' do
-      ISO3166::Country.new(:fubar).should be_nil
+      expect(ISO3166::Country.new(:fubar)).to be_nil
     end
   end
 
   describe 'all' do
     it 'should return an arry list of all countries' do
       countries = ISO3166::Country.all
-      countries.should be_an(Array)
-      countries.first.should be_an(Array)
-      countries.should have(250).countries
+      expect(countries).to be_an(Array)
+      expect(countries.first).to be_an(Array)
+      expect(countries.size).to eq(250)
     end
 
     it "should allow to customize each country representation passing a block to the method" do
       countries = ISO3166::Country.all { |country, data| [data['name'], country, data['country_code'] ] }
-      countries.should be_an(Array)
-      countries.first.should be_an(Array)
-      countries.first.should have(3).fields
-      countries.should have(250).countries
+      expect(countries).to be_an(Array)
+      expect(countries.first).to be_an(Array)
+      expect(countries.first.size).to eq(3)
+      expect(countries.size).to eq(250)
     end
   end
 
   describe 'all_translated' do
     it 'should return an alphabetized list of all country names translated to the selected locale' do
       countries = ISO3166::Country.all_translated('fr')
-      countries.should be_an(Array)
-      countries.first.should be_a(String)
-      countries.first.should eq('Afghanistan')
+      expect(countries).to be_an(Array)
+      expect(countries.first).to be_a(String)
+      expect(countries.first).to eq('Afghanistan')
       # countries missing the desired locale will not be added to the list
       # so all 250 countries may not be returned, 'fr' returns 249, for example
-      countries.should have(249).countries
+      expect(countries.size).to eq(249)
     end
 
     it 'should return an alphabetized list of all country names in English if no locale is passed' do
       countries = ISO3166::Country.all_translated
-      countries.should be_an(Array)
-      countries.first.should be_a(String)
-      countries.first.should eq('Afghanistan')
-      countries.should have(249).countries
+      expect(countries).to be_an(Array)
+      expect(countries.first).to be_a(String)
+      expect(countries.first).to eq('Afghanistan')
+      expect(countries.size).to eq(249)
     end
   end
 
   describe 'translation' do
     it 'should return the localized name for a country to the selected locale' do
       countries = ISO3166::Country.new(:de).translation('de')
-      countries.should be_an(String)
-      countries.should eq('Deutschland')
+      expect(countries).to be_an(String)
+      expect(countries).to eq('Deutschland')
     end
 
     it 'should return the localized name for a country in English' do
       countries = ISO3166::Country.new(:de).translation
-      countries.should be_an(String)
-      countries.should eq('Germany')
+      expect(countries).to be_an(String)
+      expect(countries).to eq('Germany')
     end
   end
 
   describe 'translations' do
     it 'should return an hash of all country names translated to the selected locale' do
       countries = ISO3166::Country.translations('fr')
-      countries.should be_an(Hash)
-      countries.first[0].should eq('AF')
-      countries.first.should eq(['AF', 'Afghanistan'])
+      expect(countries).to be_an(Hash)
+      expect(countries.first[0]).to eq('AF')
+      expect(countries.first).to eq(['AF', 'Afghanistan'])
       # countries missing the desired locale will not be added to the list
       # so all 250 countries may not be returned, 'fr' returns 249, for example
-      countries.should have(249).countries
+      expect(countries.size).to eq(249)
     end
 
     it 'should return an hash of all country names in English if no locale is passed' do
       countries = ISO3166::Country.translations
-      countries.should be_an(Hash)
-      countries.first[0].should eq('AF')
-      countries.first.should eq(['AF', 'Afghanistan'])
-      countries.should have(249).countries
+      expect(countries).to be_an(Hash)
+      expect(countries.first[0]).to eq('AF')
+      expect(countries.first).to eq(['AF', 'Afghanistan'])
+      expect(countries.size).to eq(249)
     end
   end
 
   describe 'countries' do
     it 'should be the same as all' do
-      ISO3166::Country.countries.should == ISO3166::Country.all
+      expect(ISO3166::Country.countries).to eq(ISO3166::Country.all)
     end
   end
 
   describe 'search' do
     it 'should return new country object when a valid alpha2 string is passed' do
-      ISO3166::Country.search('US').should be_a(ISO3166::Country)
+      expect(ISO3166::Country.search('US')).to be_a(ISO3166::Country)
     end
 
     it 'should return nil when an invalid alpha2 string is passed' do
-      ISO3166::Country.search('fubar').should be_nil
+      expect(ISO3166::Country.search('fubar')).to be_nil
     end
 
     it 'should return new country object when a valid alpha2 symbol is passed' do
-      ISO3166::Country.search(:us).should be_a(ISO3166::Country)
+      expect(ISO3166::Country.search(:us)).to be_a(ISO3166::Country)
     end
 
     it 'should return nil when an invalid alpha2 symbol is passed' do
-      ISO3166::Country.search(:fubar).should be_nil
+      expect(ISO3166::Country.search(:fubar)).to be_nil
     end
   end
 
   describe 'currency' do
     it 'should return an instance of Currency' do
-      country.currency.should be_a(ISO4217::Currency)
+      expect(country.currency).to be_a(ISO4217::Currency)
     end
 
     it 'should allow access to symbol' do
-      country.currency[:symbol].should == '$'
+      expect(country.currency[:symbol]).to eq('$')
     end
   end
 
@@ -287,7 +287,7 @@ describe ISO3166::Country do
     context "when loaded via 'iso3166' existance" do
       subject { defined?(Country) }
 
-      it { should be_false }
+      it { is_expected.to be_falsey }
     end
 
     context "when loaded via 'countries'" do
@@ -296,18 +296,18 @@ describe ISO3166::Country do
       describe "existance" do
         subject { defined?(Country) }
 
-        it { should be_true }
+        it { is_expected.to be_truthy }
       end
 
       describe "superclass" do
         subject { Country.superclass }
 
-        it { should == ISO3166::Country }
+        it { is_expected.to eq(ISO3166::Country) }
       end
 
       describe 'to_s' do
         it 'should return the country name' do
-          Country.new('GB').to_s.should == 'United Kingdom'
+          expect(Country.new('GB').to_s).to eq('United Kingdom')
         end
       end
     end
@@ -318,8 +318,8 @@ describe ISO3166::Country do
       let(:spain_data) { ISO3166::Country.find_all_by('alpha2', "ES") }
 
       it "returns a hash with the data of the country" do
-        spain_data.should be_a Hash
-        spain_data.should have(1).keys
+        expect(spain_data).to be_a Hash
+        expect(spain_data.keys.size).to eq(1)
       end
     end
 
@@ -327,33 +327,33 @@ describe ISO3166::Country do
       let(:spain_data) { ISO3166::Country.find_all_by('languages', "en") }
 
       it "returns a hash with the data of the country" do
-        spain_data.should be_a Hash
-        spain_data.size.should > 1
+        expect(spain_data).to be_a Hash
+        expect(spain_data.size).to be > 1
       end
     end
 
     it "also finds results if the given values is not upcased/downcased properly" do
       spain_data = ISO3166::Country.find_all_by('alpha2', "es")
-      spain_data.should be_a Hash
-      spain_data.should have(1).keys
+      expect(spain_data).to be_a Hash
+      expect(spain_data.keys.size).to eq(1)
     end
 
     it "also finds results if the attribute is given as a symbol" do
       spain_data = ISO3166::Country.find_all_by(:alpha2, "ES")
-      spain_data.should be_a Hash
-      spain_data.should have(1).keys
+      expect(spain_data).to be_a Hash
+      expect(spain_data.keys.size).to eq(1)
     end
 
     it "casts the given value to a string to perform the search" do
       spain_data = ISO3166::Country.find_all_by(:country_code, 34)
-      spain_data.should be_a Hash
-      spain_data.keys.should == ['ES']
+      expect(spain_data).to be_a Hash
+      expect(spain_data.keys).to eq(['ES'])
     end
 
     it "also performs searches with regexps and forces it to ignore case" do
       spain_data = ISO3166::Country.find_all_by(:names, /Españ/)
-      spain_data.should be_a Hash
-      spain_data.keys.should == ['ES']
+      expect(spain_data).to be_a Hash
+      expect(spain_data.keys).to eq(['ES'])
     end
   end
 
@@ -381,7 +381,7 @@ describe ISO3166::Country do
 
     context "when finding by invalid attribute" do
       it "should raise an error" do
-        lambda { ISO3166::Country.find_by_invalid('invalid') }.should raise_error
+        expect { ISO3166::Country.find_by_invalid('invalid') }.to raise_error
       end
     end
 
@@ -389,8 +389,8 @@ describe ISO3166::Country do
       let(:list) { ISO3166::Country.find_all_by_currency('USD') }
 
       it "should be an Array of Arrays" do
-        list.should be_a(Array)
-        list.first.should be_a(Array)
+        expect(list).to be_a(Array)
+        expect(list.first).to be_a(Array)
       end
     end
 
@@ -409,8 +409,8 @@ describe ISO3166::Country do
       let(:uk) { ISO3166::Country.find_country_by_name("United Kingdom") }
 
       it "should be a country instance" do
-        uk.should be_a(ISO3166::Country)
-        uk.alpha2.should == "GB"
+        expect(uk).to be_a(ISO3166::Country)
+        expect(uk.alpha2).to eq("GB")
       end
     end
 
@@ -418,8 +418,8 @@ describe ISO3166::Country do
       let(:uk) { ISO3166::Country.find_country_by_name("united kingdom") }
 
       it "should be a country instance" do
-        uk.should be_a(ISO3166::Country)
-        uk.alpha2.should == "GB"
+        expect(uk).to be_a(ISO3166::Country)
+        expect(uk.alpha2).to eq("GB")
       end
     end
 
@@ -427,13 +427,13 @@ describe ISO3166::Country do
       let(:bogus) { ISO3166::Country.find_country_by_name("Does not exist") }
 
       it "should be a country instance" do
-        bogus.should == nil
+        expect(bogus).to eq(nil)
       end
     end
 
     context "when finding by invalid attribute" do
       it "should raise an error" do
-        lambda { ISO3166::Country.find_country_by_invalid('invalid') }.should raise_error
+        expect { ISO3166::Country.find_country_by_invalid('invalid') }.to raise_error
       end
     end
 
@@ -441,8 +441,8 @@ describe ISO3166::Country do
       let(:list) { ISO3166::Country.find_all_countries_by_currency('USD') }
 
       it "should be an Array of Country objects" do
-        list.should be_a(Array)
-        list.first.should be_a(ISO3166::Country)
+        expect(list).to be_a(Array)
+        expect(list.first).to be_a(ISO3166::Country)
       end
     end
 
@@ -450,7 +450,7 @@ describe ISO3166::Country do
       let(:country) { ISO3166::Country.find_country_by_alpha3('CAN') }
 
       it 'should be a single country object' do
-        country.should be_a(ISO3166::Country)
+        expect(country).to be_a(ISO3166::Country)
       end
     end
   end
@@ -461,7 +461,7 @@ describe ISO3166::Country do
         [v["name"], v["names"]].flatten.uniq
       end.flatten
 
-      names.size.should == names.uniq.size
+      expect(names.size).to eq(names.uniq.size)
     end
   end
 
@@ -469,7 +469,7 @@ describe ISO3166::Country do
     let(:norway) { ISO3166::Country.search('NO') }
 
     it 'should have a currency' do
-      norway.currency.should be_a(ISO4217::Currency)
+      expect(norway.currency).to be_a(ISO4217::Currency)
     end
   end
 
@@ -477,7 +477,7 @@ describe ISO3166::Country do
     let(:guernsey) { ISO3166::Country.search('GG') }
 
     it 'should have a currency' do
-      guernsey.currency.code.should == 'GBP'
+      expect(guernsey.currency.code).to eq('GBP')
     end
   end
 
@@ -485,7 +485,7 @@ describe ISO3166::Country do
     let(:german_speaking_countries) { ISO3166::Country.find_all_countries_by_languages('de') }
 
     it "should find countries by language" do
-      german_speaking_countries.size.should == 6
+      expect(german_speaking_countries.size).to eq(6)
     end
   end
 
@@ -493,27 +493,27 @@ describe ISO3166::Country do
     let(:netherlands) { ISO3166::Country.search('NL') }
 
     it 'should return false for countries without eu_member flag' do
-      country.in_eu?.should be_false
+      expect(country.in_eu?).to be_falsey
     end
 
     it 'should return true for countries with eu_member flag set to true' do
-      netherlands.in_eu?.should be_true
+      expect(netherlands.in_eu?).to be_truthy
     end
   end
 
   describe 'gec' do
     it 'should return the country\'s GEC code' do
-      ISO3166::Country.new('NA').gec.should eql 'WA'
+      expect(ISO3166::Country.new('NA').gec).to eql 'WA'
     end
 
     it 'should return nil if the country does not have a GEC code' do
-      ISO3166::Country.new('AN').gec.should eql nil
+      expect(ISO3166::Country.new('AN').gec).to eql nil
     end
   end
 
   describe 'to_s' do
     it 'should return the country name' do
-      ISO3166::Country.new('GB').to_s.should == 'United Kingdom'
+      expect(ISO3166::Country.new('GB').to_s).to eq('United Kingdom')
     end
   end
 
@@ -521,27 +521,27 @@ describe ISO3166::Country do
     let(:belgium) { ISO3166::Country.search('BE') }
 
     it 'should not return a vat_rate for countries without federal VAT' do
-      country.vat_rates.should == nil
+      expect(country.vat_rates).to eq(nil)
     end
 
     it 'should contain all keys for vat_rates' do
-      belgium.vat_rates.should be_a(Hash)
-      belgium.vat_rates.keys.should == ["standard", "reduced", "super_reduced", "parking"]
+      expect(belgium.vat_rates).to be_a(Hash)
+      expect(belgium.vat_rates.keys).to eq(["standard", "reduced", "super_reduced", "parking"])
     end
 
     it 'should return an array of reduced vat rates' do
-      belgium.vat_rates["reduced"].should be_an(Array)
-      belgium.vat_rates["reduced"].should == [6, 12]
+      expect(belgium.vat_rates["reduced"]).to be_an(Array)
+      expect(belgium.vat_rates["reduced"]).to eq([6, 12])
     end
   end
 
   describe 'ISO3166::Country()' do
     it 'should return same object if instance of ISO3166::Country given' do
-      ISO3166::Country(country).should eq country
+      expect(ISO3166::Country(country)).to eq country
     end
 
     it 'should return country if instance of String given' do
-      ISO3166::Country('us').should eq country
+      expect(ISO3166::Country('us')).to eq country
     end
 
     it 'should return country if not convertable input given' do

--- a/spec/country_spec.rb
+++ b/spec/country_spec.rb
@@ -12,7 +12,7 @@ describe ISO3166::Country do
   end
 
   it 'allows to create a country object from a lowercase alpha2 code' do
-    country = described_class.new("us")
+    country = described_class.new('us')
     expect(country.data).not_to be_nil
   end
 
@@ -33,7 +33,7 @@ describe ISO3166::Country do
   end
 
   it 'should return alternate names' do
-    expect(country.names).to eq(["United States of America", "Vereinigte Staaten von Amerika", "États-Unis", "Estados Unidos", "アメリカ合衆国", "Verenigde Staten"])
+    expect(country.names).to eq(['United States of America', 'Vereinigte Staaten von Amerika', 'États-Unis', 'Estados Unidos', 'アメリカ合衆国', 'Verenigde Staten'])
   end
 
   it 'should return translations' do
@@ -57,8 +57,8 @@ describe ISO3166::Country do
     expect(country.longitude_dec).to eq('-98.95733642578125')
   end
 
-  it "should return continent" do
-    expect(country.continent).to eq("North America")
+  it 'should return continent' do
+    expect(country.continent).to eq('North America')
   end
 
   it 'knows about whether or not the country uses postal codes' do
@@ -186,8 +186,8 @@ describe ISO3166::Country do
       expect(countries.size).to eq(250)
     end
 
-    it "should allow to customize each country representation passing a block to the method" do
-      countries = ISO3166::Country.all { |country, data| [data['name'], country, data['country_code'] ] }
+    it 'should allow to customize each country representation passing a block to the method' do
+      countries = ISO3166::Country.all { |country, data| [data['name'], country, data['country_code']] }
       expect(countries).to be_an(Array)
       expect(countries.first).to be_an(Array)
       expect(countries.first.size).to eq(3)
@@ -234,7 +234,7 @@ describe ISO3166::Country do
       countries = ISO3166::Country.translations('fr')
       expect(countries).to be_an(Hash)
       expect(countries.first[0]).to eq('AF')
-      expect(countries.first).to eq(['AF', 'Afghanistan'])
+      expect(countries.first).to eq(%w(AF Afghanistan))
       # countries missing the desired locale will not be added to the list
       # so all 250 countries may not be returned, 'fr' returns 249, for example
       expect(countries.size).to eq(249)
@@ -244,7 +244,7 @@ describe ISO3166::Country do
       countries = ISO3166::Country.translations
       expect(countries).to be_an(Hash)
       expect(countries.first[0]).to eq('AF')
-      expect(countries.first).to eq(['AF', 'Afghanistan'])
+      expect(countries.first).to eq(%w(AF Afghanistan))
       expect(countries.size).to eq(249)
     end
   end
@@ -283,7 +283,7 @@ describe ISO3166::Country do
     end
   end
 
-  describe "Country class" do
+  describe 'Country class' do
     context "when loaded via 'iso3166' existance" do
       subject { defined?(Country) }
 
@@ -293,13 +293,13 @@ describe ISO3166::Country do
     context "when loaded via 'countries'" do
       before { require 'countries' }
 
-      describe "existance" do
+      describe 'existance' do
         subject { defined?(Country) }
 
         it { is_expected.to be_truthy }
       end
 
-      describe "superclass" do
+      describe 'superclass' do
         subject { Country.superclass }
 
         it { is_expected.to eq(ISO3166::Country) }
@@ -314,87 +314,87 @@ describe ISO3166::Country do
   end
 
   describe 'find_all_by' do
-    context "when searchead attribute equals the given value" do
-      let(:spain_data) { ISO3166::Country.find_all_by('alpha2', "ES") }
+    context 'when searchead attribute equals the given value' do
+      let(:spain_data) { ISO3166::Country.find_all_by('alpha2', 'ES') }
 
-      it "returns a hash with the data of the country" do
+      it 'returns a hash with the data of the country' do
         expect(spain_data).to be_a Hash
         expect(spain_data.keys.size).to eq(1)
       end
     end
 
-    context "when searchead attribute is list and one of its elements equals the given value" do
-      let(:spain_data) { ISO3166::Country.find_all_by('languages', "en") }
+    context 'when searchead attribute is list and one of its elements equals the given value' do
+      let(:spain_data) { ISO3166::Country.find_all_by('languages', 'en') }
 
-      it "returns a hash with the data of the country" do
+      it 'returns a hash with the data of the country' do
         expect(spain_data).to be_a Hash
         expect(spain_data.size).to be > 1
       end
     end
 
-    it "also finds results if the given values is not upcased/downcased properly" do
-      spain_data = ISO3166::Country.find_all_by('alpha2', "es")
+    it 'also finds results if the given values is not upcased/downcased properly' do
+      spain_data = ISO3166::Country.find_all_by('alpha2', 'es')
       expect(spain_data).to be_a Hash
       expect(spain_data.keys.size).to eq(1)
     end
 
-    it "also finds results if the attribute is given as a symbol" do
-      spain_data = ISO3166::Country.find_all_by(:alpha2, "ES")
+    it 'also finds results if the attribute is given as a symbol' do
+      spain_data = ISO3166::Country.find_all_by(:alpha2, 'ES')
       expect(spain_data).to be_a Hash
       expect(spain_data.keys.size).to eq(1)
     end
 
-    it "casts the given value to a string to perform the search" do
+    it 'casts the given value to a string to perform the search' do
       spain_data = ISO3166::Country.find_all_by(:country_code, 34)
       expect(spain_data).to be_a Hash
       expect(spain_data.keys).to eq(['ES'])
     end
 
-    it "also performs searches with regexps and forces it to ignore case" do
+    it 'also performs searches with regexps and forces it to ignore case' do
       spain_data = ISO3166::Country.find_all_by(:names, /Españ/)
       expect(spain_data).to be_a Hash
       expect(spain_data.keys).to eq(['ES'])
     end
   end
 
-  describe "hash finder methods" do
+  describe 'hash finder methods' do
     context "when search name in 'name'" do
-      subject { ISO3166::Country.find_by_name("Poland") }
+      subject { ISO3166::Country.find_by_name('Poland') }
       it 'should return' do
-        expect(subject.first).to eq("PL")
+        expect(subject.first).to eq('PL')
       end
     end
 
     context "when search lowercase name in 'name'" do
-      subject { ISO3166::Country.find_by_name("poland") }
+      subject { ISO3166::Country.find_by_name('poland') }
       it 'should return' do
-        expect(subject.first).to eq("PL")
+        expect(subject.first).to eq('PL')
       end
     end
 
     context "when search name in 'names'" do
-      subject { ISO3166::Country.find_by_name("Polonia") }
+      subject { ISO3166::Country.find_by_name('Polonia') }
       it 'should return' do
-        expect(subject.first).to eq("PL")
+        expect(subject.first).to eq('PL')
       end
     end
 
-    context "when finding by invalid attribute" do
-      it "should raise an error" do
+    context 'when finding by invalid attribute' do
+      it 'should raise an error' do
         expect { ISO3166::Country.find_by_invalid('invalid') }.to raise_error
       end
     end
 
-    context "when using find_all method" do
+    context 'when using find_all method' do
       let(:list) { ISO3166::Country.find_all_by_currency('USD') }
 
-      it "should be an Array of Arrays" do
+      it 'should be an Array of Arrays' do
         expect(list).to be_a(Array)
         expect(list.first).to be_a(Array)
       end
     end
 
-    context "when using find_by method" do
+    context 'when using find_by method' do
       subject { ISO3166::Country.find_by_alpha3('CAN') }
       it 'should return' do
         expect(subject.length).to eq 2
@@ -404,49 +404,49 @@ describe ISO3166::Country do
     end
   end
 
-  describe "country finder methods" do
-    context "when search name found" do
-      let(:uk) { ISO3166::Country.find_country_by_name("United Kingdom") }
+  describe 'country finder methods' do
+    context 'when search name found' do
+      let(:uk) { ISO3166::Country.find_country_by_name('United Kingdom') }
 
-      it "should be a country instance" do
+      it 'should be a country instance' do
         expect(uk).to be_a(ISO3166::Country)
-        expect(uk.alpha2).to eq("GB")
+        expect(uk.alpha2).to eq('GB')
       end
     end
 
-    context "when search lowercase name found" do
-      let(:uk) { ISO3166::Country.find_country_by_name("united kingdom") }
+    context 'when search lowercase name found' do
+      let(:uk) { ISO3166::Country.find_country_by_name('united kingdom') }
 
-      it "should be a country instance" do
+      it 'should be a country instance' do
         expect(uk).to be_a(ISO3166::Country)
-        expect(uk.alpha2).to eq("GB")
+        expect(uk.alpha2).to eq('GB')
       end
     end
 
-    context "when search name not found" do
-      let(:bogus) { ISO3166::Country.find_country_by_name("Does not exist") }
+    context 'when search name not found' do
+      let(:bogus) { ISO3166::Country.find_country_by_name('Does not exist') }
 
-      it "should be a country instance" do
+      it 'should be a country instance' do
         expect(bogus).to eq(nil)
       end
     end
 
-    context "when finding by invalid attribute" do
-      it "should raise an error" do
+    context 'when finding by invalid attribute' do
+      it 'should raise an error' do
         expect { ISO3166::Country.find_country_by_invalid('invalid') }.to raise_error
       end
     end
 
-    context "when using find_all method" do
+    context 'when using find_all method' do
       let(:list) { ISO3166::Country.find_all_countries_by_currency('USD') }
 
-      it "should be an Array of Country objects" do
+      it 'should be an Array of Country objects' do
         expect(list).to be_a(Array)
         expect(list.first).to be_a(ISO3166::Country)
       end
     end
 
-    context "when using find_by method" do
+    context 'when using find_by method' do
       let(:country) { ISO3166::Country.find_country_by_alpha3('CAN') }
 
       it 'should be a single country object' do
@@ -455,10 +455,10 @@ describe ISO3166::Country do
     end
   end
 
-  describe "names in Data" do
-    it "should be unique (to allow .find_by_name work properly)" do
-      names = ISO3166::Country::Data.collect do |k,v|
-        [v["name"], v["names"]].flatten.uniq
+  describe 'names in Data' do
+    it 'should be unique (to allow .find_by_name work properly)' do
+      names = ISO3166::Country::Data.map do |_k, v|
+        [v['name'], v['names']].flatten.uniq
       end.flatten
 
       expect(names.size).to eq(names.uniq.size)
@@ -484,7 +484,7 @@ describe ISO3166::Country do
   describe 'Languages' do
     let(:german_speaking_countries) { ISO3166::Country.find_all_countries_by_languages('de') }
 
-    it "should find countries by language" do
+    it 'should find countries by language' do
       expect(german_speaking_countries.size).to eq(6)
     end
   end
@@ -526,12 +526,12 @@ describe ISO3166::Country do
 
     it 'should contain all keys for vat_rates' do
       expect(belgium.vat_rates).to be_a(Hash)
-      expect(belgium.vat_rates.keys).to eq(["standard", "reduced", "super_reduced", "parking"])
+      expect(belgium.vat_rates.keys).to eq(%w(standard reduced super_reduced parking))
     end
 
     it 'should return an array of reduced vat rates' do
-      expect(belgium.vat_rates["reduced"]).to be_an(Array)
-      expect(belgium.vat_rates["reduced"]).to eq([6, 12])
+      expect(belgium.vat_rates['reduced']).to be_an(Array)
+      expect(belgium.vat_rates['reduced']).to eq([6, 12])
     end
   end
 
@@ -545,9 +545,9 @@ describe ISO3166::Country do
     end
 
     it 'should return country if not convertable input given' do
-      expect {
+      expect do
         ISO3166::Country(42)
-      }.to raise_error(TypeError, "can't convert Fixnum into ISO3166::Country")
+      end.to raise_error(TypeError, "can't convert Fixnum into ISO3166::Country")
     end
   end
 end

--- a/spec/mongoid_spec.rb
+++ b/spec/mongoid_spec.rb
@@ -9,7 +9,7 @@ describe 'Mongoid support' do
   context 'instance methods' do
     describe 'mongoize' do
       it 'should delegate mongoization to the class method' do
-        britain.mongoize.should eql ISO3166::Country.mongoize(britain)
+        expect(britain.mongoize).to eql ISO3166::Country.mongoize(britain)
       end
     end
   end
@@ -17,11 +17,11 @@ describe 'Mongoid support' do
   context 'class methods' do
     describe 'mongoize' do
       it 'should store the alpha2 given a country object' do
-        ISO3166::Country.mongoize(britain).should eql britain.alpha2
+        expect(ISO3166::Country.mongoize(britain)).to eql britain.alpha2
       end
 
       it 'should store the alpha2 given a valid alpha2' do
-        ISO3166::Country.mongoize('GB').should eql britain.alpha2
+        expect(ISO3166::Country.mongoize('GB')).to eql britain.alpha2
       end
 
       it 'should raise BadMongoidTypeError given an invalid object' do
@@ -47,19 +47,19 @@ describe 'Mongoid support' do
 
     describe 'demongoize' do
       it 'should instantiate an equivalent object from stored alpha2 code' do
-        ISO3166::Country.demongoize(britain.mongoize).data
-          .should eql britain.data
+        expect(ISO3166::Country.demongoize(britain.mongoize).data)
+          .to eql britain.data
       end
 
       it 'should be indifferent to storage by alpha2' do
-        ISO3166::Country.demongoize(ISO3166::Country.mongoize('GB'))
-        .data.should eql britain.data
+        expect(ISO3166::Country.demongoize(ISO3166::Country.mongoize('GB'))
+        .data).to eql britain.data
       end
     end
 
     describe 'evolve' do
       it 'should delegate to self.mongoize and return the mongoized object' do
-        ISO3166::Country.should_receive(:mongoize).with(britain)
+        expect(ISO3166::Country).to receive(:mongoize).with(britain)
         ISO3166::Country.evolve(britain)
       end
     end

--- a/spec/mongoid_spec.rb
+++ b/spec/mongoid_spec.rb
@@ -27,16 +27,16 @@ describe 'Mongoid support' do
       it 'should store nil given an invalid object' do
         bad_types = [[], Time.now, {}, Date.today]
         bad_types.each do |type|
-          ISO3166::Country.mongoize(type).should eql nil
+          expect(ISO3166::Country.mongoize(type)).to eql nil
         end
       end
 
       it 'should store nil given an empty country object' do
-        ISO3166::Country.mongoize(ISO3166::Country.new('')).should eql nil
+        expect(ISO3166::Country.mongoize(ISO3166::Country.new(''))).to eql nil
       end
 
       it 'should store nil given a bad alpha2' do
-        ISO3166::Country.mongoize('bad_alpha_2').should eql nil
+        expect(ISO3166::Country.mongoize('bad_alpha_2')).to eql nil
       end
 
     end


### PR DESCRIPTION
This conversion is done by Transpec 3.0.7 with the following command:
    transpec

* 114 conversions
    from: obj.should
      to: expect(obj).to

* 42 conversions
    from: == expected
      to: eq(expected)

* 10 conversions
    from: collection.should have(n).items
      to: expect(collection.size).to eq(n)

* 3 conversions
    from: be_true
      to: be_truthy

* 3 conversions
    from: it { should ... }
      to: it { is_expected.to ... }

* 3 conversions
    from: obj.should have(n).keys
      to: expect(obj.keys.size).to eq(n)

* 3 conversions
    from: obj.should_not
      to: expect(obj).not_to

* 2 conversions
    from: be_false
      to: be_falsey

* 2 conversions
    from: lambda { }.should
      to: expect { }.to

* 1 conversion
    from: > expected
      to: be > expected

* 1 conversion
    from: obj.should_receive(:message)
      to: expect(obj).to receive(:message)

For more details: https://github.com/yujinakayama/transpec#supported-conversions