### PR TITLE
Bad state data present in Uruguay has been removed

### DIFF
--- a/lib/data/subdivisions/UY.yaml
+++ b/lib/data/subdivisions/UY.yaml
@@ -144,30 +144,3 @@ TT:
   min_longitude: -55.158798
   max_latitude: -32.682854
   max_longitude: -53.2823961
-X1~:
-  name: ''
-  names: ''
-  latitude: -32.522779
-  longitude: -55.765835
-  min_latitude: -35.0314185
-  min_longitude: -58.491361
-  max_latitude: -30.085215
-  max_longitude: -53.1842925
-X2~:
-  name: ''
-  names: ''
-  latitude: -32.522779
-  longitude: -55.765835
-  min_latitude: -35.0314185
-  min_longitude: -58.491361
-  max_latitude: -30.085215
-  max_longitude: -53.1842925
-X3~:
-  name: ''
-  names: ''
-  latitude: -32.522779
-  longitude: -55.765835
-  min_latitude: -35.0314185
-  min_longitude: -58.491361
-  max_latitude: -30.085215
-  max_longitude: -53.1842925


### PR DESCRIPTION
Issue : 
There were Bad / Invalid data which were found in the state data for Uruguay. This resulted in null data when the countries data was loaded.

Fix:
Removed the bad data that was present in Uruguay i.e removed ~X1,~X2 and ~X3. 