### PR TITLE
fix: add hash keys for translations of russian regions

### DIFF
--- a/lib/countries/data/subdivisions/RU.yaml
+++ b/lib/countries/data/subdivisions/RU.yaml
@@ -3,7 +3,8 @@ AD:
   unofficial_names:
   - Adygei Republic
   - Adygeja
-  translations: Республика Адыгея
+  translations:
+    ru: Республика Адыгея
   geo:
     latitude: 44.8229155
     longitude: 40.1754463
@@ -17,7 +18,8 @@ AL:
   - Altaj
   - Altay
   - Gorno-Altaj
-  translations: Республика Алтай
+  translations:
+    ru: Республика Алтай
   geo:
     latitude: 55.7671943
     longitude: 37.606158
@@ -32,7 +34,8 @@ ALT:
   - Altajskij Kray
   - Altajskiy Kraj
   - Altaj
-  translations: Алтайский край
+  translations:
+    ru: Алтайский край
   geo:
     latitude: 51.7936298
     longitude: 82.6758596
@@ -44,7 +47,8 @@ ALT:
 AMU:
   unofficial_names:
   - Amurskaja Oblast
-  translations: Амурская область
+  translations:
+    ru: Амурская область
   geo:
     latitude: 54.60350649999999
     longitude: 127.4801721
@@ -57,7 +61,8 @@ ARK:
   unofficial_names:
   - Arhangelskaja Oblast
   - Arhangelsk
-  translations: Архангельская область
+  translations:
+    ru: Архангельская область
   geo:
     latitude: 63.2852803
     longitude: 42.5884191
@@ -70,7 +75,8 @@ AST:
   unofficial_names:
   - Astrahanska Oblast
   - Astrahan
-  translations: Астраханская область
+  translations:
+    ru: Астраханская область
   geo:
     latitude: 46.1321166
     longitude: 48.0610115
@@ -82,7 +88,8 @@ AST:
 BA:
   unofficial_names:
   - Baškortostan
-  translations: Республика Башкортостан
+  translations:
+    ru: Республика Башкортостан
   geo:
     latitude: 54.2312172
     longitude: 56.1645257
@@ -94,7 +101,8 @@ BA:
 BEL:
   unofficial_names:
   - Belgorodskaja Oblast
-  translations: Белгородская область
+  translations:
+    ru: Белгородская область
   geo:
     latitude: 50.71069259999999
     longitude: 37.7533377
@@ -107,7 +115,8 @@ BRY:
   unofficial_names:
   - Brjanskaja Oblast
   - Brjansk
-  translations: Брянская область
+  translations:
+    ru: Брянская область
   geo:
     latitude: 53.0408599
     longitude: 33.2690899
@@ -120,7 +129,8 @@ BU:
   unofficial_names:
   - Buryat Republic
   - Burjatija
-  translations: Республика Бурятия
+  translations:
+    ru: Республика Бурятия
   geo:
     latitude: 55.7685161
     longitude: 37.6425744
@@ -138,7 +148,8 @@ CE:
   - Čečens
   - Čečenskaja Respublika
   - Čečenija
-  translations: Чеченская Республика
+  translations:
+    ru: Чеченская Республика
   geo:
     latitude: 55.7521689
     longitude: 37.5886438
@@ -152,7 +163,8 @@ CHE:
   - Cheljabinsk
   - Čeljabinskaja Oblast
   - Čeljabinsk
-  translations: Челябинская область
+  translations:
+    ru: Челябинская область
   geo:
     latitude: 54.43194219999999
     longitude: 60.87889629999999
@@ -167,7 +179,8 @@ CHU:
   - Čukotskij Avtonomnyj Okrug
   - Čukči
   - Čukotka
-  translations: Чукотский автономный округ
+  translations:
+    ru: Чукотский автономный округ
   geo:
     latitude: 65.6298355
     longitude: 171.6952159
@@ -182,7 +195,8 @@ CU:
   - Chuvashskaya Respublika
   - Čuvašskaja Respublika
   - Čuvašija
-  translations: Чувашская Республика
+  translations:
+    ru: Чувашская Республика
   geo:
     latitude: 55.55959920000001
     longitude: 46.9283536
