### PR TITLE
Add MOP as the currency for Macao

### DIFF
--- a/lib/data/countries/MO.yaml
+++ b/lib/data/countries/MO.yaml
@@ -4,9 +4,9 @@ MO:
   alpha2: MO
   alpha3: MAC
   country_code: '853'
-  currency: 
+  currency: MOP
   international_prefix: '00'
-  ioc: 
+  ioc:
   gec: MC
   latitude: 22 10 N
   longitude: 113 33 E


### PR DESCRIPTION
Macao doesn't have a currency at the moment but it should be MOP. 
http://www.currency-iso.org/en/home/tables/table-a1.html
https://en.wikipedia.org/wiki/ISO_4217
http://www.xe.com/iso4217.php