### PR TITLE
Add local_names and local_name methods to Country instances

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -62,6 +62,11 @@ Country Info
     c.name #=> "United States"
     c.names #=> ["United States of America", "Vereinigte Staaten von Amerika", "États-Unis", "Estados Unidos"]
 
+    # Get the names for a country translated to its local languages
+    c = Country[:BE]
+    c.local_names #=> ["België", "Belgique", "Belgien"]
+    c.local_name #=> "België"
+
     # Get a specific translation
     c.translation('de') #=> 'Vereinigte Staaten von Amerika'
     c.translations['fr'] #=> "États-Unis"

--- a/lib/countries/country.rb
+++ b/lib/countries/country.rb
@@ -99,6 +99,14 @@ class ISO3166::Country
     @data['translations'][locale.downcase]
   end
 
+  def local_names
+    @local_names ||= languages.map{ |language| translations[language] }
+  end
+
+  def local_name
+    @local_name ||= local_names.first
+  end
+
   private
 
   class << self

--- a/spec/country_spec.rb
+++ b/spec/country_spec.rb
@@ -97,6 +97,18 @@ describe ISO3166::Country do
     end
   end
 
+  context 'with Belgium' do
+    let(:country) { ISO3166::Country.search('BE') }
+
+    it 'should return its local names based on its languages' do
+      expect(country.local_names).to match_array(['België', 'Belgique', 'Belgien'])
+    end
+
+    it 'should return its first local name' do
+      expect(country.local_name).to eq('België')
+    end
+  end
+
   it 'should return ioc code' do
     expect(country.ioc).to eq('USA')
   end


### PR DESCRIPTION
Pull request for #297

Usage example:

```ruby
c = Country[:BE]
c.local_names #=> ["België", "Belgique", "Belgien"]
c.local_name #=> "België"
```