@@ -193,7 +207,8 @@ CU:
   name: Chuvashskaya Respublika
 DA:
   unofficial_names: Dagestan, Respublika
-  translations: Республика Дагестан
+  translations:
+    ru: Республика Дагестан
   geo:
     latitude: 55.7599606
     longitude: 37.6504362
@@ -206,7 +221,8 @@ IN:
   unofficial_names:
   - Ingushetija
   - Ingušetija
-  translations: Республика Ингушетия
+  translations:
+    ru: Республика Ингушетия
   geo:
     latitude: 43.4051698
     longitude: 44.82029989999999
@@ -218,7 +234,8 @@ IN:
 IRK:
   unofficial_names:
   - Irkutskaja Oblast
-  translations: Иркутская область
+  translations:
+    ru: Иркутская область
   geo:
     latitude: 56.13214199999999
     longitude: 103.948625
@@ -230,7 +247,8 @@ IRK:
 IVA:
   unofficial_names:
   - Ivanovskaja Oblast
-  translations: Ивановская область
+  translations:
+    ru: Ивановская область
   geo:
     latitude: 57.1056854
     longitude: 41.4830084
@@ -246,6 +264,7 @@ KAM:
   - Kamčatka
   translations:
     en: Kamchatskaya oblast'
+    ru: Камчатский край
   geo:
     latitude: 55.743583
     longitude: 37.5880195
@@ -259,7 +278,8 @@ KB:
   - Kabardino-Balkarian Republic
   - Kabardino-Balkarskaja Respublika
   - Kabardino-Balkarija
-  translations: Кабардино-Балкарская республика
+  translations:
+    ru: Кабардино-Балкарская республика
   geo:
     latitude: 43.3932469
     longitude: 43.5628498
@@ -273,7 +293,8 @@ KC:
   - Karachay-Cherkessian
   - Karačajevo-Čerkesskaja Respublika
   - Karačaj-Čerkessija
-  translations: Карачаево-Черкесская республика
+  translations:
+    ru: Карачаево-Черкесская республика
   geo:
     latitude: 43.8845143
     longitude: 41.730394
@@ -285,7 +306,8 @@ KC:
 KDA:
   unofficial_names:
   - Krasnodarskij Kraj
-  translations: Красноярский край
+  translations:
+    ru: Краснодарский край
   geo:
     latitude: 45.6415289
     longitude: 39.7055977
@@ -297,7 +319,8 @@ KDA:
 KEM:
   unofficial_names:
   - Kemerovskaja Oblast
-  translations: Кемеровская область
+  translations:
+    ru: Кемеровская область
   geo:
     latitude: 54.7574648
     longitude: 87.4055288
@@ -309,7 +332,8 @@ KEM:
 KGD:
   unofficial_names:
   - Kaliningradskaja Oblast
-  translations: Калининградская область
+  translations:
+    ru: Калининградская область
   geo:
     latitude: 54.8235292
     longitude: 21.4816163
@@ -321,7 +345,8 @@ KGD:
 KGN:
   unofficial_names:
   - Kurganskaja Oblast
-  translations: Курганская область
+  translations:
+    ru: Курганская область
   geo:
     latitude: 55.4481548
     longitude: 65.11809749999999
@@ -334,7 +359,8 @@ KHA:
   unofficial_names:
   - Habarovskij Kray
   - Habarovsk
-  translations: Хабаровский край
+  translations:
+    ru: Хабаровский край
   geo:
     latitude: 50.5888431
     longitude: 135
@@ -347,7 +373,8 @@ KHM:
   unofficial_names:
   - Hanty-Mansijskij Avtonomnyj Okrug
   - Hanty-Mansija
-  translations: Ханты-Мансийский автономный округ - Югра
+  translations:
+    ru: Ханты-Мансийский автономный округ - Югра
   geo:
     latitude: 62.2287062
     longitude: 70.6410058
@@ -359,7 +386,8 @@ KHM:
 KIR:
   unofficial_names:
   - Kirovskaja Oblast
-  translations: Кировская область
+  translations:
+    ru: Кировская область
   geo:
     latitude: 58.4198529
     longitude: 50.2097248
