### PR TITLE
Added 47 as calling code for Bouvet Island, Norwegian territory

### DIFF
--- a/lib/countries/data/countries/BV.yaml
+++ b/lib/countries/data/countries/BV.yaml
@@ -3,7 +3,7 @@ BV:
   continent: Antarctica
   alpha2: BV
   alpha3: BVT
-  country_code: ''
+  country_code: '47'
   currency: NOK
   international_prefix: ''
   ioc: 


### PR DESCRIPTION
Sources:
https://en.wikipedia.org/wiki/Bouvet_Island
http://en.advisto.com/country-phone-codes.htm

Fixes one example in #315