### PR TITLE
Corrected Naming for Portugal subdivisions

### DIFF
--- a/lib/countries/data/subdivisions/PT.yaml
+++ b/lib/countries/data/subdivisions/PT.yaml
@@ -162,8 +162,8 @@
   max_latitude: 40.7325793
   max_longitude: -7.8250273
 '20':
-  name: Região Autónoma dos Açores
-  names: Região Autónoma dos Açores
+  name: Açores
+  names: Açores
   latitude: 37.7412488
   longitude: -25.6755944
   min_latitude: 36.9278178
@@ -171,8 +171,8 @@
   max_latitude: 39.7261497
   max_longitude: -25.0131855
 '30':
-  name: Região Autónoma da Madeira
-  names: Região Autónoma da Madeira
+  name: Madeira
+  names: Madeira
   latitude: 32.76070740000001
   longitude: -16.9594723
   min_latitude: 30.0303451


### PR DESCRIPTION
Açores and Madeira are the names used for these subdivisions: https://pt.wikipedia.org/wiki/ISO_3166-2:PT