### PR TITLE
Fix NZ typo's.

### DIFF
--- a/lib/countries/data/subdivisions/NZ.yaml
+++ b/lib/countries/data/subdivisions/NZ.yaml
@@ -36,8 +36,8 @@ GIS:
   max_latitude: -38.6219639
   max_longitude: 178.115354
 HKB:
-  name: Hawkes's Bay
-  names: Hawkes's Bay
+  name: Hawke's Bay
+  names: Hawke's Bay
   latitude: -39.7711616
   longitude: 176.7416374
   min_latitude: -40.440783
@@ -145,8 +145,8 @@ WTC:
   max_latitude: -41.16730769999999
   max_longitude: 172.4800189
 X1~:
-  name: Chatham  Islands
-  names: Chatham  Islands
+  name: Chatham Islands
+  names: Chatham Islands
   latitude: -43.9120964
   longitude: -176.5433025
   min_latitude: -44.4343162


### PR DESCRIPTION
Hawke's Bay had an extra unwanted _s_, and the Chatham Islands had an unnecessary space.