### PR TITLE
Use {{region_short}} in address_format

### DIFF
--- a/lib/data/countries/AU.yaml
+++ b/lib/data/countries/AU.yaml
@@ -4,7 +4,7 @@ AU:
   address_format: |-
     {{recipient}}
     {{street}}
-    {{city}} {{region}} {{postalcode}}
+    {{city}} {{region_code}} {{postalcode}}
     {{country}}
   alpha2: AU
   alpha3: AUS

--- a/lib/data/countries/AU.yaml
+++ b/lib/data/countries/AU.yaml
@@ -4,7 +4,7 @@ AU:
   address_format: |-
     {{recipient}}
     {{street}}
-    {{city}} {{region_code}} {{postalcode}}
+    {{city}} {{region_short}} {{postalcode}}
     {{country}}
   alpha2: AU
   alpha3: AUS

--- a/lib/data/countries/BR.yaml
+++ b/lib/data/countries/BR.yaml
@@ -4,7 +4,7 @@ BR:
   address_format: |-
     {{recipient}}
     {{street}}
-    {{postalcode}} {{city}} {{region_code}}
+    {{postalcode}} {{city}} {{region_short}}
     {{country}}
   alpha2: BR
   alpha3: BRA

--- a/lib/data/countries/BR.yaml
+++ b/lib/data/countries/BR.yaml
@@ -4,7 +4,7 @@ BR:
   address_format: |-
     {{recipient}}
     {{street}}
-    {{postalcode}} {{city}} {{region}}
+    {{postalcode}} {{city}} {{region_code}}
     {{country}}
   alpha2: BR
   alpha3: BRA

--- a/lib/data/countries/CA.yaml
+++ b/lib/data/countries/CA.yaml
@@ -4,7 +4,7 @@ CA:
   address_format: |-
     {{recipient}}
     {{street}}
-    {{city}} {{region}} {{postalcode}}
+    {{city}} {{region_code}} {{postalcode}}
     {{country}}
   alpha2: CA
   alpha3: CAN

--- a/lib/data/countries/CA.yaml
+++ b/lib/data/countries/CA.yaml
@@ -4,7 +4,7 @@ CA:
   address_format: |-
     {{recipient}}
     {{street}}
-    {{city}} {{region_code}} {{postalcode}}
+    {{city}} {{region_short}} {{postalcode}}
     {{country}}
   alpha2: CA
   alpha3: CAN

--- a/lib/data/countries/CN.yaml
+++ b/lib/data/countries/CN.yaml
@@ -4,7 +4,7 @@ CN:
   address_format: |-
     {{recipient}}
     {{street}}
-    {{postalcode}} {{city}} {{region_code}}
+    {{postalcode}} {{city}} {{region_short}}
     {{country}}
   alpha2: CN
   alpha3: CHN

--- a/lib/data/countries/CN.yaml
+++ b/lib/data/countries/CN.yaml
@@ -4,7 +4,7 @@ CN:
   address_format: |-
     {{recipient}}
     {{street}}
-    {{postalcode}} {{city}} {{region}}
+    {{postalcode}} {{city}} {{region_code}}
     {{country}}
   alpha2: CN
   alpha3: CHN

--- a/lib/data/countries/HK.yaml
+++ b/lib/data/countries/HK.yaml
@@ -4,7 +4,7 @@ HK:
   address_format: |-
     {{recipient}}
     {{street}}
-    {{postalcode}} {{city}} {{region}}
+    {{postalcode}} {{city}} {{region_code}}
     {{country}}
   alpha2: HK
   alpha3: HKG

--- a/lib/data/countries/HK.yaml
+++ b/lib/data/countries/HK.yaml
@@ -4,7 +4,7 @@ HK:
   address_format: |-
     {{recipient}}
     {{street}}
-    {{postalcode}} {{city}} {{region_code}}
+    {{postalcode}} {{city}} {{region_short}}
     {{country}}
   alpha2: HK
   alpha3: HKG

--- a/lib/data/countries/ID.yaml
+++ b/lib/data/countries/ID.yaml
@@ -5,7 +5,7 @@ ID:
     {{recipient}}
     {{street}}
     {{city}}
