### PR TITLE
Remove empty Philippines subdivision PH-MNL

### DIFF
--- a/lib/countries/data/subdivisions/PH.yaml
+++ b/lib/countries/data/subdivisions/PH.yaml
@@ -588,18 +588,6 @@ MDR:
     max_latitude: 13.5314771
     max_longitude: 121.5576218
   name: Mindoro Oriental
-MNL:
-  unofficial_names: ''
-  translations:
-    en: ''
-  geo:
-    latitude: 12.879721
-    longitude: 121.774017
-    min_latitude: 4.5870339
-    min_longitude: 116.7029193
-    max_latitude: 19.5740241
-    max_longitude: 126.6043837
-  name: ''
 MOU:
   unofficial_names: Mountain Province
   translations:


### PR DESCRIPTION
The PH-MNL subdivision is not listed in the ISO-3166-2 specification at
https://www.iso.org/obp/ui/#iso:code:3166:PH

Wikipedia article
https://en.wikipedia.org/wiki/Template:ISO_3166_name_PH-MNL
indicates PH-MNL returns Philippines instead of a subdivision within
Philippines.

Also, the PH-MNL subdivision in Philippines does not have a name.

So this entry should not exist.