### PR TITLE
Romanian Standard VAT rate is 20% as of 2016-01-01

### DIFF
--- a/lib/countries/data/countries/RO.yaml
+++ b/lib/countries/data/countries/RO.yaml
@@ -38,7 +38,7 @@ RO:
   nationality: Romanian
   eu_member: true
   vat_rates:
-    standard: 24
+    standard: 20
     reduced:
     - 5
     - 9


### PR DESCRIPTION
See: http://www.vatlive.com/european-news/romania-confirms-vat-rate-cut-to-20-2016/