### PR TITLE
adding MIT license to gemspec

### DIFF
--- a/countries.gemspec
+++ b/countries.gemspec
@@ -14,6 +14,7 @@ Gem::Specification.new do |gem|
   gem.name          = 'countries'
   gem.require_paths = ['lib']
   gem.version       = Countries::VERSION
+  gem.license       = 'MIT'
 
   gem.add_dependency('i18n_data', '~> 0.7.0')
   gem.add_dependency('money', '~> 6.0')


### PR DESCRIPTION
Listing the license in the gemspec can be useful for other tools that read gem dependencies.

More info at [Gemspec#license=](http://guides.rubygems.org/specification-reference/#license=)