### PR TITLE
.to_s should return the translation of the current locale and fall back to name if no translation present.

### DIFF
--- a/lib/countries/country.rb
+++ b/lib/countries/country.rb
@@ -92,7 +92,7 @@ class ISO3166::Country
   end
 
   def to_s
-    @data['name']
+    translation(I18n.locale.to_s) || @data['name']
   end
 
   def translation(locale = 'en')

--- a/lib/countries/country.rb
+++ b/lib/countries/country.rb
@@ -125,7 +125,7 @@ class ISO3166::Country
 
     def all_names_with_codes(locale = 'en')
       ISO3166::Country.all.map do |c|
-        [(c.translation(locale) || c.name ).html_safe, c.alpha2]
+        [(c.to_s).html_safe, c.alpha2]
       end.sort_by { |d| d[0] }
     end
 

--- a/spec/country_spec.rb
+++ b/spec/country_spec.rb
@@ -600,8 +600,18 @@ describe ISO3166::Country do
   end
 
   describe 'to_s' do
-    it 'should return the country name' do
-      expect(ISO3166::Country.new('GB').to_s).to eq('United Kingdom')
+    it 'should return the country first translation for locale' do
+      I18n.available_locales = [:en, :de]
+      I18n.with_locale(:de) do
+        expect(ISO3166::Country.new('GB').to_s).to eq('Vereinigtes Königreich')
+      end
+    end
+
+    it 'should return the country name if no translation is present' do
+      I18n.available_locales = [:en, :de, :derp]
+      I18n.with_locale(:derp) do
+        expect(ISO3166::Country.new('GB').to_s).to eq('United Kingdom')
+      end
     end
   end
 


### PR DESCRIPTION
This should let sorting occur easily on a per language basis, as name is relative. 