### PR TITLE
Remove empty Turkmenistan subdivision TM-X~

### DIFF
--- a/lib/countries/data/subdivisions/TM.yaml
+++ b/lib/countries/data/subdivisions/TM.yaml
@@ -71,17 +71,3 @@ M:
     max_latitude: 39.5136029
     max_longitude: 64.737839
   name: Mary
-X~:
-  unofficial_names:
-  - Ashgabat
-  - Aşkabat
-  translations:
-    en: ''
-  geo:
-    latitude: 38.969719
-    longitude: 59.556278
-    min_latitude: 35.12876
-    min_longitude: 52.4478449
-    max_latitude: 42.798844
-    max_longitude: 66.707353
-  name: ''


### PR DESCRIPTION
The TM-X~ subdivision is not listed in the ISO-3166-2 specification at
https://www.iso.org/obp/ui/#iso:code:3166:TM

Wikipedia article
https://en.wikipedia.org/wiki/Template:ISO_3166_name_TM-X~
indicates TM-X~ returns Turkmenistan instead of a subdivision within
Turkmenistan.

Also, the TM-X~ subdivision does not have a name.

So this entry should not exist.