### PR TITLE
Added XAF as currency code for Congo

### DIFF
--- a/lib/countries/data/countries/CG.yaml
+++ b/lib/countries/data/countries/CG.yaml
@@ -4,7 +4,7 @@ CG:
   alpha2: CG
   alpha3: COG
   country_code: '242'
-  currency: 
+  currency: XAF
   international_prefix: '00'
   ioc: CGO
   gec: CF


### PR DESCRIPTION
Sources:
http://www.oanda.com/help/currency-iso-code-country
https://en.wikipedia.org/wiki/CFA_franc#Central_African
https://en.wikipedia.org/wiki/Central_African_CFA_franc