@@ -372,7 +400,8 @@ KK:
   unofficial_names:
   - Khakass Republic
   - Hakasija
-  translations: Республика Хакасия
+  translations:
+    ru: Республика Хакасия
   geo:
     latitude: 53.0452281
     longitude: 90.3982145
@@ -387,7 +416,8 @@ KL:
   - Kalmyk Republic
   - Khalmg-Tangch
   - Kalmykija
-  translations: Республика Калмыкия
+  translations:
+    ru: Республика Калмыкия
   geo:
     latitude: 46.5676845
     longitude: 45.7731614
@@ -400,7 +430,8 @@ KLU:
   unofficial_names:
   - Kaluzhskaya Oblast
   - Kalužskaja Oblast
-  translations: Калужская область
+  translations:
+    ru: Калужская область
   geo:
     latitude: 54.3872666
     longitude: 35.1889094
@@ -411,7 +442,8 @@ KLU:
   name: Kaluzhskaya oblast'
 KO:
   unofficial_names: Komi, Respublika
-  translations: Республика Коми
+  translations:
+    ru: Республика Коми
   geo:
     latitude: 63.8630539
     longitude: 54.8312689
@@ -423,7 +455,8 @@ KO:
 KOS:
   unofficial_names:
   - Kostromskaja Oblast
-  translations: Костромская область
+  translations:
+    ru: Костромская область
   geo:
     latitude: 58.5501069
     longitude: 43.9541103
@@ -436,7 +469,8 @@ KR:
   unofficial_names:
   - Karelian Republic
   - Karelija
-  translations: Республика Карелия
+  translations:
+    ru: Республика Карелия
   geo:
     latitude: 63.15587019999999
     longitude: 32.9905552
@@ -448,7 +482,8 @@ KR:
 KRS:
   unofficial_names:
   - Kurskaja Oblast
-  translations: Курская область
+  translations:
+    ru: Курская область
   geo:
     latitude: 51.76340260000001
     longitude: 35.3811812
@@ -462,7 +497,8 @@ KYA:
   - Krasnojarsk
   - Krasnojarskij Kraj
   - Krasnojarsk
-  translations: Красноярский край
+  translations:
+    ru: Красноярский край
   geo:
     latitude: 64.24797579999999
     longitude: 95.11041759999999
@@ -474,7 +510,8 @@ KYA:
 LEN:
   unofficial_names:
   - Leningradskaja Oblast
-  translations: Ленинградская область
+  translations:
+    ru: Ленинградская область
   geo:
     latitude: 60.0793208
     longitude: 31.8926644
@@ -487,7 +524,8 @@ LIP:
   unofficial_names:
   - Lipeckaja Oblast
   - Lipeck
-  translations: Липецкая область
+  translations:
+    ru: Липецкая область
   geo:
     latitude: 52.5264702
     longitude: 39.2032269
@@ -499,7 +537,8 @@ LIP:
 MAG:
   unofficial_names:
   - Magadanskaja Oblast
-  translations: Магаданская область
+  translations:
+    ru: Магаданская область
   geo:
     latitude: 62.66434169999999
     longitude: 153.9149909
@@ -512,7 +551,8 @@ ME:
   unofficial_names:
   - Mariy El
   - Marij El
-  translations: Республика Марий Эл
+  translations:
+    ru: Республика Марий Эл
   geo:
     latitude: 56.438457
     longitude: 47.9607757
@@ -525,7 +565,8 @@ MO:
   unofficial_names:
   - Mordovian Republic
   - Mordovija
-  translations: Республика Мордовия
+  translations:
+    ru: Республика Мордовия
   geo:
     latitude: 54.2369441
     longitude: 44.0683969
@@ -536,11 +577,9 @@ MO:
   name: Mordoviya, Respublika
 MOS:
   unofficial_names:
-  - Moskva
-  - Moskau
-  - Moscou
-  - Moscú
-  translations: Московская область
+  - Moskovskaja Oblast
+  translations:
+    ru: Московская область
   geo:
     latitude: 55.340396
     longitude: 38.2917651
@@ -551,8 +590,12 @@ MOS:
   name: Moskovskaya oblast'
 MOW:
   unofficial_names:
