### PR TITLE
Restrict money version to ~> 6.7

### DIFF
--- a/countries.gemspec
+++ b/countries.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.license       = 'MIT'
 
   gem.add_dependency('i18n_data', '~> 0.7.0')
-  gem.add_dependency('money', '~> 6.0')
+  gem.add_dependency('money', '~> 6.7')
   gem.add_dependency('unicode_utils', '~> 1.4')
   gem.add_development_dependency('rspec', '>= 3')
   gem.add_development_dependency('activesupport', '>= 3')


### PR DESCRIPTION
This gem (countries) depends on money ~>6.0 and requires `sixarm_ruby_unaccent` in countries.rb. The problem is, `sixarm_ruby_unaccent` is a dependency of money v6.7 and up. One of our gems depends on an earlier version of money, so countries >= 2.0 caused our builds to error.

This PR updates countries to depend on money 6.7 and above.