-    {{region_code}} {{postalcode}}
+    {{region}} {{postalcode}}
     {{country}}
   alpha2: ID
   alpha3: IDN

--- a/lib/data/countries/ID.yaml
+++ b/lib/data/countries/ID.yaml
@@ -5,7 +5,7 @@ ID:
     {{recipient}}
     {{street}}
     {{city}}
-    {{region}} {{postalcode}}
+    {{region_code}} {{postalcode}}
     {{country}}
   alpha2: ID
   alpha3: IDN

--- a/lib/data/countries/IE.yaml
+++ b/lib/data/countries/IE.yaml
@@ -4,7 +4,7 @@ IE:
   address_format: |-
     {{recipient}}
     {{street}}
-    {{city}} {{region_code}} {{postalcode}}
+    {{city}} {{region_short}} {{postalcode}}
     {{country}}
   alpha2: IE
   alpha3: IRL

--- a/lib/data/countries/IE.yaml
+++ b/lib/data/countries/IE.yaml
@@ -4,7 +4,7 @@ IE:
   address_format: |-
     {{recipient}}
     {{street}}
-    {{city}} {{region}} {{postalcode}}
+    {{city}} {{region_code}} {{postalcode}}
     {{country}}
   alpha2: IE
   alpha3: IRL

--- a/lib/data/countries/IT.yaml
+++ b/lib/data/countries/IT.yaml
@@ -4,7 +4,7 @@ IT:
   address_format: |-
     {{recipient}}
     {{street}}
-    {{postalcode}} {{city}} {{region}}
+    {{postalcode}} {{city}} {{region_code}}
     {{country}}
   alpha2: IT
   alpha3: ITA

--- a/lib/data/countries/IT.yaml
+++ b/lib/data/countries/IT.yaml
@@ -4,7 +4,7 @@ IT:
   address_format: |-
     {{recipient}}
     {{street}}
-    {{postalcode}} {{city}} {{region_code}}
+    {{postalcode}} {{city}} {{region_short}}
     {{country}}
   alpha2: IT
   alpha3: ITA

--- a/lib/data/countries/JP.yaml
+++ b/lib/data/countries/JP.yaml
@@ -3,7 +3,7 @@ JP:
   continent: Asia
   address_format: |-
     〒{{postalcode}}
-    {{region_code}}{{city}}{{street}}
+    {{region_short}}{{city}}{{street}}
     {{recipient}}
     {{country}}
   alpha2: JP

--- a/lib/data/countries/JP.yaml
+++ b/lib/data/countries/JP.yaml
@@ -3,7 +3,7 @@ JP:
   continent: Asia
   address_format: |-
     〒{{postalcode}}
-    {{region}}{{city}}{{street}}
+    {{region_code}}{{city}}{{street}}
     {{recipient}}
     {{country}}
   alpha2: JP

--- a/lib/data/countries/KR.yaml
+++ b/lib/data/countries/KR.yaml
@@ -4,7 +4,7 @@ KR:
   address_format: |-
     {{recipient}}
     {{street}}
-    {{city}} {{region_code}}
+    {{city}} {{region_short}}
     {{postalcode}}
     {{country}}
   alpha2: KR

--- a/lib/data/countries/KR.yaml
+++ b/lib/data/countries/KR.yaml
@@ -4,7 +4,7 @@ KR:
   address_format: |-
     {{recipient}}
     {{street}}
-    {{city}} {{region}}
+    {{city}} {{region_code}}
     {{postalcode}}
     {{country}}
   alpha2: KR

--- a/lib/data/countries/MX.yaml
+++ b/lib/data/countries/MX.yaml
@@ -4,7 +4,7 @@ MX:
   address_format: |-
     {{recipient}}
     {{street}}
-    {{postalcode}} {{city}} {{region_code}}
+    {{postalcode}} {{city}} {{region_short}}
     {{country}}
   alpha2: MX
   alpha3: MEX

--- a/lib/data/countries/MX.yaml
+++ b/lib/data/countries/MX.yaml
@@ -4,7 +4,7 @@ MX:
   address_format: |-
     {{recipient}}
     {{street}}
-    {{postalcode}} {{city}} {{region}}
+    {{postalcode}} {{city}} {{region_code}}
     {{country}}
   alpha2: MX
   alpha3: MEX

