### PR TITLE
Make California's 'names' value match other states' style

### DIFF
--- a/lib/countries/data/subdivisions/US.yaml
+++ b/lib/countries/data/subdivisions/US.yaml
@@ -60,9 +60,7 @@ AZ:
   max_longitude: -109.0452231
 CA:
   name: California
-  names:
-  - Californie
-  - Kalifornien
+  names: California
   latitude: 36.778261
   longitude: -119.4179324
   min_latitude: 32.5342321


### PR DESCRIPTION
While trying to iterate over each US state, I found that while most states have a single value for the `names` key, California had multiple values. The other states included only the English version of the name, while California included some translations;

```
AZ
{"name"=>"Arizona", "names"=>"Arizona"}
CA
{"name"=>"California", "names"=>["Californie", "Kalifornien"]}
CO
{"name"=>"Colorado", "names"=>"Colorado"}
CT
{"name"=>"Connecticut", "names"=>"Connecticut"}
```

This causes some unexpected behavior when iterating over each state's information. 

If the plan is to add multiple translations for all states, then this PR isn't necessary. However, if there are no plans to do so, I think it would be helpful to keep these consistent. 

