### PR TITLE
Correct telephone number lengths in Italy

### DIFF
--- a/lib/data/countries/IT.yaml
+++ b/lib/data/countries/IT.yaml
@@ -27,6 +27,7 @@ IT:
   - 3
   national_number_lengths:
   - 9
+  - 11
   national_prefix: None
   number: '380'
   region: Europe


### PR DESCRIPTION
Mobile telephones in Italy can be from 9 to 11 digits long.

https://en.wikipedia.org/wiki/Telephone_numbers_in_Italy#Number_format