### PR TITLE
Change Zimbabwe currency code to USD

### DIFF
--- a/lib/countries/data/countries/ZW.yaml
+++ b/lib/countries/data/countries/ZW.yaml
@@ -45,4 +45,4 @@ ZW:
     max_longitude: '33.05'
     min_latitude: "-22.316667"
     min_longitude: '25.333333'
-  currency_code: ZWD
+  currency_code: USD


### PR DESCRIPTION
The successor is difficult, but the Zimbabwean Dollar was demonetised in 2015 and replaced with a basket of currencies. The government uses the USD in official transactions, however.