### PR TITLE
Return nil if translation is not found

### DIFF
--- a/lib/countries/country.rb
+++ b/lib/countries/country.rb
@@ -108,6 +108,8 @@ class ISO3166::Country
 
   def translation(language_alpha2 = 'en')
     I18nData.countries(language_alpha2)[alpha2]
+  rescue I18nData::NoTranslationAvailable
+    nil
   end
 
   private

--- a/spec/country_spec.rb
+++ b/spec/country_spec.rb
@@ -227,6 +227,11 @@ describe ISO3166::Country do
       expect(countries).to be_an(String)
       expect(countries).to eq('Germany')
     end
+
+    it 'should return nil when a translation is not found' do
+      countries = ISO3166::Country.new(:de).translation('xxx')
+      expect(countries).to be_nil
+    end
   end
 
   describe 'translations' do


### PR DESCRIPTION
The newly added translation method in ISO3166::Country should return nil
rather than throwing an I18nData::NoTranslationAvailable exception if a 
translation is not found.