-  - Moskovskaja Oblast
-  translations: Москва
+  - Moskva
+  - Moskau
+  - Moscou
+  - Moscú
+  translations:
+    ru: Москва
   geo:
     latitude: 55.755826
     longitude: 37.6173
@@ -564,7 +607,8 @@ MOW:
 MUR:
   unofficial_names:
   - Murmanskaja Oblast
-  translations: Мурманская область
+  translations:
+    ru: Мурманская область
   geo:
     latitude: 67.84426739999999
     longitude: 35.0884101
@@ -576,7 +620,8 @@ MUR:
 NEN:
   unofficial_names:
   - Nenetskij Avtonomnyj Okrug
-  translations: Ненецкий автономный округ
+  translations:
+    ru: Ненецкий автономный округ
   geo:
     latitude: 67.6078337
     longitude: 57.63383309999999
@@ -588,7 +633,8 @@ NEN:
 NGR:
   unofficial_names:
   - Novgorodskaja Oblast
-  translations: Новгородская область
+  translations:
+    ru: Новгородская область
   geo:
     latitude: 58.2427552
     longitude: 32.5665191
@@ -605,7 +651,8 @@ NIZ:
   - Nizhegorodskaya Oblast
   - Nižegorodskaja Oblast
   - Nižnij Novgorod
-  translations: Нижегородская область
+  translations:
+    ru: Нижегородская область
   geo:
     latitude: 55.7995159
     longitude: 44.0296769
@@ -617,7 +664,8 @@ NIZ:
 NVS:
   unofficial_names:
   - Novosibirskaja Oblast
-  translations: Новосибирская область
+  translations:
+    ru: Новосибирская область
   geo:
     latitude: 55.4467133
     longitude: 80.1043924
@@ -629,7 +677,8 @@ NVS:
 OMS:
   unofficial_names:
   - Omskaja Oblast
-  translations: Омская область
+  translations:
+    ru: Омская область
   geo:
     latitude: 55.0554669
     longitude: 73.3167343
@@ -641,7 +690,8 @@ OMS:
 ORE:
   unofficial_names:
   - Orenburgskaja Oblast
-  translations: Оренбургская область
+  translations:
+    ru: Оренбургская область
   geo:
     latitude: 51.76340260000001
     longitude: 54.6188188
@@ -654,7 +704,8 @@ ORL:
   unofficial_names:
   - Orlovskaja Oblast
   - Orjol
-  translations: Орловская область
+  translations:
+    ru: Орловская область
   geo:
     latitude: 52.7450189
     longitude: 36.4849627
@@ -668,6 +719,7 @@ PER:
   - Permskaja Oblast
   translations:
     en: Perm
+    ru: Пермский край
   geo:
     latitude: 58.00000000000001
     longitude: 56.316667
@@ -679,7 +731,8 @@ PER:
 PNZ:
   unofficial_names:
   - Penzenskaja Oblast
-  translations: Пензенская область
+  translations:
+    ru: Пензенская область
   geo:
     latitude: 53.1412105
     longitude: 44.0940048
@@ -693,7 +746,8 @@ PRI:
   - Primorskij
   - Primorskij Kraj
   - Primorje
-  translations: Приморский край
+  translations:
+    ru: Приморский край
   geo:
     latitude: 45.0525641
     longitude: 135
@@ -707,7 +761,8 @@ PSK:
   - Pihkva
   - Pleskau
   - Pskovskaja Oblast
-  translations: Псковская область
+  translations:
+    ru: Псковская область
   geo:
     latitude: 56.7708599
     longitude: 29.094009
@@ -719,7 +774,8 @@ PSK:
 ROS:
   unofficial_names:
   - Rostovskaja Oblast
-  translations: Ростовская область
+  translations:
+    ru: Ростовская область
   geo:
     latitude: 47.6853247
     longitude: 41.8258952
@@ -732,7 +788,8 @@ RYA:
   unofficial_names:
   - Rjazanskaja Oblast
   - Rjazan
-  translations: Рязанская область
+  translations:
+    ru: Рязанская область
   geo:
     latitude: 54.3875964
     longitude: 41.259566
@@ -747,7 +804,8 @@ SA:
   - Sakha
   - Yakutsk-Sakha
   - Saha
