### PR TITLE
Make ::all_translated return the same format as ::all, but with translated names

### DIFF
--- a/lib/countries/country.rb
+++ b/lib/countries/country.rb
@@ -119,7 +119,10 @@ class ISO3166::Country
     alias_method :countries, :all
 
     def all_translated(locale = 'en')
-      translations(locale).values
+      locale = locale.to_s.downcase
+      all do |country, data|
+        [data['translations'][locale], country]
+      end.reject{ |a| a[0].nil? }.sort_by{ |a| a[0] }
     end
 
     def translations(locale = 'en')

--- a/spec/country_spec.rb
+++ b/spec/country_spec.rb
@@ -196,21 +196,23 @@ describe ISO3166::Country do
   end
 
   describe 'all_translated' do
-    it 'should return an alphabetized list of all country names translated to the selected locale' do
+    it 'should return an alphabetized array list of all country names translated to the selected locale' do
       countries = ISO3166::Country.all_translated('fr')
       expect(countries).to be_an(Array)
-      expect(countries.first).to be_a(String)
-      expect(countries.first).to eq('Afghanistan')
+      expect(countries.first).to be_a(Array)
+      expect(countries.first[0]).to eq('Afghanistan')
+      expect(countries.first[1]).to eq('AF')
       # countries missing the desired locale will not be added to the list
       # so all 250 countries may not be returned, 'fr' returns 249, for example
       expect(countries.size).to eq(249)
     end
 
-    it 'should return an alphabetized list of all country names in English if no locale is passed' do
+    it 'should return an alphabetized array list of all country names in English if no locale is passed' do
       countries = ISO3166::Country.all_translated
       expect(countries).to be_an(Array)
-      expect(countries.first).to be_a(String)
-      expect(countries.first).to eq('Afghanistan')
+      expect(countries.first).to be_a(Array)
+      expect(countries.first[0]).to eq('Afghanistan')
+      expect(countries.first[1]).to eq('AF')
       expect(countries.size).to eq(249)
     end
   end


### PR DESCRIPTION
I thought it might be more intuitive to have `Country.all_translated` return with the same array list as `Country.all` since the method names are indicating the same type of response.  This makes it really useful to use for country select dropdown boxes so the same country code is saved into the database regardless of language chosen.