### PR TITLE
Unnecessary call to uniq causing perf regression.

### DIFF
--- a/lib/countries/data.rb
+++ b/lib/countries/data.rb
@@ -7,11 +7,10 @@ module ISO3166
 
     def initialize(alpha2)
       @alpha2 = alpha2.to_s.upcase
-      self.class.update_cache
     end
 
     def call
-      @@cache[@alpha2]
+      self.class.update_cache[@alpha2]
     end
 
     class << self
@@ -73,12 +72,12 @@ module ISO3166
       private
 
       def loaded_codes
-        (@@cache.keys + @@registered_data.keys).uniq
+        (@@cache.keys + @@registered_data.keys)
       end
 
       # Codes that we have translations for in dataset
       def internal_codes
-        loaded_codes - @@registered_data.keys
+        @@cache.keys - @@registered_data.keys
       end
 
       def cache_flush_required?

--- a/lib/countries/data.rb
+++ b/lib/countries/data.rb
@@ -51,8 +51,9 @@ module ISO3166
       end
 
       def load_data!
-        return @@cache unless @@cache.size == loaded_codes || @@cache.keys.empty?
+        return @@cache unless load_required?
         @@cache = load_cache %w(cache countries.json)
+        @@_country_codes = @@cache.keys
         @@cache = @@cache.merge(@@registered_data)
         @@cache
       end
@@ -71,13 +72,17 @@ module ISO3166
 
       private
 
+      def load_required?
+        @@cache.empty?
+      end
+
       def loaded_codes
-        (@@cache.keys + @@registered_data.keys)
+        @@cache.keys
       end
 
       # Codes that we have translations for in dataset
       def internal_codes
-        @@cache.keys - @@registered_data.keys
+        @@_country_codes - @@registered_data.keys
       end
 
       def cache_flush_required?

--- a/spec/perf_spec.rb
+++ b/spec/perf_spec.rb
@@ -2,9 +2,6 @@
 require 'spec_helper'
 
 describe ISO3166::Data, perf: true, order: :defined do
-  require 'benchmark'
-  require 'memory_profiler'
-  require 'ruby-prof'
 
   ALL_LOCALES = [
     :af, :am, :ar, :as, :az, :be, :bg, :bn, :br, :bs, :ca, :cs, :cy, :da, :de,
@@ -17,6 +14,9 @@ describe ISO3166::Data, perf: true, order: :defined do
   ].freeze
 
   def perf_report(name)
+    require 'benchmark'
+    require 'memory_profiler'
+    require 'ruby-prof'
     # profile the code
     RubyProf.start
 


### PR DESCRIPTION
2.0.5 Benchmark
```
Rehearsal --------------------------------------------------
find_by_alpha2   2.520000   0.040000   2.560000 (  2.574010)
new              0.310000   0.010000   0.320000 (  0.325458)
----------------------------------------- total: 2.880000sec

                     user     system      total        real
find_by_alpha2   2.500000   0.030000   2.530000 (  2.546312)
new              0.300000   0.000000   0.300000 (  0.297833)
```

HEAD Benchmark
```
Rehearsal --------------------------------------------------
find_by_alpha2   0.450000   0.000000   0.450000 (  0.446878)
new              0.030000   0.000000   0.030000 (  0.027353)
----------------------------------------- total: 0.480000sec

                     user     system      total        real
find_by_alpha2   0.470000   0.000000   0.470000 (  0.486354)
new              0.030000   0.000000   0.030000 (  0.025358)
```