### PR TITLE
Add missing currency information

### DIFF
--- a/lib/data/countries/AQ.yaml
+++ b/lib/data/countries/AQ.yaml
@@ -4,9 +4,9 @@ AQ:
   alpha2: AQ
   alpha3: ATA
   country_code: '672'
-  currency: 
+  currency: USD
   international_prefix: ''
-  ioc: 
+  ioc:
   gec: AY
   latitude: 90 00 S
   longitude: 0 00 E

--- a/lib/data/countries/AX.yaml
+++ b/lib/data/countries/AX.yaml
@@ -4,10 +4,10 @@ AX:
   alpha2: AX
   alpha3: ALA
   country_code: '358'
-  currency: 
+  currency: EUR
   international_prefix: ''
-  ioc: 
-  gec: 
+  ioc:
+  gec:
   latitude: ''
   longitude: ''
   name: "Åland Islands"
@@ -23,7 +23,7 @@ AX:
   region: Europe
   subregion: Northern Europe
   world_region: EMEA
-  un_locode: 
+  un_locode:
   languages:
   - sv
   nationality: Swedish

--- a/lib/data/countries/CD.yaml
+++ b/lib/data/countries/CD.yaml
@@ -4,7 +4,7 @@ CD:
   alpha2: CD
   alpha3: COD
   country_code: '243'
-  currency: 
+  currency: CDF
   international_prefix: '00'
   ioc: COD
   gec: CG

--- a/lib/data/countries/GQ.yaml
+++ b/lib/data/countries/GQ.yaml
@@ -4,7 +4,7 @@ GQ:
   alpha2: GQ
   alpha3: GNQ
   country_code: '240'
-  currency: 
+  currency: XAF
   international_prefix: '00'
   ioc: GEQ
   gec: EK

--- a/lib/data/countries/GS.yaml
+++ b/lib/data/countries/GS.yaml
@@ -4,9 +4,9 @@ GS:
   alpha2: GS
   alpha3: SGS
   country_code: '500'
-  currency: 
+  currency: GBP
   international_prefix: ''
-  ioc: 
+  ioc:
   gec: SX
   latitude: 54 30 S
   longitude: 37 00 W

--- a/lib/data/countries/MG.yaml
+++ b/lib/data/countries/MG.yaml
@@ -4,7 +4,7 @@ MG:
   alpha2: MG
   alpha3: MDG
   country_code: '261'
-  currency: 
+  currency: MGA
   international_prefix: '00'
   ioc: MAD
   gec: MA

--- a/lib/data/countries/NU.yaml
+++ b/lib/data/countries/NU.yaml
@@ -4,9 +4,9 @@ NU:
   alpha2: NU
   alpha3: NIU
   country_code: '683'
-  currency: 
+  currency: NZD
   international_prefix: '00'
-  ioc: 
+  ioc:
   gec: NE
   latitude: 19 02 S
   longitude: 169 52 W

--- a/lib/data/countries/PS.yaml
+++ b/lib/data/countries/PS.yaml
@@ -3,8 +3,9 @@ PS:
   continent: Asia
   alpha2: PS
   alpha3: PSE
+  alt_currency: EGP
   country_code: '970'
-  currency: 
+  currency: ILS
   international_prefix: '00'
   ioc: PLE
   gec: WE
@@ -29,7 +30,7 @@ PS:
   region: Asia
   subregion: Western Asia
   world_region: EMEA
-  un_locode: 
+  un_locode:
   languages:
   - ar
   - he

--- a/lib/data/countries/VU.yaml
+++ b/lib/data/countries/VU.yaml
@@ -4,7 +4,7 @@ VU:
   alpha2: VU
   alpha3: VUT
   country_code: '678'
-  currency: 
+  currency: VUV
   international_prefix: '00'
   ioc: VAN
   gec: NH


### PR DESCRIPTION
A few countries are missing currency information. The following snippet lists their currencies as listed on Wikipedia.

Country | Currency
------------ | -------------
Antarctica | None<sup>1</sup>, but United States Dollar is common (USD)
Åland Islands | Euro (EUR)
Congo | Central African CFA franc (XAF)
Equatorial Guinea | Central African CFA franc (XAF) 
South Georgia and the South Sandwich Islands | Pound sterling (GBP)
Madagascar | Malagasy ariary (MGA)
Niue | New Zealand dollar (NZD)
Palestine, State of | New Israeli Shekel (ILS), Egyptian Pound (EGP), Jordinian Dinar (JOD)<sup>2</sup> 
Vanuatu | Vanuatu vatu (VUV)

<sup>1</sup>No official currency, although they do have a novelty Antarctic Dollar that can be bought in the United States, it isn't legal tender anywhere. Each base seems to use their home country currency. https://en.wikipedia.org/wiki/Antarctica#Economy
<sup>2</sup>New Israeli Shekel seems to be the most used from what I could glean, but I'm unsure.
