### PR TITLE
Enabling Ruby warnings

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -6,7 +6,7 @@ require 'rspec/core/rake_task'
 
 desc 'Run all examples'
 RSpec::Core::RakeTask.new(:spec) do |t|
-  t.rspec_opts = %w(--color)
+  t.rspec_opts = %w(--color --warnings)
 end
 
 task default: [:spec]

--- a/lib/countries/country.rb
+++ b/lib/countries/country.rb
@@ -112,7 +112,7 @@ class ISO3166::Country
 
     def all(&blk)
       blk ||= proc { |country, data| [data['name'], country] }
-      Data.map &blk
+      Data.map(&blk)
     end
 
     alias_method :countries, :all

--- a/lib/countries/country.rb
+++ b/lib/countries/country.rb
@@ -14,7 +14,6 @@ class ISO3166::Country
     :number,
     :alpha2,
     :alpha3,
-    :currency,
     :name,
     :names,
     :latitude,
@@ -156,7 +155,7 @@ class ISO3166::Country
     protected
 
     def parse_attributes(attribute, val)
-      fail "Invalid attribute name '#{attribute}'" unless AttrReaders.include?(attribute.to_sym)
+      fail "Invalid attribute name '#{attribute}'" unless instance_methods.include?(attribute.to_sym)
 
       attributes = Array(attribute.to_s)
       if attributes == ['name']

--- a/lib/countries/country.rb
+++ b/lib/countries/country.rb
@@ -35,7 +35,6 @@ class ISO3166::Country
     :un_locode,
     :languages,
     :nationality,
-    :address_format,
     :dissolved_on,
     :eu_member,
     :alt_currency,


### PR DESCRIPTION
These commits are removing some of the warnings that appears when running a dependent gem/app in verbose mode (`ruby -w`).

Some of those warnings are code-smells, so that's why I'm trying to get rid of them.

Please tell me if you wanna squash those. I didn't as they're basically isolated and independent from one another.

Thanks for this gem!