### PR TITLE
Add "South Korea" as alias name for KR

### DIFF
--- a/lib/data/countries/KR.yaml
+++ b/lib/data/countries/KR.yaml
@@ -18,6 +18,7 @@ KR:
   longitude: 127 30 E
   name: Korea, Republic of
   names:
+  - South Korea
   - Korea (South)
   - Südkorea
   - Corée du Sud


### PR DESCRIPTION
"South Korea" is commonly used in popular media to refer to the Republic of Korea (KR). Can we add this as an alias?
http://en.wikipedia.org/wiki/South_Korea