-  translations: Республика Саха (Якутия)
+  translations:
+    ru: Республика Саха (Якутия)
   geo:
     latitude: 66.7613451
     longitude: 124.1237531
@@ -760,7 +818,8 @@ SAK:
   unofficial_names:
   - Sahalinskaya Oblast
   - Sahalin
-  translations: Сахалинская область
+  translations:
+    ru: Сахалинская область
   geo:
     latitude: 49.9807847
     longitude: 143.3738129
@@ -772,7 +831,8 @@ SAK:
 SAM:
   unofficial_names:
   - Samarskaja Oblast
-  translations: Самарская область
+  translations:
+    ru: Самарская область
   geo:
     latitude: 53.41838389999999
     longitude: 50.4725528
@@ -784,7 +844,8 @@ SAM:
 SAR:
   unofficial_names:
   - Saratovskaja Oblast
-  translations: Саратовская область
+  translations:
+    ru: Саратовская область
   geo:
     latitude: 51.83692629999999
     longitude: 46.7539397
@@ -799,7 +860,8 @@ SE:
   - North Ossetian Republic
   - Osetija
   - Alanija
-  translations: Республика Северная Осетия-Алания
+  translations:
+    ru: Республика Северная Осетия-Алания
   geo:
     latitude: 43.0451302
     longitude: 44.2870972
@@ -811,7 +873,8 @@ SE:
 SMO:
   unofficial_names:
   - Smolenskaja Oblast
-  translations: Смоленская область
+  translations:
+    ru: Смоленская область
   geo:
     latitude: 54.9882994
     longitude: 32.6677378
@@ -827,7 +890,8 @@ SPE:
   - Sankt Petersburg
   - Saint-Pétersbourg
   - San Petersburgo
-  translations: Санкт-Петербург
+  translations:
+    ru: Санкт-Петербург
   geo:
     latitude: 59.9342802
     longitude: 30.3350986
@@ -839,7 +903,8 @@ SPE:
 STA:
   unofficial_names:
   - Stavropolskij Kraj
-  translations: Ставропольский край
+  translations:
+    ru: Ставропольский край
   geo:
     latitude: 44.6680993
     longitude: 43.520214
@@ -851,7 +916,8 @@ STA:
 SVE:
   unofficial_names:
   - Sverdlovskaja Oblast
-  translations: Свердловская область
+  translations:
+    ru: Свердловская область
   geo:
     latitude: 59.007735
     longitude: 61.9316226
@@ -862,7 +928,8 @@ SVE:
   name: Sverdlovskaya oblast'
 TA:
   unofficial_names: Tatarstan, Respublika
-  translations: Республика Татарстан
+  translations:
+    ru: Республика Татарстан
   geo:
     latitude: 55.1802364
     longitude: 50.7263945
@@ -874,7 +941,8 @@ TA:
 TAM:
   unofficial_names:
   - Tambovskaja Oblast
-  translations: Тамбовская область
+  translations:
+    ru: Тамбовская область
   geo:
     latitude: 52.6416589
     longitude: 41.4216451
@@ -886,7 +954,8 @@ TAM:
 TOM:
   unofficial_names:
   - Tomskaja Oblast
-  translations: Томская область
+  translations:
+    ru: Томская область
   geo:
     latitude: 58.8969882
     longitude: 82.67654999999999
@@ -898,7 +967,8 @@ TOM:
 TUL:
   unofficial_names:
   - Tulskaja Oblast
-  translations: Тульская область
+  translations:
+    ru: Тульская область
   geo:
     latitude: 54.163768
     longitude: 37.5649507
@@ -910,7 +980,8 @@ TUL:
 TVE:
   unofficial_names:
   - Tverskaja Oblast
-  translations: Тверская область
+  translations:
+    ru: Тверская область
   geo:
     latitude: 57.0021654
     longitude: 33.9853142
@@ -922,7 +993,8 @@ TVE:
 TY:
   unofficial_names:
   - Tuva
-  translations: Республика Тыва
+  translations:
+    ru: Республика Тыва
   geo:
     latitude: 51.8872669
     longitude: 95.62601719999999
