### PR TITLE
Romanian standard VAT rate 19% since 2017-01-01

### DIFF
--- a/lib/countries/data/countries/RO.yaml
+++ b/lib/countries/data/countries/RO.yaml
@@ -27,7 +27,7 @@ RO:
   eu_member: true
   eea_member: true
   vat_rates:
-    standard: 20
+    standard: 19
     reduced:
     - 5
     - 9


### PR DESCRIPTION
Down from 20%.

http://www.vatlive.com/vat-news/romania-cuts-vat-to-19-2017/