### PR TITLE
Update PH Subdivisions

### DIFF
--- a/lib/countries/data/subdivisions/PH.yaml
+++ b/lib/countries/data/subdivisions/PH.yaml
@@ -755,3 +755,14 @@ ZSI:
   names: Zamboanga Sibuguey [Zamboanga Sibugay]
   latitude: 7.02427
   longitude: 122.189
+'00':
+  name: National Capital Region
+  names:
+  - National Capital Region
+  - Pambansang Punong Rehiyon
+  latitude: 14.6090537
+  longitude: 121.0222565
+  min_latitude: 14.3493861
+  min_longitude: 120.9172569
+  max_latitude: 14.781217
+  max_longitude: 121.132012

--- a/lib/countries/data/subdivisions/PH.yaml
+++ b/lib/countries/data/subdivisions/PH.yaml
@@ -261,6 +261,24 @@ DAV:
   min_longitude: 125.250456
   max_latitude: 7.997327
   max_longitude: 125.944498
+DIN:
+  name: Dinagat Islands
+  names: Dinagat Islands
+  latitude: 10.1281816
+  longitude: 125.6095474
+  min_latitude: 9.8547497
+  min_longitude: 125.465279
+  max_latitude: 10.4716027
+  max_longitude: 125.7067526
+DVO:
+  name: Davao Occidental
+  names: Davao Occidental
+  latitude: 12.879721
+  longitude: 121.774017
+  min_latitude: 4.5870339
+  min_longitude: 116.7029193
+  max_latitude: 19.5740241
+  max_longitude: 126.6043837
 EAS:
   name: Eastern Samar
   names: Eastern Samar


### PR DESCRIPTION
There were 2 subdivisions missing which I have added - DIN and DVO

There is also a set of regions for PH https://en.wikipedia.org/wiki/ISO_3166-2:PH

All subdivisions are within a region except for the Region of `00` which has no subdivisions. I've added `00` and could add the other subdivisions (similar to what appears to exist for the UK). 

Is this PR good or should I add the additional PH regions?