@@ -936,7 +1008,8 @@ TYU:
   - Tjumenskaja Oblast
   - Tumen
   - Tjumen
-  translations: Тюменская область
+  translations:
+    ru: Тюменская область
   geo:
     latitude: 56.9634387
     longitude: 66.948278
@@ -950,7 +1023,8 @@ UD:
   - Udmurt Republic
   - Udmurtskaya Respublika
   - Udmurtija
-  translations: Удмуртская Республика
+  translations:
+    ru: Удмуртская Республика
   geo:
     latitude: 57.0670218
     longitude: 53.0277948
@@ -963,7 +1037,8 @@ ULY:
   unofficial_names:
   - Uljanovskaja Oblast
   - Uljanovsk
-  translations: Ульяновская область
+  translations:
+    ru: Ульяновская область
   geo:
     latitude: 53.9793357
     longitude: 47.7762426
@@ -975,7 +1050,8 @@ ULY:
 VGG:
   unofficial_names:
   - Volgogradskaja Oblast
-  translations: Волгоградская область
+  translations:
+    ru: Волгоградская область
   geo:
     latitude: 49.7604522
     longitude: 45
@@ -987,7 +1063,8 @@ VGG:
 VLA:
   unofficial_names:
   - Vladimirskaja Oblast
-  translations: Владимирская область
+  translations:
+    ru: Владимирская область
   geo:
     latitude: 56.1553465
     longitude: 40.5926685
@@ -999,7 +1076,8 @@ VLA:
 VLG:
   unofficial_names:
   - Vologodskaja Oblast
-  translations: Вологодская область
+  translations:
+    ru: Вологодская область
   geo:
     latitude: 59.8706711
     longitude: 40.6555411
@@ -1012,7 +1090,8 @@ VOR:
   unofficial_names:
   - Voronežskaja Oblast
   - Voronež
-  translations: Воронежская область
+  translations:
+    ru: Воронежская область
   geo:
     latitude: 50.8589713
     longitude: 39.8644375
@@ -1026,7 +1105,8 @@ YAN:
   - Jamalija
   - Jamalo-Nenetskij Avtonomnyj Okrug
   - Jamalo-Nenets
-  translations: Ямало-Ненецкий автономный округ
+  translations:
+    ru: Ямало-Ненецкий автономный округ
   geo:
     latitude: 66.0653057
     longitude: 76.9345194
@@ -1039,7 +1119,8 @@ YAR:
   unofficial_names:
   - Jaroslavskaja Oblast
   - Jaroslavl
-  translations: Ярославская область
+  translations:
+    ru: Ярославская область
   geo:
     latitude: 57.8991523
     longitude: 38.8388633
@@ -1055,7 +1136,8 @@ YEV:
   - Jewish Autonomous Oblast
   - Yevreyskaya Oblast
   - Jevrej
-  translations: Еврейская автономная область
+  translations:
+    ru: Еврейская автономная область
   geo:
     latitude: 48.4808147
     longitude: 131.7657367
@@ -1069,7 +1151,8 @@ ZAB:
   - Zabajkal'skij kraj
   - Zabajkal'skij
   - Zabaykal'skij kray
-  translations: Забайкальский край
+  translations:
+    ru: Забайкальский край
   geo:
     latitude: 53.0928771
     longitude: 116.967656

--- a/spec/subdivision_spec.rb
+++ b/spec/subdivision_spec.rb
@@ -1,0 +1,18 @@
+# coding: utf-8
+
+require 'spec_helper'
+
+describe ISO3166::Subdivision do
+  let(:countries) { ISO3166::Country.all }
+  let(:available_types) { [Hash, NilClass] }
+
+  describe 'translations' do
+    it 'should be hash or nil' do
+      countries.each do |country|
+        country.subdivisions.each do |_, region|
+          expect(available_types).to include(region.translations.class)
+        end
+      end
+    end
+  end
+end


### PR DESCRIPTION
- replaced in lib/countries/data/subdivisions/RU.yaml rows like 
`translations: Республика Адыгея`
 to
`translations:`
&nbsp;&nbsp;`ru: Республика Адыгея`

- added spec, which checks if ISO3166::Subdivision.translations is either Hash or nil