### PR TITLE
Fix New York, Washington, Oklahoma state's latitude/longitude information

### DIFF
--- a/Rakefile
+++ b/Rakefile
@@ -93,7 +93,11 @@ task :fetch_subdivisions do
     # Iterate subdivisions
     state_data = c.subdivisions.dup
     state_data.reject { |_, data| data['latitude'] }.each do |code, data|
-      if (result = geocode("#{data['name']}, #{c.name}"))
+      location = "#{data['name']}, #{c.name}"
+      if(c.alpha2 == "US" && code == "NY")
+        location = "New York State, United States"
+      end
+      if (result = geocode(location))
         geometry = result.geometry
         if geometry['location']
           state_data[code]['latitude'] = geometry['location']['lat']

--- a/Rakefile
+++ b/Rakefile
@@ -97,7 +97,7 @@ task :fetch_subdivisions do
 
       # Handle special geocoding cases where Google defaults to well known
       # cities, instead of the states.
-      if(c.alpha2 == "US" && ["NY", "WA"].include?(code))
+      if(c.alpha2 == "US" && ["NY", "WA", "OK"].include?(code))
         location = "#{data['name']} State, United States"
       end
 

--- a/Rakefile
+++ b/Rakefile
@@ -94,9 +94,13 @@ task :fetch_subdivisions do
     state_data = c.subdivisions.dup
     state_data.reject { |_, data| data['latitude'] }.each do |code, data|
       location = "#{data['name']}, #{c.name}"
-      if(c.alpha2 == "US" && code == "NY")
-        location = "New York State, United States"
+
+      # Handle special geocoding cases where Google defaults to well known
+      # cities, instead of the states.
+      if(c.alpha2 == "US" && ["NY", "WA"].include?(code))
+        location = "#{data['name']} State, United States"
       end
+
       if (result = geocode(location))
         geometry = result.geometry
         if geometry['location']

--- a/lib/data/subdivisions/NA.yaml
+++ b/lib/data/subdivisions/NA.yaml
@@ -38,9 +38,21 @@ KA:
 KE:
   name: Kavango East
   names: Kavango East
+  latitude: -18.271048
+  longitude: 18.4276047
+  min_latitude: -19.1762981
+  min_longitude: 17.995449
+  max_latitude: -17.393156
+  max_longitude: 22.522122
 KW:
   name: Kavango West
   names: Kavango West
+  latitude: -18.271048
+  longitude: 18.4276047
+  min_latitude: -19.1762981
+  min_longitude: 17.995449
+  max_latitude: -17.393156
+  max_longitude: 22.522122
 KH:
   name: Khomas
   names: Khomas

--- a/lib/data/subdivisions/US.yaml
+++ b/lib/data/subdivisions/US.yaml
@@ -345,12 +345,12 @@ NV:
 NY:
   name: New York
   names: New York
-  latitude: 40.7127837
-  longitude: -74.0059413
-  min_latitude: 40.4913699
-  min_longitude: -74.25908989999999
-  max_latitude: 40.91525559999999
-  max_longitude: -73.70027209999999
+  latitude: 43.2994285
+  longitude: -74.21793260000001
+  min_latitude: 40.4913686
+  min_longitude: -79.76214379999999
+  max_latitude: 45.015865
+  max_longitude: -71.8562755
 OH:
   name: Ohio
   names: Ohio

--- a/lib/data/subdivisions/US.yaml
+++ b/lib/data/subdivisions/US.yaml
@@ -363,12 +363,12 @@ OH:
 OK:
   name: Oklahoma
   names: Oklahoma
-  latitude: 35.4675602
-  longitude: -97.5164276
-  min_latitude: 35.2905439
-  min_longitude: -97.83367489999999
-  max_latitude: 35.674752
-  max_longitude: -97.12472
+  latitude: 35.0077519
+  longitude: -97.092877
+  min_latitude: 33.615787
+  min_longitude: -103.002455
+  max_latitude: 37.0023119
+  max_longitude: -94.430662
 OR:
   name: Oregon
   names: Oregon

--- a/lib/data/subdivisions/US.yaml
+++ b/lib/data/subdivisions/US.yaml
@@ -484,12 +484,12 @@ VT:
 WA:
   name: Washington
   names: Washington
-  latitude: 38.9071923
-  longitude: -77.0368707
-  min_latitude: 38.8031495
-  min_longitude: -77.11974
-  max_latitude: 38.995548
-  max_longitude: -76.909393
+  latitude: 47.7510741
+  longitude: -120.7401386
+  min_latitude: 45.5485987
+  min_longitude: -124.7857167
+  max_latitude: 49.0024305
+  max_longitude: -116.91558
 WI:
   name: Wisconsin
   names: Wisconsin


### PR DESCRIPTION
When Google's geocoder is passed "New York, United States", it actually returns the geocoding information for New York City, and not the actual state. So the previously stored details were for the extent of the city, rather than the state. This fixes the initial geocoding logic by making a special case for New York to geocode "New York State". The stored YAML details have been updated with the new results for the state.

I've seen Google's geocoder change how it geocodes the string "New York" over the years, but appending "State" to the end has been a reliable way to force it to geocode the state (at least in my experience for the past couple years). So I think this approach should be safe in case anyone want to do a full re-geocoding sometime in the future.

When re-running the geocoding, it looks like a couple new locations in Namibia now have location results, so I committed those results as well, but if you'd prefer I separate those out from this pull request, just let me know.