### PR TITLE
Update GE.yaml

### DIFF
--- a/lib/data/countries/GE.yaml
+++ b/lib/data/countries/GE.yaml
@@ -35,5 +35,5 @@ GE:
   min_latitude: '41.15'
   max_longitude: '46.635556'
   max_latitude: '43.570556'
-  latitude_dec: '32.64832305908203'
-  longitude_dec: "-83.44453430175781"
+  latitude_dec: '42.3207845'
+  longitude_dec: '43.3713615'


### PR DESCRIPTION
Current decimal coordinates refer to Georgia as US state instead of Georgia as country.