### PR TITLE
Force converting passed locale to string

### DIFF
--- a/lib/countries/country.rb
+++ b/lib/countries/country.rb
@@ -96,7 +96,7 @@ class ISO3166::Country
   end
 
   def translation(locale = 'en')
-    @data['translations'][locale.downcase]
+    @data['translations'][locale.downcase.to_s]
   end
 
   def local_names


### PR DESCRIPTION
Added ability to pass locale as symbol to avoid behavior like that:

```
2.1.5 :017 > Country["AT"].translation :de
 => nil 
2.1.5 :018 > Country["AT"].translation "de"
 => "Österreich"
```