### PR TITLE
Add sixarm_ruby_unaccent to gemspec dependencies

### DIFF
--- a/countries.gemspec
+++ b/countries.gemspec
@@ -19,6 +19,7 @@ Gem::Specification.new do |gem|
   gem.add_dependency('i18n_data', '~> 0.7.0')
   gem.add_dependency('money', '~> 6.7')
   gem.add_dependency('unicode_utils', '~> 1.4')
+  gem.add_dependency('sixarm_ruby_unaccent', '~> 1.1')
   gem.add_development_dependency('rspec', '>= 3')
   gem.add_development_dependency('activesupport', '>= 3')
 end


### PR DESCRIPTION
`countries` requires `sixarm_ruby_unaccent` (as included in `lib/countries.rb`), however it's not listed as a dependency. This causes breakages unless the gem already happens to be installed or it's installed manually.