### PR TITLE
Add alternate spelling of Macao/Macau

### DIFF
--- a/lib/data/countries/MO.yaml
+++ b/lib/data/countries/MO.yaml
@@ -13,6 +13,7 @@ MO:
   name: Macao
   names:
   - Macao
+  - Macau
   - "マカオ"
   national_destination_code_lengths:
   - 2


### PR DESCRIPTION
Macau is used by Stripe

https://en.wikipedia.org/wiki/Macau