--- a/lib/data/countries/PH.yaml
+++ b/lib/data/countries/PH.yaml
@@ -3,7 +3,7 @@ PH:
   continent: Asia
   address_format: |-
     {{recipient}}
-    {{street}} {{region_code}}
+    {{street}} {{region_short}}
     {{postalcode}} {{city}}
     {{country}}
   alpha2: PH

--- a/lib/data/countries/PH.yaml
+++ b/lib/data/countries/PH.yaml
@@ -3,7 +3,7 @@ PH:
   continent: Asia
   address_format: |-
     {{recipient}}
-    {{street}} {{region}}
+    {{street}} {{region_code}}
     {{postalcode}} {{city}}
     {{country}}
   alpha2: PH

--- a/lib/data/countries/PT.yaml
+++ b/lib/data/countries/PT.yaml
@@ -4,7 +4,7 @@ PT:
   address_format: |-
     {{recipient}}
     {{street}}
-    {{postalcode}} {{city}} {{region_code}}
+    {{postalcode}} {{city}} {{region_short}}
     {{country}}
   alpha2: PT
   alpha3: PRT

--- a/lib/data/countries/PT.yaml
+++ b/lib/data/countries/PT.yaml
@@ -4,7 +4,7 @@ PT:
   address_format: |-
     {{recipient}}
     {{street}}
-    {{postalcode}} {{city}} {{region}}
+    {{postalcode}} {{city}} {{region_code}}
     {{country}}
   alpha2: PT
   alpha3: PRT

--- a/lib/data/countries/TW.yaml
+++ b/lib/data/countries/TW.yaml
@@ -4,7 +4,7 @@ TW:
   address_format: |-
     {{recipient}}
     {{street}}
-    {{city}} {{region_code}} {{postalcode}}
+    {{city}} {{region_short}} {{postalcode}}
     {{country}}
   alpha2: TW
   alpha3: TWN

--- a/lib/data/countries/TW.yaml
+++ b/lib/data/countries/TW.yaml
@@ -4,7 +4,7 @@ TW:
   address_format: |-
     {{recipient}}
     {{street}}
-    {{city}} {{region}} {{postalcode}}
+    {{city}} {{region_code}} {{postalcode}}
     {{country}}
   alpha2: TW
   alpha3: TWN

--- a/lib/data/countries/UA.yaml
+++ b/lib/data/countries/UA.yaml
@@ -4,7 +4,7 @@ UA:
   address_format: |-
     {{recipient}}
     {{street}}
-    {{city}} {{region}}
+    {{city}} {{region_code}}
     {{postalcode}}
     {{country}}
   alpha2: UA

--- a/lib/data/countries/UA.yaml
+++ b/lib/data/countries/UA.yaml
@@ -4,7 +4,7 @@ UA:
   address_format: |-
     {{recipient}}
     {{street}}
-    {{city}} {{region_code}}
+    {{city}} {{region_short}}
     {{postalcode}}
     {{country}}
   alpha2: UA

--- a/lib/data/countries/US.yaml
+++ b/lib/data/countries/US.yaml
@@ -4,7 +4,7 @@ US:
   address_format: |-
     {{recipient}}
     {{street}}
-    {{city}} {{region_code}} {{postalcode}}
+    {{city}} {{region_short}} {{postalcode}}
     {{country}}
   alpha2: US
   alpha3: USA

--- a/lib/data/countries/US.yaml
+++ b/lib/data/countries/US.yaml
@@ -4,7 +4,7 @@ US:
   address_format: |-
     {{recipient}}
     {{street}}
-    {{city}} {{region}} {{postalcode}}
+    {{city}} {{region_code}} {{postalcode}}
     {{country}}
   alpha2: US
   alpha3: USA


### PR DESCRIPTION
The {{region}} placeholder was used ambiguously in address_format.

According to the discussion at http://github.com/hexorx/countries/pull/221
we agreed on using different placeholders, {{region}} and {{region_short}}, 
depending on whether the full region name (like 'Bayern' for Germany) or 
the abbrevation (like 'NY' in US address format) should be used.

This commit replaces any occurence of {{region}} by {{region_short}}
where {{region}} was not used on a separate line in the YAML files in
the /lib/data/countries directory.