### PR TITLE
Fix the min/max lat/lon of Florida

### DIFF
--- a/lib/countries/data/subdivisions/US.yaml
+++ b/lib/countries/data/subdivisions/US.yaml
@@ -110,10 +110,10 @@ FL:
   names: Florida
   latitude: 27.6648274
   longitude: -81.5157535
-  min_latitude: -90
-  min_longitude: -180
-  max_latitude: 90
-  max_longitude: 180
+  min_latitude: 24.5210795
+  min_longitude: -87.634896
+  max_latitude: 31.000968
+  max_longitude: -80.0311371
 GA:
   name: Georgia
   names: Georgia


### PR DESCRIPTION
The US state Florida currently has incorrect min/max latitude and longitudes (-90, -180 and 90,180). I cleared these and re-ran the `rake fetch_subdivisions` task to fetch the latest boundaries from the geocoder.