### PR TITLE
Update EE.yaml remove ru from languages

### DIFF
--- a/lib/countries/data/countries/EE.yaml
+++ b/lib/countries/data/countries/EE.yaml
@@ -29,7 +29,6 @@ EE:
   un_locode: EE
   languages:
   - et
-  - ru
   nationality: Estonian
   eu_member: true
   vat_rates:


### PR DESCRIPTION
RU is not an official language of Estonia.