### PR TITLE
Fix Subdivisions & States in README

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -71,8 +71,8 @@ Country Info
 
   Subdivisions & States
 
-    c.subdivisions #=> {"CO" => {:name => "Colorado", :names => "Colorado"}, ... }
-    c.states #=> {"CO" => {:name => "Colorado", :names => "Colorado"}, ... }
+    c.subdivisions #=> {"CO" => {"name" => "Colorado", "names" => "Colorado"}, ... }
+    c.states #=> {"CO" => {"name" => "Colorado", "names" => "Colorado"}, ... }
 
   Location
 


### PR DESCRIPTION
`Country#subdivisions` and `Country#states` returns an array of hashes with string keys, not symbols.