### PR TITLE
Use Subdivision Names from Unicode CLDR

### DIFF
--- a/lib/countries/data/subdivisions/AD.yaml
+++ b/lib/countries/data/subdivisions/AD.yaml
@@ -80,7 +80,7 @@
     max_longitude: 1.5353385
   name: Andorra la Vella
   comments: 
-08:
+'08':
   unofficial_names:
   - Les Escaldes
   translations:

--- a/lib/countries/data/subdivisions/AE.yaml
+++ b/lib/countries/data/subdivisions/AE.yaml
@@ -10,7 +10,7 @@ AJ:
     min_longitude: 55.4239777
     max_latitude: 25.450004
     max_longitude: 55.6371712
-  name: "'Ajmān"
+  name: Ajman
   comments: 
 AZ:
   unofficial_names:
@@ -29,7 +29,7 @@ AZ:
     min_longitude: 54.268856
     max_latitude: 24.6213301
     max_longitude: 54.8509598
-  name: Abū Z̧aby [Abu Dhabi]
+  name: Abu Dhabi
   comments: 
 DU:
   unofficial_names:
@@ -44,7 +44,7 @@ DU:
     min_longitude: 54.895991
     max_latitude: 25.356306
     max_longitude: 55.56369770000001
-  name: Dubayy
+  name: Dubai
   comments: 
 FU:
   unofficial_names:
@@ -60,7 +60,7 @@ FU:
     min_longitude: 55.96323
     max_latitude: 25.667782
     max_longitude: 56.3760899
-  name: Al Fujayrah
+  name: Fujairah
   comments: 
 RK:
   unofficial_names:
@@ -75,7 +75,7 @@ RK:
     min_longitude: 55.8637944
     max_latitude: 25.9116106
     max_longitude: 56.0727597
-  name: Ra's al Khaymah
+  name: Ras al-Khaimah
   comments: 
 SH:
   unofficial_names:
@@ -90,7 +90,7 @@ SH:
     min_longitude: 55.34973
     max_latitude: 25.3988264
     max_longitude: 55.6726397
-  name: Ash Shariqah [Sharjah]
+  name: Sharjah
   comments: 
 UQ:
   unofficial_names:
@@ -105,5 +105,5 @@ UQ:
     min_longitude: 55.5175201
     max_latitude: 25.6954771
     max_longitude: 55.953869
-  name: Umm al Qaywayn
+  name: Umm al-Quwain
   comments: 

--- a/lib/countries/data/subdivisions/AF.yaml
+++ b/lib/countries/data/subdivisions/AF.yaml
@@ -27,7 +27,7 @@ BAM:
     min_longitude: 66.2868759
     max_latitude: 35.479285
     max_longitude: 68.2664631
-  name: Bamian
+  name: Bamyan
   comments: 
 BDG:
   unofficial_names:
@@ -87,7 +87,7 @@ DAY:
     min_longitude: 65.23819689999999
     max_latitude: 34.36751
     max_longitude: 67.4245309
-  name: Daykondi
+  name: Daykundi
   comments: 
 FRA:
   unofficial_names:
@@ -147,7 +147,7 @@ GHO:
     min_longitude: 63.19821899999999
     max_latitude: 35.276925
     max_longitude: 66.736645
-  name: Ghowr
+  name: Ghōr
   comments: 
 HEL:
   unofficial_names:
@@ -211,7 +211,7 @@ KAB:
     min_longitude: 68.9495086
     max_latitude: 34.7619227
     max_longitude: 69.4459534
-  name: Kabul [Kabol]
+  name: Kabul
   comments: 
 KAN:
   unofficial_names:
@@ -258,7 +258,7 @@ KDZ:
     min_longitude: 68.7845421
     max_latitude: 36.77299259999999
     max_longitude: 68.9773179
-  name: Kondoz [Kunduz]
+  name: Kunduz
   comments: 
 KHO:
   unofficial_names:
@@ -277,7 +277,7 @@ KHO:
     min_longitude: 69.3547779
     max_latitude: 33.7335318
     max_longitude: 70.3265909
-  name: Khowst
+  name: Khost
   comments: 
 KNR:
   unofficial_names:
@@ -292,7 +292,7 @@ KNR:
     min_longitude: 71.3623594
     max_latitude: 35.0906452
     max_longitude: 71.3708674
-  name: Konar [Kunar]
+  name: Kunar
   comments: 
 LAG:
   unofficial_names:
@@ -341,7 +341,7 @@ NAN:
     min_longitude: 69.482636
     max_latitude: 34.809976
     max_longitude: 71.17125709999999
-  name: Nangrahar [Nangarhar]
+  name: Nangarhar
   comments: 
 NIM:
   unofficial_names:
@@ -374,7 +374,7 @@ NUR:
     min_longitude: 69.916771
     max_latitude: 36.0492169
     max_longitude: 71.614166
-  name: Nurestan
+  name: Nuristan
   comments: 
 ORU:
   unofficial_names:
@@ -514,7 +514,7 @@ WAR:
     min_longitude: 67.232205
     max_latitude: 34.797575
     max_longitude: 68.972619
-  name: Wardak [Wardag]
+  name: Maidan Wardak
   comments: 
 ZAB:
   unofficial_names:
@@ -530,5 +530,5 @@ ZAB:
     min_longitude: 66.192899
     max_latitude: 33.083939
     max_longitude: 68.1166841
-  name: Zabol [Zabul]
+  name: Zabul
   comments: 

--- a/lib/countries/data/subdivisions/AG.yaml
+++ b/lib/countries/data/subdivisions/AG.yaml
@@ -23,7 +23,7 @@
     min_longitude: -61.8614586
     max_latitude: 17.1409954
     max_longitude: -61.8271922
-  name: Saint John’s
+  name: Saint John
   comments: 
 '05':
   unofficial_names: Saint Mary
@@ -64,7 +64,7 @@
     max_longitude: -61.71377
   name: Saint Peter
   comments: 
-08:
+'08':
   unofficial_names: Saint Philip
   translations:
     en: Saint Philip

--- a/lib/countries/data/subdivisions/AL.yaml
+++ b/lib/countries/data/subdivisions/AL.yaml
@@ -458,7 +458,7 @@ TR:
     min_longitude: 19.7535682
     max_latitude: 41.36684109999999
     max_longitude: 19.8820782
-  name: Tiranë
+  name: Tirana
   comments: 
 VL:
   unofficial_names: Vlorë

--- a/lib/countries/data/subdivisions/AM.yaml
+++ b/lib/countries/data/subdivisions/AM.yaml
@@ -10,7 +10,7 @@ AG:
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Aragac?otn
+  name: Aragatsotn
 AR:
   unofficial_names: Ararat
   translations:
@@ -46,7 +46,7 @@ ER:
     min_longitude: 44.3620849
     max_latitude: 40.2426667
     max_longitude: 44.6150493
-  name: Erevan
+  name: Yerevan
 GR:
   unofficial_names:
   - Gegharkunick
@@ -59,7 +59,7 @@ GR:
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Gegark'unik'
+  name: Gegharkunik
 KT:
   unofficial_names:
   - Kotaik
@@ -72,7 +72,7 @@ KT:
     min_longitude: 44.398311
     max_latitude: 40.71982999999999
     max_longitude: 45.043105
-  name: Kotayk'
+  name: Kotayk
 LO:
   unofficial_names:
   - Lorri
@@ -85,7 +85,7 @@ LO:
     min_longitude: 44.016761
     max_latitude: 41.299259
     max_longitude: 44.960212
-  name: Lo?y
+  name: Lori
 SH:
   unofficial_names: Širak
   translations:
@@ -97,7 +97,7 @@ SH:
     min_longitude: 43.4497797
     max_latitude: 41.1808931
     max_longitude: 44.2037191
-  name: Širak
+  name: Shirak
 SU:
   unofficial_names: Syunik'
   translations:
@@ -109,7 +109,7 @@ SU:
     min_longitude: 45.70893909999999
     max_latitude: 39.854328
     max_longitude: 46.630035
-  name: Syunik'
+  name: Syunik
 TV:
   unofficial_names:
   - Tavoush
@@ -122,7 +122,7 @@ TV:
     min_longitude: 44.766082
     max_latitude: 41.3018379
     max_longitude: 45.5956799
-  name: Tavuš
+  name: Tavush
 VD:
   unofficial_names: Vayoc Jor
   translations:
@@ -134,4 +134,4 @@ VD:
     min_longitude: 45.066502
     max_latitude: 40.01380899999999
     max_longitude: 45.825905
-  name: Vayoc Jor
+  name: Vayots Dzor

--- a/lib/countries/data/subdivisions/AO.yaml
+++ b/lib/countries/data/subdivisions/AO.yaml
@@ -60,7 +60,7 @@ CCU:
     min_longitude: 16.463013
     max_latitude: -13.60931
     max_longitude: 23.4281539
-  name: Cuando-Cubango
+  name: Cuando Cubango
 CNN:
   unofficial_names: Cunene
   translations:
@@ -171,7 +171,7 @@ MAL:
     min_longitude: 16.2992908
     max_latitude: -9.5124286
     max_longitude: 16.3876533
-  name: Malange
+  name: Malanje
 MOX:
   unofficial_names: Moxico
   translations:

--- a/lib/countries/data/subdivisions/AR.yaml
+++ b/lib/countries/data/subdivisions/AR.yaml
@@ -22,7 +22,7 @@ B:
     min_longitude: -58.5314522
     max_latitude: -34.5265464
     max_longitude: -58.33518840000001
-  name: Buenos Aires
+  name: Buenos Aires Province
 C:
   unofficial_names: Capital federal
   translations:
@@ -34,7 +34,7 @@ C:
     min_longitude: -58.5314522
     max_latitude: -34.5265464
     max_longitude: -58.33518840000001
-  name: Capital federal
+  name: Buenos Aires
 D:
   unofficial_names: San Luis
   translations:

--- a/lib/countries/data/subdivisions/AT.yaml
+++ b/lib/countries/data/subdivisions/AT.yaml
@@ -24,7 +24,7 @@
     min_longitude: 12.6563901
     max_latitude: 47.13131
     max_longitude: 15.0651401
-  name: Kärnten
+  name: Carinthia
 '3':
   unofficial_names:
   - Lower Austria
@@ -37,7 +37,7 @@
     min_longitude: 14.4521301
     max_latitude: 49.02062
     max_longitude: 17.06847
-  name: Niederösterreich
+  name: Lower Austria
 '4':
   unofficial_names:
   - Upper Austria
@@ -50,7 +50,7 @@
     min_longitude: 12.74895
     max_latitude: 48.7726901
     max_longitude: 14.99129
-  name: Oberösterreich
+  name: Upper Austria
 '5':
   unofficial_names:
   - Salzbourg
@@ -76,7 +76,7 @@
     min_longitude: 13.56417
     max_latitude: 47.82789
     max_longitude: 16.17014
-  name: Steiermark
+  name: Styria
 '7':
   unofficial_names:
   - Tyrol
@@ -89,7 +89,7 @@
     min_longitude: 10.0980701
     max_latitude: 47.74310999999999
     max_longitude: 12.9662801
-  name: Tirol
+  name: Tyrol
 '8':
   unofficial_names: Vorarlberg
   translations:
@@ -114,4 +114,4 @@
     min_longitude: 16.1826199
     max_latitude: 48.3230999
     max_longitude: 16.5774999
-  name: Wien
+  name: Vienna

--- a/lib/countries/data/subdivisions/AZ.yaml
+++ b/lib/countries/data/subdivisions/AZ.yaml
@@ -22,7 +22,7 @@ ABS:
     min_longitude: 48.843646
     max_latitude: 40.638273
     max_longitude: 49.908777
-  name: Abseron
+  name: Absheron
 AGA:
   unofficial_names: Agstafa
   translations:
@@ -46,7 +46,7 @@ AGC:
     min_longitude: 47.0597249
     max_latitude: 40.248541
     max_longitude: 47.735411
-  name: Agcabädi
+  name: Aghjabadi
 AGM:
   unofficial_names: Agdam
   translations:
@@ -70,7 +70,7 @@ AGS:
     min_longitude: 47.4376344
     max_latitude: 40.6659586
     max_longitude: 47.5069858
-  name: Agdas
+  name: Agdash
 AGU:
   unofficial_names: Agsu
   translations:
@@ -106,7 +106,7 @@ BA:
     min_longitude: 49.6538049
     max_latitude: 40.486602
     max_longitude: 50.0561143
-  name: Baki
+  name: Baku
 BAB:
   unofficial_names: Babäk
   translations:
@@ -118,7 +118,7 @@ BAB:
     min_longitude: 45.4309559
     max_latitude: 39.1675349
     max_longitude: 45.46829229999999
-  name: Babäk
+  name: Babek
 BAL:
   unofficial_names: Balakän
   translations:
@@ -130,7 +130,7 @@ BAL:
     min_longitude: 46.3497733
     max_latitude: 41.7560107
     max_longitude: 46.4600659
-  name: Balakän
+  name: Balakan
 BAR:
   unofficial_names: Bärdä
   translations:
@@ -142,7 +142,7 @@ BAR:
     min_longitude: 47.09220879999999
     max_latitude: 40.405915
     max_longitude: 47.1718597
-  name: Bärdä
+  name: Barda
 BEY:
   unofficial_names: Beyläqan
   translations:
@@ -154,7 +154,7 @@ BEY:
     min_longitude: 47.58363250000001
     max_latitude: 39.7852244
     max_longitude: 47.6407099
-  name: Beyläqan
+  name: Beylagan
 BIL:
   unofficial_names: Biläsuvar
   translations:
@@ -166,7 +166,7 @@ BIL:
     min_longitude: 48.5262895
     max_latitude: 39.4795993
     max_longitude: 48.5670376
-  name: Biläsuvar
+  name: Bilasuvar
 CAB:
   unofficial_names: Cäbrayil
   translations:
@@ -178,7 +178,7 @@ CAB:
     min_longitude: 46.692907
     max_latitude: 39.478561
     max_longitude: 47.27655410000001
-  name: Cäbrayil
+  name: Jabrayil
 CAL:
   unofficial_names: Cälilabab
   translations:
@@ -190,7 +190,7 @@ CAL:
     min_longitude: 48.1295969
     max_latitude: 39.408813
     max_longitude: 48.754075
-  name: Cälilabab
+  name: Jalilabad
 CUL:
   unofficial_names: Culfa
   translations:
@@ -202,7 +202,7 @@ CUL:
     min_longitude: 45.605641
     max_latitude: 38.9734231
     max_longitude: 45.6617546
-  name: Culfa
+  name: Julfa
 DAS:
   unofficial_names: Daskäsän
   translations:
@@ -214,7 +214,7 @@ DAS:
     min_longitude: 46.0622406
     max_latitude: 40.5287404
     max_longitude: 46.09107969999999
-  name: Daskäsän
+  name: Dashkasan
 DAV:
   unofficial_names: Däväçi
   translations:
@@ -238,7 +238,7 @@ FUZ:
     min_longitude: 47.1216489
     max_latitude: 39.6252594
     max_longitude: 47.1828459
-  name: Füzuli
+  name: Fizuli
 GA:
   unofficial_names: Gäncä
   translations:
@@ -250,7 +250,7 @@ GA:
     min_longitude: 46.2979746
     max_latitude: 40.7553196
     max_longitude: 46.4393805
-  name: Gäncä
+  name: Ganja
 GAD:
   unofficial_names: Gädäbäy
   translations:
@@ -262,7 +262,7 @@ GAD:
     min_longitude: 45.3550831
     max_latitude: 40.821649
     max_longitude: 45.915231
-  name: Gädäbäy
+  name: Gadabay
 GOR:
   unofficial_names: Goranboy
   translations:
@@ -286,7 +286,7 @@ GOY:
     min_longitude: 47.67448410000001
     max_latitude: 40.6723061
     max_longitude: 47.78572080000001
-  name: Göyçay
+  name: Goychay
 HAC:
   unofficial_names: Haciqabul
   translations:
@@ -298,7 +298,7 @@ HAC:
     min_longitude: 48.8856411
     max_latitude: 40.0635722
     max_longitude: 48.959273
-  name: Haciqabul
+  name: Hajigabul
 IMI:
   unofficial_names: Imisli
   translations:
@@ -310,7 +310,7 @@ IMI:
     min_longitude: 48.0193521
     max_latitude: 39.8917536
     max_longitude: 48.1096519
-  name: Imisli
+  name: Imishli
 ISM:
   unofficial_names: Ismayilli
   translations:
@@ -322,7 +322,7 @@ ISM:
     min_longitude: 48.13007349999999
     max_latitude: 40.8119253
     max_longitude: 48.2034588
-  name: Ismayilli
+  name: Ismailli
 KAL:
   unofficial_names: Kälbäcär
   translations:
@@ -334,7 +334,7 @@ KAL:
     min_longitude: 45.6090569
     max_latitude: 40.31433699999999
     max_longitude: 46.759549
-  name: Kälbäcär
+  name: Kalbajar
 KUR:
   unofficial_names: Kürdämir
   translations:
@@ -346,7 +346,7 @@ KUR:
     min_longitude: 48.120718
     max_latitude: 40.3976794
     max_longitude: 48.2148742
-  name: Kürdämir
+  name: Kurdamir
 LA:
   unofficial_names: Länkäran City
   translations:
@@ -358,7 +358,7 @@ LA:
     min_longitude: 48.8232207
     max_latitude: 38.7975439
     max_longitude: 48.8669301
-  name: Länkäran City
+  name: Lankaran
 LAC:
   unofficial_names: Laçin
   translations:
@@ -370,7 +370,7 @@ LAC:
     min_longitude: 46.5265846
     max_latitude: 39.652359
     max_longitude: 46.5657878
-  name: Laçin
+  name: Lachin
 LAN:
   unofficial_names: Länkäran
   translations:
@@ -382,7 +382,7 @@ LAN:
     min_longitude: 48.8232207
     max_latitude: 38.7975439
     max_longitude: 48.8669301
-  name: Länkäran
+  name: Lankaran District
 LER:
   unofficial_names: Lerik
   translations:
@@ -406,7 +406,7 @@ MAS:
     min_longitude: 48.6470318
     max_latitude: 39.0481191
     max_longitude: 48.6902905
-  name: Masalli
+  name: Masally
 MI:
   unofficial_names: Mingäçevir
   translations:
@@ -418,7 +418,7 @@ MI:
     min_longitude: 46.9520472
     max_latitude: 40.7958107
     max_longitude: 47.1156406
-  name: Mingäçevir
+  name: Mingachevir
 NA:
   unofficial_names: Naftalan
   translations:
@@ -442,7 +442,7 @@ NEF:
     min_longitude: 49.2190934
     max_latitude: 39.4222045
     max_longitude: 49.2725657
-  name: Neftçala
+  name: Neftchala
 NX:
   unofficial_names: Naxçivan
   translations:
@@ -454,7 +454,7 @@ NX:
     min_longitude: 45.3697586
     max_latitude: 39.228264
     max_longitude: 45.4377366
-  name: Naxçivan
+  name: Nakhchivan AR
 OGU:
   unofficial_names: Oguz
   translations:
@@ -466,7 +466,7 @@ OGU:
     min_longitude: 47.4506378
     max_latitude: 41.0923544
     max_longitude: 47.4782753
-  name: Oguz
+  name: Oghuz
 ORD:
   unofficial_names: Ordubad
   translations:
@@ -490,7 +490,7 @@ QAB:
     min_longitude: 47.8214693
     max_latitude: 41.0042653
     max_longitude: 47.8774202
-  name: Qäbälä
+  name: Qabala
 QAX:
   unofficial_names: Qax
   translations:
@@ -502,7 +502,7 @@ QAX:
     min_longitude: 46.89085009999999
     max_latitude: 41.4429194
     max_longitude: 46.9906713
-  name: Qax
+  name: Qakh
 QAZ:
   unofficial_names: Qazax
   translations:
@@ -514,7 +514,7 @@ QAZ:
     min_longitude: 45.3229809
     max_latitude: 41.1163487
     max_longitude: 45.3892851
-  name: Qazax
+  name: Qazakh
 QBA:
   unofficial_names: Quba
   translations:
@@ -550,7 +550,7 @@ QOB:
     min_longitude: 49.38769749999999
     max_latitude: 40.1079896
     max_longitude: 49.433756
-  name: Qobustan
+  name: Gobustan
 QUS:
   unofficial_names: Qusar
   translations:
@@ -574,7 +574,7 @@ SA:
     min_longitude: -114.8165909
     max_latitude: 37.0042599
     max_longitude: -109.0452231
-  name: Säki City
+  name: Shaki
 SAB:
   unofficial_names: Sabirabad
   translations:
@@ -598,7 +598,7 @@ SAD:
     min_longitude: 44.85340129999999
     max_latitude: 39.7285114
     max_longitude: 44.9173451
-  name: Sädäräk
+  name: Sadarak
 SAH:
   unofficial_names: Sahbuz
   translations:
@@ -610,7 +610,7 @@ SAH:
     min_longitude: 45.5522345
     max_latitude: 39.4185908
     max_longitude: 45.597639
-  name: Sahbuz
+  name: Shahbuz
 SAK:
   unofficial_names: Säki
   translations:
@@ -622,7 +622,7 @@ SAK:
     min_longitude: 46.808805
     max_latitude: 41.485622
     max_longitude: 47.6075521
-  name: Säki
+  name: Shaki District
 SAL:
   unofficial_names: Salyan
   translations:
@@ -646,7 +646,7 @@ SAR:
     min_longitude: 44.82024
     max_latitude: 39.785526
     max_longitude: 45.2860981
-  name: Särur
+  name: Sharur
 SAT:
   unofficial_names: Saatli
   translations:
@@ -658,7 +658,7 @@ SAT:
     min_longitude: 48.2874871
     max_latitude: 39.9668589
     max_longitude: 48.4565735
-  name: Saatli
+  name: Saatly
 SIY:
   unofficial_names: Siyäzän
   translations:
@@ -670,7 +670,7 @@ SIY:
     min_longitude: 49.0923215
     max_latitude: 41.09882270000001
     max_longitude: 49.1377259
-  name: Siyäzän
+  name: Siazan
 SKR:
   unofficial_names: Sämkir
   translations:
@@ -682,7 +682,7 @@ SKR:
     min_longitude: 45.713568
     max_latitude: 41.129959
     max_longitude: 46.323192
-  name: Sämkir
+  name: Shamkir
 SM:
   unofficial_names: Sumqayit
   translations:
@@ -706,7 +706,7 @@ SMI:
     min_longitude: 48.6082792
     max_latitude: 40.6541736
     max_longitude: 48.6714078
-  name: Samaxi
+  name: Shamakhi
 SMX:
   unofficial_names: Samux
   translations:
@@ -718,7 +718,7 @@ SMX:
     min_longitude: 46.3920022
     max_latitude: 40.7820362
     max_longitude: 46.42375939999999
-  name: Samux
+  name: Samukh
 SS:
   unofficial_names: Susa City
   translations:
@@ -742,7 +742,7 @@ SUS:
     min_longitude: 46.7307758
     max_latitude: 39.7725926
     max_longitude: 46.765623
-  name: Susa
+  name: Shusha
 TAR:
   unofficial_names: Tärtär
   translations:
@@ -754,7 +754,7 @@ TAR:
     min_longitude: 46.9110202
     max_latitude: 40.3576638
     max_longitude: 46.96801199999999
-  name: Tärtär
+  name: Tartar
 TOV:
   unofficial_names: Tovuz
   translations:
@@ -778,7 +778,7 @@ UCA:
     min_longitude: 47.6283074
     max_latitude: 40.5296863
     max_longitude: 47.6742697
-  name: Ucar
+  name: Ujar
 XA:
   unofficial_names: Xankändi
   translations:
@@ -790,7 +790,7 @@ XA:
     min_longitude: 46.7298317
     max_latitude: 39.8520223
     max_longitude: 46.7890549
-  name: Xankändi
+  name: Stepanakert
 XAC:
   unofficial_names: Xaçmaz
   translations:
@@ -802,7 +802,7 @@ XAC:
     min_longitude: 48.774619
     max_latitude: 41.4863344
     max_longitude: 48.8417817
-  name: Xaçmaz
+  name: Khachmaz
 XAN:
   unofficial_names: Xanlar
   translations:
@@ -826,7 +826,7 @@ XCI:
     min_longitude: 46.770262
     max_latitude: 39.9206634
     max_longitude: 46.8147892
-  name: Xocali
+  name: Khojali
 XIZ:
   unofficial_names: Xizi
   translations:
@@ -838,7 +838,7 @@ XIZ:
     min_longitude: 49.0516375
     max_latitude: 40.9251219
     max_longitude: 49.0894889
-  name: Xizi
+  name: Khizi
 XVD:
   unofficial_names: Xocavänd
   translations:
@@ -850,7 +850,7 @@ XVD:
     min_longitude: 46.63206090000001
     max_latitude: 39.883672
     max_longitude: 47.345414
-  name: Xocavänd
+  name: Khojavend
 YAR:
   unofficial_names: Yardimli
   translations:
@@ -862,7 +862,7 @@ YAR:
     min_longitude: 48.2148314
     max_latitude: 38.9156798
     max_longitude: 48.2865858
-  name: Yardimli
+  name: Yardymli
 YE:
   unofficial_names: Yevlax City
   translations:
@@ -874,7 +874,7 @@ YE:
     min_longitude: 47.1098042
     max_latitude: 40.6331705
     max_longitude: 47.1835326
-  name: Yevlax City
+  name: Yevlakh
 YEV:
   unofficial_names: Yevlax
   translations:
@@ -886,7 +886,7 @@ YEV:
     min_longitude: 47.1098042
     max_latitude: 40.6331705
     max_longitude: 47.1835326
-  name: Yevlax
+  name: Yevlakh District
 ZAN:
   unofficial_names: Zängilan
   translations:
@@ -898,7 +898,7 @@ ZAN:
     min_longitude: 46.43833900000001
     max_latitude: 39.224588
     max_longitude: 46.8760261
-  name: Zängilan
+  name: Zangilan
 ZAQ:
   unofficial_names: Zaqatala
   translations:
@@ -922,4 +922,4 @@ ZAR:
     min_longitude: 47.6942681
     max_latitude: 40.2448614
     max_longitude: 47.73121829999999
-  name: Zärdab
+  name: Zardab

--- a/lib/countries/data/subdivisions/BA.yaml
+++ b/lib/countries/data/subdivisions/BA.yaml
@@ -10,7 +10,7 @@ BIH:
     min_longitude: 15.7237473
     max_latitude: 45.2271323
     max_longitude: 19.0392512
-  name: Federacija Bosna i Hercegovina
+  name: Federation of Bosnia and Herzegovina
 SRP:
   unofficial_names: Republika Srpska
   translations:

--- a/lib/countries/data/subdivisions/BB.yaml
+++ b/lib/countries/data/subdivisions/BB.yaml
@@ -83,7 +83,7 @@
     max_latitude: 13.3350319
     max_longitude: -59.57436509999999
   name: Saint Lucy
-08:
+'08':
   unofficial_names: Saint Michael
   translations:
     en: Saint Michael
@@ -95,7 +95,7 @@
     max_latitude: 13.158466
     max_longitude: -59.567387
   name: Saint Michael
-09:
+'09':
   unofficial_names: Saint Peter
   translations:
     en: Saint Peter

--- a/lib/countries/data/subdivisions/BD.yaml
+++ b/lib/countries/data/subdivisions/BD.yaml
@@ -11,7 +11,7 @@
     min_longitude: 92.06628789999999
     max_latitude: 22.3738885
     max_longitude: 92.6736258
-  name: Bandarban zila
+  name: Bandarban
 '02':
   unofficial_names: Barguna zila
   translations:
@@ -23,7 +23,7 @@
     min_longitude: 89.9018097
     max_latitude: 22.4833355
     max_longitude: 90.3753377
-  name: Barguna zila
+  name: Barguna
 '03':
   unofficial_names:
   - Bogora
@@ -38,7 +38,7 @@
     min_longitude: 89.37668409999999
     max_latitude: 24.8477604
     max_longitude: 89.3775746
-  name: Bogra zila
+  name: Bogra
 '04':
   unofficial_names:
   - Brahman Bariya
@@ -52,7 +52,7 @@
     min_longitude: 90.7208058
     max_latitude: 24.2700489
     max_longitude: 91.329775
-  name: Brahmanbaria zila
+  name: Brahmanbaria
 '05':
   unofficial_names:
   - Bagarhat
@@ -69,7 +69,7 @@
     min_longitude: 89.5296264
     max_latitude: 22.9821798
     max_longitude: 89.9644057
-  name: Bagerhat zila
+  name: Bagerhat
 '06':
   unofficial_names:
   - Barisal
@@ -82,7 +82,7 @@
     min_longitude: 90.01811029999999
     max_latitude: 23.0715591
     max_longitude: 90.6517982
-  name: Barisal zila
+  name: Barisal Division
 '07':
   unofficial_names:
   - Bhola
@@ -95,8 +95,8 @@
     min_longitude: 90.64671279999999
     max_latitude: 22.6855212
     max_longitude: 90.64759780000001
-  name: Bhola zila
-08:
+  name: Bhola
+'08':
   unofficial_names:
   - Comilla
   - Komilla
@@ -109,8 +109,8 @@
     min_longitude: 91.1800995
     max_latitude: 23.4636252
     max_longitude: 91.18206289999999
-  name: Comilla zila
-09:
+  name: Comilla
+'09':
   unofficial_names:
   - Chandipur
   - Chandpur
@@ -123,7 +123,7 @@
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Chandpur zila
+  name: Chandpur
 '10':
   unofficial_names:
   - Chattagam
@@ -137,7 +137,7 @@
     min_longitude: 91.8367609
     max_latitude: 22.3421259
     max_longitude: 91.8377062
-  name: Chittagong zila
+  name: Chittagong
 '11':
   unofficial_names:
   - Coxʿs Bazar
@@ -151,7 +151,7 @@
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Cox's Bazar zila
+  name: Cox’s Bazar
 '12':
   unofficial_names:
   - Chuadanga
@@ -164,7 +164,7 @@
     min_longitude: 88.62422
     max_latitude: 23.839448
     max_longitude: 89.0196419
-  name: Chuadanga zila
+  name: Chuadanga
 '13':
   unofficial_names:
   - Dacca
@@ -179,7 +179,7 @@
     min_longitude: 89.312214
     max_latitude: 25.409475
     max_longitude: 91.276907
-  name: Dhaka zila
+  name: Dhaka
 '14':
   unofficial_names:
   - Dinajpur
@@ -192,7 +192,7 @@
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Dinajpur zila
+  name: Dinajpur
 '15':
   unofficial_names:
   - Faridpur
@@ -205,7 +205,7 @@
     min_longitude: 89.84295929999999
     max_latitude: 23.6090422
     max_longitude: 89.84357089999999
-  name: Faridpur zila
+  name: Faridpur
 '16':
   unofficial_names:
   - Feni
@@ -218,7 +218,7 @@
     min_longitude: 91.2493516
     max_latitude: 23.2796693
     max_longitude: 91.5834905
-  name: Feni zila
+  name: Feni
 '17':
   unofficial_names:
   - Gopalganj
@@ -231,7 +231,7 @@
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Gopalganj zila
+  name: Gopalganj
 '18':
   unofficial_names:
   - Gajipur
@@ -244,7 +244,7 @@
     min_longitude: 90.15131939999999
     max_latitude: 24.3391985
     max_longitude: 90.7003785
-  name: Gazipur zila
+  name: Gazipur
 '19':
   unofficial_names:
   - Gaibanda
@@ -261,7 +261,7 @@
     min_longitude: 89.18460850000001
     max_latitude: 25.6440024
     max_longitude: 89.7584724
-  name: Gaibandha zila
+  name: Gaibandha
 '20':
   unofficial_names:
   - Habiganj
@@ -276,7 +276,7 @@
     min_longitude: 91.41626819999999
     max_latitude: 24.3734684
     max_longitude: 91.41687689999999
-  name: Habiganj zila
+  name: Habiganj
 '21':
   unofficial_names:
   - Jamalpur
@@ -289,7 +289,7 @@
     min_longitude: 89.93349189999999
     max_latitude: 24.9386408
     max_longitude: 89.9348223
-  name: Jamalpur zila
+  name: Jamalpur
 '22':
   unofficial_names:
   - Jessore
@@ -303,7 +303,7 @@
     min_longitude: 88.8516283
     max_latitude: 23.3734594
     max_longitude: 89.5698166
-  name: Jessore zila
+  name: Jessore
 '23':
   unofficial_names:
   - Jhanaydah
@@ -320,7 +320,7 @@
     min_longitude: 88.6967468
     max_latitude: 23.7696749
     max_longitude: 89.3786287
-  name: Jhenaidah zila
+  name: Jhenaidah
 '24':
   unofficial_names:
   - Jaipur Hat
@@ -335,7 +335,7 @@
     min_longitude: 88.9223099
     max_latitude: 25.2799365
     max_longitude: 89.2781638
-  name: Jaipurhat zila
+  name: Joypurhat
 '25':
   unofficial_names:
   - Jhalakati
@@ -349,7 +349,7 @@
     min_longitude: 90.0208569
     max_latitude: 22.7844511
     max_longitude: 90.39070129999999
-  name: Jhalakati zila
+  name: Jhalokati
 '26':
   unofficial_names:
   - Kishoreganj
@@ -362,7 +362,7 @@
     min_longitude: 90.57661069999999
     max_latitude: 24.6345348
     max_longitude: 91.2555313
-  name: Kishoreganj zila
+  name: Kishoreganj
 '27':
   unofficial_names:
   - Khulna
@@ -375,7 +375,7 @@
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Khulna zila
+  name: Khulna
 '28':
   unofficial_names:
   - Kurigram
@@ -388,7 +388,7 @@
     min_longitude: 89.458022
     max_latitude: 26.2355339
     max_longitude: 89.8903942
-  name: Kurigram zila
+  name: Kurigram
 '29':
   unofficial_names: Khagrachari zila
   translations:
@@ -400,7 +400,7 @@
     min_longitude: 91.7165709
     max_latitude: 23.7311798
     max_longitude: 92.17374799999999
-  name: Khagrachari zila
+  name: Khagrachari
 '30':
   unofficial_names:
   - Kushtia
@@ -414,7 +414,7 @@
     min_longitude: 88.6941719
     max_latitude: 24.2097079
     max_longitude: 89.3705176
-  name: Kushtia zila
+  name: Kushtia
 '31':
   unofficial_names:
   - Lakshmipur
@@ -428,7 +428,7 @@
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Lakshmipur zila
+  name: Lakshmipur
 '32':
   unofficial_names:
   - Lalmanir Hat
@@ -442,7 +442,7 @@
     min_longitude: 88.9110662
     max_latitude: 26.4629664
     max_longitude: 89.56303609999999
-  name: Lalmonirhat zila
+  name: Lalmonirhat
 '33':
   unofficial_names:
   - Manikganj
@@ -455,7 +455,7 @@
     min_longitude: 89.6924686
     max_latitude: 24.0301595
     max_longitude: 90.25637619999999
-  name: Manikganj zila
+  name: Manikganj
 '34':
   unofficial_names:
   - Mymensingh
@@ -470,7 +470,7 @@
     min_longitude: 90.08703229999999
     max_latitude: 25.1973305
     max_longitude: 90.81951149999999
-  name: Mymensingh zila
+  name: Mymensingh
 '35':
   unofficial_names: Munshiganj zila
   translations:
@@ -482,7 +482,7 @@
     min_longitude: 90.1798152
     max_latitude: 23.6743985
     max_longitude: 90.71299549999999
-  name: Munshiganj zila
+  name: Munshiganj
 '36':
   unofficial_names:
   - Madaripur
@@ -495,7 +495,7 @@
     min_longitude: 90.2048202
     max_latitude: 23.1668738
     max_longitude: 90.20507769999999
-  name: Madaripur zila
+  name: Madaripur
 '37':
   unofficial_names:
   - Magura
@@ -508,7 +508,7 @@
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Magura zila
+  name: Magura
 '38':
   unofficial_names:
   - Maulvi Bazar
@@ -522,7 +522,7 @@
     min_longitude: 91.59713760000001
     max_latitude: 24.8346482
     max_longitude: 92.29768759999999
-  name: Moulvibazar zila
+  name: Maulvi Bazar
 '39':
   unofficial_names: Meherpur zila
   translations:
@@ -534,7 +534,7 @@
     min_longitude: 88.5595894
     max_latitude: 23.978685
     max_longitude: 88.8895656
-  name: Meherpur zila
+  name: Meherpur
 '40':
   unofficial_names:
   - Narayanganj
@@ -547,7 +547,7 @@
     min_longitude: 90.4319429
     max_latitude: 23.9584895
     max_longitude: 90.757885
-  name: Narayanganj zila
+  name: Narayanganj
 '41':
   unofficial_names:
   - Netrakona
@@ -561,7 +561,7 @@
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Netrakona zila
+  name: Netrokona
 '42':
   unofficial_names:
   - Narsinghdi
@@ -574,7 +574,7 @@
     min_longitude: 90.56034559999999
     max_latitude: 24.2503296
     max_longitude: 90.9857498
-  name: Narsingdi zila
+  name: Narsingdi
 '43':
   unofficial_names:
   - Narail
@@ -588,7 +588,7 @@
     min_longitude: 89.37712669999999
     max_latitude: 23.3145922
     max_longitude: 89.7925473
-  name: Narail zila
+  name: Narail
 '44':
   unofficial_names:
   - Nator
@@ -602,7 +602,7 @@
     min_longitude: 88.84579169999999
     max_latitude: 24.6554422
     max_longitude: 89.3405628
-  name: Natore zila
+  name: Natore
 '45':
   unofficial_names:
   - Nawabganj
@@ -616,7 +616,7 @@
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Nawabganj zila
+  name: Nawabganj
 '46':
   unofficial_names:
   - Nilphamari
@@ -629,7 +629,7 @@
     min_longitude: 88.7379457
     max_latitude: 26.3130356
     max_longitude: 89.1966248
-  name: Nilphamari zila
+  name: Nilphamari
 '47':
   unofficial_names:
   - Noakhali
@@ -642,7 +642,7 @@
     min_longitude: 90.8422743
     max_latitude: 23.1329408
     max_longitude: 91.4192964
-  name: Noakhali zila
+  name: Noakhali
 '48':
   unofficial_names:
   - Naogaon
@@ -656,7 +656,7 @@
     min_longitude: 88.94079579999999
     max_latitude: 24.8134302
     max_longitude: 88.94238349999999
-  name: Naogaon zila
+  name: Naogaon
 '49':
   unofficial_names:
   - Pabna
@@ -669,7 +669,7 @@
     min_longitude: 89.23269499999999
     max_latitude: 24.0029743
     max_longitude: 89.2340201
-  name: Pabna zila
+  name: Pabna
 '50':
   unofficial_names:
   - Perojpur
@@ -683,7 +683,7 @@
     min_longitude: 88.1259999
     max_latitude: 25.6812
     max_longitude: 88.1489501
-  name: Pirojpur zila
+  name: Pirojpur
 '51':
   unofficial_names:
   - Patukhali
@@ -696,7 +696,7 @@
     min_longitude: 90.0830841
     max_latitude: 22.6105247
     max_longitude: 90.66673279999999
-  name: Patuakhali zila
+  name: Patuakhali
 '52':
   unofficial_names: Panchagarh zila
   translations:
@@ -708,7 +708,7 @@
     min_longitude: 88.5441398
     max_latitude: 26.3444988
     max_longitude: 88.5685159
-  name: Panchagarh zila
+  name: Panchagarh
 '53':
   unofficial_names:
   - Rajbari
@@ -721,7 +721,7 @@
     min_longitude: 89.2988491
     max_latitude: 23.908124
     max_longitude: 89.8695803
-  name: Rajbari zila
+  name: Rajbari
 '54':
   unofficial_names:
   - Rajshahi
@@ -735,7 +735,7 @@
     min_longitude: 88.9815109
     max_latitude: 24.4145705
     max_longitude: 88.9830614
-  name: Rajshahi zila
+  name: Rajshahi
 '55':
   unofficial_names:
   - Rangpur
@@ -748,7 +748,7 @@
     min_longitude: 89.2431368
     max_latitude: 25.758965
     max_longitude: 89.2436118
-  name: Rangpur zila
+  name: Rangpur
 '56':
   unofficial_names:
   - Rangamati
@@ -761,7 +761,7 @@
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Rangamati zila
+  name: Rangamati Hill
 '57':
   unofficial_names:
   - Sherpur
@@ -774,7 +774,7 @@
     min_longitude: 89.8807812
     max_latitude: 25.3026742
     max_longitude: 90.3096772
-  name: Sherpur zila
+  name: Sherpur
 '58':
   unofficial_names:
   - Satkhira
@@ -787,7 +787,7 @@
     min_longitude: 88.90323389999999
     max_latitude: 22.9491463
     max_longitude: 89.3596172
-  name: Satkhira zila
+  name: Satkhira
 '59':
   unofficial_names:
   - Serajgonj
@@ -801,7 +801,7 @@
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Sirajganj zila
+  name: Sirajganj
 '60':
   unofficial_names:
   - Silhat
@@ -815,7 +815,7 @@
     min_longitude: 91.8633924
     max_latitude: 24.8905095
     max_longitude: 91.864036
-  name: Sylhet zila
+  name: Sylhet
 '61':
   unofficial_names:
   - Shunamganj
@@ -829,7 +829,7 @@
     min_longitude: 90.93542579999999
     max_latitude: 25.2041646
     max_longitude: 91.739831
-  name: Sunamganj zila
+  name: Sunamganj
 '62':
   unofficial_names:
   - Shariatpur
@@ -842,7 +842,7 @@
     min_longitude: 90.2019596
     max_latitude: 23.4635612
     max_longitude: 90.6138611
-  name: Shariatpur zila
+  name: Shariatpur
 '63':
   unofficial_names:
   - Tangail
@@ -856,7 +856,7 @@
     min_longitude: 89.9137585
     max_latitude: 24.2642256
     max_longitude: 89.9231774
-  name: Tangail zila
+  name: Tangail
 '64':
   unofficial_names:
   - Thakurgaon
@@ -869,4 +869,4 @@
     min_longitude: 88.0882072
     max_latitude: 26.2147449
     max_longitude: 88.64207259999999
-  name: Thakurgaon zila
+  name: Thakurgaon

--- a/lib/countries/data/subdivisions/BE.yaml
+++ b/lib/countries/data/subdivisions/BE.yaml
@@ -29,7 +29,7 @@ VAN:
     min_longitude: 4.217600099999999
     max_latitude: 51.3774301
     max_longitude: 4.49784
-  name: Antwerpen (nl)
+  name: Antwerp
 VBR:
   unofficial_names:
   - Brabant-Vlanderen
@@ -45,7 +45,7 @@ VBR:
     min_longitude: 5.6001346
     max_latitude: 51.378742
     max_longitude: 5.625843
-  name: Vlaams Brabant (nl)
+  name: Flemish Brabant
 VLI:
   unofficial_names:
   - Limbourg
@@ -58,7 +58,7 @@ VLI:
     min_longitude: 5.5660666
     max_latitude: 51.778577
     max_longitude: 6.226801399999999
-  name: Limburg (nl)
+  name: Limburg
 VOV:
   unofficial_names:
   - Oos-Vlanderen
@@ -74,7 +74,7 @@ VOV:
     min_longitude: 3.3312501
     max_latitude: 51.35284
     max_longitude: 4.3301
-  name: Oost-Vlaanderen (nl)
+  name: East Flanders
 VWV:
   unofficial_names:
   - Wes-Vlanderen
@@ -90,7 +90,7 @@ VWV:
     min_longitude: 2.5449401
     max_latitude: 51.3685479
     max_longitude: 3.5232999
-  name: West-Vlaanderen (nl)
+  name: West Flanders
 WBR:
   unofficial_names:
   - Waals-Brabant
@@ -105,7 +105,7 @@ WBR:
     min_longitude: 4.0911501
     max_latitude: 50.80735
     max_longitude: 5.02037
-  name: Brabant Wallon (fr)
+  name: Walloon Brabant
 WHT:
   unofficial_names:
   - Henegouwen
@@ -119,7 +119,7 @@ WHT:
     min_longitude: 2.8421299
     max_latitude: 50.81077
     max_longitude: 4.6171299
-  name: Hainaut (fr)
+  name: Hainaut
 WLG:
   unofficial_names:
   - Luik
@@ -133,7 +133,7 @@ WLG:
     min_longitude: 5.5230701
     max_latitude: 50.68819
     max_longitude: 5.675110099999999
-  name: Liège (fr)
+  name: Liège
 WLX:
   unofficial_names:
   - Luxembourg
@@ -147,7 +147,7 @@ WLX:
     min_longitude: 4.9683901
     max_latitude: 50.4306101
     max_longitude: 6.034400000000001
-  name: Luxembourg (fr)
+  name: Luxembourg
 WNA:
   unofficial_names:
   - Namen
@@ -160,4 +160,4 @@ WNA:
     min_longitude: 4.7229
     max_latitude: 50.5312201
     max_longitude: 4.98398
-  name: Namur (fr)
+  name: Namur

--- a/lib/countries/data/subdivisions/BF.yaml
+++ b/lib/countries/data/subdivisions/BF.yaml
@@ -482,7 +482,7 @@ TUI:
     min_longitude: -3.9798661
     max_latitude: 11.8717401
     max_longitude: -2.831935
-  name: Tui
+  name: Tuy
 YAG:
   unofficial_names: Yagha
   translations:

--- a/lib/countries/data/subdivisions/BG.yaml
+++ b/lib/countries/data/subdivisions/BG.yaml
@@ -83,7 +83,7 @@
     max_latitude: 42.9150995
     max_longitude: 25.3884394
   name: Gabrovo
-08:
+'08':
   unofficial_names: Dobrich
   translations:
     en: Dobrich
@@ -95,7 +95,7 @@
     max_latitude: 43.608704
     max_longitude: 27.8607443
   name: Dobrich
-09:
+'09':
   unofficial_names: Kardzhali
   translations:
     en: Kardzhali
@@ -118,7 +118,7 @@
     min_longitude: 22.6594581
     max_latitude: 42.3022897
     max_longitude: 22.7273332
-  name: Kjustendil
+  name: Kyustendil
 '11':
   unofficial_names: Lovech
   translations:
@@ -262,7 +262,7 @@
     min_longitude: 23.1909885
     max_latitude: 42.7877752
     max_longitude: 23.4569049
-  name: Sofia-Grad
+  name: Sofia
 '23':
   unofficial_names: Sofia
   translations:
@@ -274,7 +274,7 @@
     min_longitude: 23.1909885
     max_latitude: 42.7877752
     max_longitude: 23.4569049
-  name: Sofia
+  name: Sofia District
 '24':
   unofficial_names: Stara Zagora
   translations:
@@ -322,7 +322,7 @@
     min_longitude: 26.8972271
     max_latitude: 43.3144123
     max_longitude: 27.0506347
-  name: Šumen
+  name: Shumen
 '28':
   unofficial_names: Yambol
   translations:

--- a/lib/countries/data/subdivisions/BH.yaml
+++ b/lib/countries/data/subdivisions/BH.yaml
@@ -15,7 +15,7 @@
     min_longitude: 50.51370679999999
     max_latitude: 26.247324
     max_longitude: 50.6259022
-  name: Al Manamah (Al ‘Asimah)
+  name: Capital
 '14':
   unofficial_names:
   - Eastern
@@ -33,7 +33,7 @@
     min_longitude: 50.4545967
     max_latitude: 26.138158
     max_longitude: 50.8223101
-  name: Al Janubiyah
+  name: Southern
 '15':
   unofficial_names: Al Muharraq
   translations:
@@ -45,7 +45,7 @@
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Al Muharraq
+  name: Muharraq
 '16':
   unofficial_names:
   - Central
@@ -59,7 +59,7 @@
     min_longitude: 50.5095921
     max_latitude: 26.1932879
     max_longitude: 50.671664
-  name: Al Wustá
+  name: Central
 '17':
   unofficial_names:
   - Northern
@@ -74,4 +74,4 @@
     min_longitude: 50.3788254
     max_latitude: 26.235592
     max_longitude: 50.5664624
-  name: Ash Shamaliyah
+  name: Northern

--- a/lib/countries/data/subdivisions/BO.yaml
+++ b/lib/countries/data/subdivisions/BO.yaml
@@ -10,7 +10,7 @@ B:
     min_longitude: -67.54975999999999
     max_latitude: -10.400086
     max_longitude: -61.50248
-  name: El Beni
+  name: Beni
 C:
   unofficial_names: Cochabamba
   translations:

--- a/lib/countries/data/subdivisions/BR.yaml
+++ b/lib/countries/data/subdivisions/BR.yaml
@@ -82,7 +82,7 @@ DF:
     min_longitude: -48.2870947
     max_latitude: -15.5001712
     max_longitude: -47.3081926
-  name: Distrito Federal
+  name: Federal District
 ES:
   unofficial_names: Espírito Santo
   translations:

--- a/lib/countries/data/subdivisions/BT.yaml
+++ b/lib/countries/data/subdivisions/BT.yaml
@@ -27,7 +27,7 @@
     min_longitude: 89.5604609
     max_latitude: 27.0611895
     max_longitude: 89.5806313
-  name: Chhukha
+  name: Chukha
 '13':
   unofficial_names:
   - Ha
@@ -41,7 +41,7 @@
     min_longitude: 88.89505199999999
     max_latitude: 27.6211449
     max_longitude: 89.39598099999999
-  name: Ha
+  name: Haa
 '14':
   unofficial_names:
   - Samchi
@@ -213,7 +213,7 @@
     min_longitude: 91.23415949999999
     max_latitude: 27.280493
     max_longitude: 91.2454034
-  name: Monggar
+  name: Mongar
 '43':
   unofficial_names:
   - Pema Gatshel
@@ -243,7 +243,7 @@
     min_longitude: 91.1688424
     max_latitude: 27.677438
     max_longitude: 91.1892156
-  name: Lhuentse
+  name: Lhuntse
 '45':
   unofficial_names:
   - Samdruk Jongkhar
@@ -258,7 +258,7 @@
     min_longitude: 90.995525
     max_latitude: 27.2464701
     max_longitude: 92.1221539
-  name: Samdrup Jongkha
+  name: Samdrup Jongkhar
 GA:
   unofficial_names:
   - Gaza
@@ -284,4 +284,4 @@ TY:
     min_longitude: 91.31767270000002
     max_latitude: 28.050773
     max_longitude: 91.73789980000001
-  name: Trashi Yangtse
+  name: Trashiyangtse

--- a/lib/countries/data/subdivisions/BW.yaml
+++ b/lib/countries/data/subdivisions/BW.yaml
@@ -72,7 +72,7 @@ NE:
     min_longitude: 27.2119901
     max_latitude: -20.473381
     max_longitude: 28.013578
-  name: North-East
+  name: North East
 NW:
   unofficial_names: North-West
   translations:
@@ -84,7 +84,7 @@ NW:
     min_longitude: 20.9969499
     max_latitude: -17.780813
     max_longitude: 25.9879499
-  name: North-West
+  name: North West
 SE:
   unofficial_names: South-East
   translations:
@@ -96,7 +96,7 @@ SE:
     min_longitude: 25.5438541
     max_latitude: -24.511588
     max_longitude: 26.1813639
-  name: South-East
+  name: South East
 SO:
   unofficial_names: Southern
   translations:

--- a/lib/countries/data/subdivisions/BY.yaml
+++ b/lib/countries/data/subdivisions/BY.yaml
@@ -19,7 +19,7 @@ BR:
     min_longitude: 23.1783377
     max_latitude: 53.4118989
     max_longitude: 27.5825019
-  name: Brestskaya voblasts' (be) Brestskaya oblast' (ru)
+  name: Brest
 HO:
   unofficial_names:
   - Gomel
@@ -39,7 +39,7 @@ HO:
     min_longitude: 27.2441409
     max_latitude: 53.3679551
     max_longitude: 31.7992701
-  name: Homyel'skaya voblasts' (be) Gomel'skaya oblast' (ru)
+  name: Homel
 HR:
   unofficial_names:
   - Gardinas
@@ -59,7 +59,7 @@ HR:
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Hrodzenskaya voblasts' (be) Grodnenskaya oblast' (ru)
+  name: Hrodna
 MA:
   unofficial_names:
   - Mahiljov
@@ -84,7 +84,7 @@ MA:
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Mahilyowskaya voblasts' (be) Mogilevskaya oblast' (ru)
+  name: Magileu
 MI:
   unofficial_names:
   - Minskaja Oblastʿ
@@ -99,7 +99,7 @@ MI:
     min_longitude: 26.06101
     max_latitude: 55.017477
     max_longitude: 29.487841
-  name: Minskaya voblasts' (be) Minskaya oblast' (ru)
+  name: Minsk Region
 VI:
   unofficial_names:
   - Vicebskaja Voblastsʿ
@@ -119,7 +119,7 @@ VI:
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Vitsyebskaya voblasts' (be) Vitebskaya oblast' (ru)
+  name: Vitebsk
 X1~:
   unofficial_names:
   - Gorod Minsk

--- a/lib/countries/data/subdivisions/CD.yaml
+++ b/lib/countries/data/subdivisions/CD.yaml
@@ -60,7 +60,7 @@ KE:
     min_longitude: 21.9100151
     max_latitude: -1.738482
     max_longitude: 26.265937
-  name: Kasai-Oriental
+  name: Kasaï-Oriental
 KN:
   unofficial_names: Kinshasa
   translations:
@@ -84,7 +84,7 @@ KW:
     min_longitude: 19.6801381
     max_latitude: -2.338351
     max_longitude: 23.742881
-  name: Kasai-Occidental
+  name: Kasaï-Occidental
 MA:
   unofficial_names: Maniema
   translations:
@@ -108,7 +108,7 @@ NK:
     min_longitude: 27.201624
     max_latitude: 0.9623669
     max_longitude: 29.984388
-  name: Nord-Kivu
+  name: North Kivu
 OR:
   unofficial_names:
   - Haut-Zaire
@@ -134,4 +134,4 @@ SK:
     min_longitude: 26.798393
     max_latitude: -1.568222
     max_longitude: 29.2644927
-  name: Sud-Kivu
+  name: South Kivu

--- a/lib/countries/data/subdivisions/CF.yaml
+++ b/lib/countries/data/subdivisions/CF.yaml
@@ -150,7 +150,7 @@ MP:
     min_longitude: 16.457023
     max_latitude: 5.965332
     max_longitude: 19.1128831
-  name: Ombella-Mpoko
+  name: Ombella-M’Poko
 NM:
   unofficial_names: Nana-Mambéré
   translations:

--- a/lib/countries/data/subdivisions/CH.yaml
+++ b/lib/countries/data/subdivisions/CH.yaml
@@ -11,7 +11,7 @@ AG:
     min_longitude: 7.713470099999999
     max_latitude: 47.6209201
     max_longitude: 8.455169999999999
-  name: Aargau (de)
+  name: Aargau
 AI:
   unofficial_names: Appenzell Innerrhoden (de)
   translations:
@@ -23,7 +23,7 @@ AI:
     min_longitude: 9.309809999999999
     max_latitude: 47.43874
     max_longitude: 9.617479999999999
-  name: Appenzell Innerrhoden (de)
+  name: Appenzell Innerrhoden
 AR:
   unofficial_names:
   - Appenzell-Ausser Rhoden
@@ -36,7 +36,7 @@ AR:
     min_longitude: 9.1910399
     max_latitude: 47.4690301
     max_longitude: 9.63088
-  name: Appenzell Ausserrhoden (de)
+  name: Appenzell Ausserrhoden
 BE:
   unofficial_names:
   - Berne
@@ -49,7 +49,7 @@ BE:
     min_longitude: 7.294230000000001
     max_latitude: 46.99019
     max_longitude: 7.495510099999999
-  name: Bern (de)
+  name: Bern
 BL:
   unofficial_names:
   - Bâle-Campagne
@@ -62,7 +62,7 @@ BL:
     min_longitude: 7.32527
     max_latitude: 47.56441
     max_longitude: 7.9618001
-  name: Basel-Landschaft (de)
+  name: Basel-Landschaft
 BS:
   unofficial_names:
   - Basel
@@ -79,7 +79,7 @@ BS:
     min_longitude: 7.554819900000001
     max_latitude: 47.5899201
     max_longitude: 7.634099999999999
-  name: Basel-Stadt (de)
+  name: Basel-Stadt
 FR:
   unofficial_names:
   - Freiburg
@@ -92,7 +92,7 @@ FR:
     min_longitude: 7.1357
     max_latitude: 46.82144
     max_longitude: 7.1838299
-  name: Fribourg (fr)
+  name: Fribourg
 GE:
   unofficial_names:
   - Ginevra
@@ -108,7 +108,7 @@ GE:
     min_longitude: 6.1103201
     max_latitude: 46.232399
     max_longitude: 6.177856999999999
-  name: Genève (fr)
+  name: Geneva
 GL:
   unofficial_names:
   - Glaris
@@ -135,7 +135,7 @@ GR:
     min_longitude: 8.6509399
     max_latitude: 47.06496
     max_longitude: 10.4923401
-  name: Graubünden (de)
+  name: Graubünden
 JU:
   unofficial_names: Jura (fr)
   translations:
@@ -147,7 +147,7 @@ JU:
     min_longitude: 6.84042
     max_latitude: 47.50452
     max_longitude: 7.55821
-  name: Jura (fr)
+  name: Jura
 LU:
   unofficial_names:
   - Lucerna
@@ -161,7 +161,7 @@ LU:
     min_longitude: 8.206470099999999
     max_latitude: 47.08349
     max_longitude: 8.358139999999999
-  name: Luzern (de)
+  name: Lucerne
 NE:
   unofficial_names:
   - Neuenburg
@@ -174,7 +174,7 @@ NE:
     min_longitude: 6.893409999999999
     max_latitude: 47.06389
     max_longitude: 6.99177
-  name: Neuchâtel (fr)
+  name: Neuchâtel
 NW:
   unofficial_names:
   - Nidwald
@@ -187,7 +187,7 @@ NW:
     min_longitude: 8.2182101
     max_latitude: 47.0036169
     max_longitude: 8.57489
-  name: Nidwalden (de)
+  name: Nidwalden
 OW:
   unofficial_names:
   - Obwald
@@ -200,7 +200,7 @@ OW:
     min_longitude: 8.042349999999999
     max_latitude: 46.98021
     max_longitude: 8.506639999999999
-  name: Obwalden (de)
+  name: Obwalden
 SG:
   unofficial_names:
   - Saint Galle
@@ -215,7 +215,7 @@ SG:
     min_longitude: 9.29144
     max_latitude: 47.4530299
     max_longitude: 9.4353001
-  name: Sankt Gallen (de)
+  name: St. Gallen
 SH:
   unofficial_names:
   - Schaffhouse
@@ -228,7 +228,7 @@ SH:
     min_longitude: 8.585830099999999
     max_latitude: 47.74462
     max_longitude: 8.7058599
-  name: Schaffhausen (de)
+  name: Schaffhausen
 SO:
   unofficial_names:
   - Soleure
@@ -241,7 +241,7 @@ SO:
     min_longitude: 7.50923
     max_latitude: 47.22025
     max_longitude: 7.552230000000001
-  name: Solothurn (de)
+  name: Solothurn
 SZ:
   unofficial_names: Schwyz (de)
   translations:
@@ -253,7 +253,7 @@ SZ:
     min_longitude: 8.60339
     max_latitude: 47.06635
     max_longitude: 8.7787901
-  name: Schwyz (de)
+  name: Schwyz
 TG:
   unofficial_names:
   - Thurgovie
@@ -266,7 +266,7 @@ TG:
     min_longitude: 8.66793
     max_latitude: 47.6954101
     max_longitude: 9.4764901
-  name: Thurgau (de)
+  name: Thurgau
 TI:
   unofficial_names:
   - Tessin
@@ -280,7 +280,7 @@ TI:
     min_longitude: 8.38218
     max_latitude: 46.63241
     max_longitude: 9.159730000000001
-  name: Ticino (it)
+  name: Ticino
 UR:
   unofficial_names: Uri (de)
   translations:
@@ -292,7 +292,7 @@ UR:
     min_longitude: 8.397459999999999
     max_latitude: 46.9880412
     max_longitude: 8.95788
-  name: Uri (de)
+  name: Uri
 VD:
   unofficial_names:
   - Waadt
@@ -305,7 +305,7 @@ VD:
     min_longitude: 6.06401
     max_latitude: 46.98170229999999
     max_longitude: 7.2492599
-  name: Vaud (fr)
+  name: Vaud
 VS:
   unofficial_names:
   - Vallese
@@ -319,7 +319,7 @@ VS:
     min_longitude: 6.77046
     max_latitude: 46.6539699
     max_longitude: 8.4785401
-  name: Valais (fr)
+  name: Valais
 ZG:
   unofficial_names:
   - Zoug
@@ -332,7 +332,7 @@ ZG:
     min_longitude: 8.4754
     max_latitude: 47.18973
     max_longitude: 8.55844
-  name: Zug (de)
+  name: Zug
 ZH:
   unofficial_names:
   - Zurigo
@@ -347,4 +347,4 @@ ZH:
     min_longitude: 8.448059899999999
     max_latitude: 47.43468
     max_longitude: 8.6253701
-  name: Zürich (de)
+  name: Zürich

--- a/lib/countries/data/subdivisions/CI.yaml
+++ b/lib/countries/data/subdivisions/CI.yaml
@@ -10,7 +10,7 @@
     min_longitude: -5.451649
     max_latitude: 6.385650900000001
     max_longitude: -3.4372559
-  name: Lagunes (Région des)
+  name: Lagunes
 '02':
   unofficial_names: Haut-Sassandra (Région du)
   translations:
@@ -22,7 +22,7 @@
     min_longitude: -7.0862301
     max_latitude: 7.791552
     max_longitude: -5.9337941
-  name: Haut-Sassandra (Région du)
+  name: Haut-Sassandra
 '03':
   unofficial_names: Savanes (Région des)
   translations:
@@ -34,7 +34,7 @@
     min_longitude: -6.9397169
     max_latitude: 10.736642
     max_longitude: -3.781528999999999
-  name: Savanes (Région des)
+  name: Savanes
 '04':
   unofficial_names: Vallée du Bandama (Région de la)
   translations:
@@ -46,7 +46,7 @@
     min_longitude: -5.787452
     max_latitude: 9.3980309
     max_longitude: -3.90265
-  name: Vallée du Bandama (Région de la)
+  name: Vallée du Bandama
 '05':
   unofficial_names: Moyen-Comoé (Région du)
   translations:
@@ -58,7 +58,7 @@
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Moyen-Comoé (Région du)
+  name: Moyen-Comoé
 '06':
   unofficial_names: 18 Montagnes (Région des)
   translations:
@@ -70,7 +70,7 @@
     min_longitude: -8.472178999999999
     max_latitude: 8.1423519
     max_longitude: -6.978052
-  name: 18 Montagnes (Région des)
+  name: Dix-Huit Montagnes
 '07':
   unofficial_names: Lacs (Région des)
   translations:
@@ -82,8 +82,8 @@
     min_longitude: -5.6588403
     max_latitude: 7.549774999999999
     max_longitude: -4.618317999999999
-  name: Lacs (Région des)
-08:
+  name: Lacs
+'08':
   unofficial_names: Zanzan (Région du)
   translations:
     en: Zanzan (Région du)
@@ -94,8 +94,8 @@
     min_longitude: -4.318694
     max_latitude: 9.957134100000001
     max_longitude: -2.494897
-  name: Zanzan (Région du)
-09:
+  name: Zanzan
+'09':
   unofficial_names: Bas-Sassandra (Région du)
   translations:
     en: Bas-Sassandra (Région du)
@@ -106,7 +106,7 @@
     min_longitude: -6.5960402
     max_latitude: 5.784246899999999
     max_longitude: -6.5954098
-  name: Bas-Sassandra (Région du)
+  name: Bas-Sassandra
 '10':
   unofficial_names: Denguélé (Région du)
   translations:
@@ -118,7 +118,7 @@
     min_longitude: -8.1668441
     max_latitude: 10.4881189
     max_longitude: -6.570768999999999
-  name: Denguélé (Région du)
+  name: Denguélé
 '11':
   unofficial_names: Nzi-Comoé (Région)
   translations:
@@ -130,7 +130,7 @@
     min_longitude: -4.976705
     max_latitude: 8.0401179
     max_longitude: -3.5027291
-  name: Nzi-Comoé (Région)
+  name: N’zi-Comoé
 '12':
   unofficial_names: Marahoué (Région de la)
   translations:
@@ -142,7 +142,7 @@
     min_longitude: -6.4365789
     max_latitude: 7.743432100000001
     max_longitude: -5.4057449
-  name: Marahoué (Région de la)
+  name: Marahoué
 '13':
   unofficial_names: Sud-Comoé (Région du)
   translations:
@@ -154,7 +154,7 @@
     min_longitude: -3.806113099999999
     max_latitude: 6.244889
     max_longitude: -2.72626
-  name: Sud-Comoé (Région du)
+  name: Sud-Comoé
 '14':
   unofficial_names: Worodougou (Région du)
   translations:
@@ -166,7 +166,7 @@
     min_longitude: -7.2327379
     max_latitude: 9.213116099999999
     max_longitude: -5.3440999
-  name: Worodougou (Région du)
+  name: Worodougou
 '15':
   unofficial_names: Sud-Bandama (Région du)
   translations:
@@ -178,7 +178,7 @@
     min_longitude: -6.0445639
     max_latitude: 6.2457021
     max_longitude: -4.917968999999999
-  name: Sud-Bandama (Région du)
+  name: Sud-Bandama
 '16':
   unofficial_names: Agnébi (Région de l')
   translations:
@@ -190,7 +190,7 @@
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Agnébi (Région de l')
+  name: Agnéby
 '17':
   unofficial_names: Bafing (Région du)
   translations:
@@ -202,7 +202,7 @@
     min_longitude: -8.248766999999999
     max_latitude: 9.082188
     max_longitude: -7.065940899999999
-  name: Bafing (Région du)
+  name: Bafing
 '18':
   unofficial_names: Fromager (Région du)
   translations:
@@ -214,7 +214,7 @@
     min_longitude: -6.4061419
     max_latitude: 6.6425311
     max_longitude: -5.204736
-  name: Fromager (Région du)
+  name: Fromager
 '19':
   unofficial_names: Moyen-Cavally (Région du)
   translations:
@@ -226,4 +226,4 @@
     min_longitude: -8.5993019
     max_latitude: 6.967223
     max_longitude: -6.971871999999999
-  name: Moyen-Cavally (Région du)
+  name: Moyen-Cavally

--- a/lib/countries/data/subdivisions/CL.yaml
+++ b/lib/countries/data/subdivisions/CL.yaml
@@ -12,7 +12,7 @@ AI:
     min_longitude: -75.67981809999999
     max_latitude: -43.6399768
     max_longitude: -71.08750119999999
-  name: Aisén del General Carlos Ibáñez del Campo
+  name: Aysén
 AN:
   unofficial_names: Antofagasta
   translations:
@@ -74,7 +74,7 @@ BI:
     min_longitude: -73.9699354
     max_latitude: -36.0083148
     max_longitude: -70.98831919999999
-  name: Bío-Bío
+  name: Bío Bío
 CO:
   unofficial_names: Coquimbo
   translations:
@@ -101,7 +101,7 @@ LI:
     min_longitude: -72.0717305
     max_latitude: -33.8537682
     max_longitude: -70.0121472
-  name: Libertador General Bernardo O'Higgins
+  name: Libertador General Bernardo O’Higgins
 LL:
   unofficial_names: Los Lagos
   translations:
@@ -138,7 +138,7 @@ MA:
     min_longitude: -75.7296587
     max_latitude: -48.5966006
     max_longitude: -66.4181435
-  name: Magallanes
+  name: Magallanes Region
 ML:
   unofficial_names: Maule
   translations:
@@ -163,7 +163,7 @@ RM:
     min_longitude: -71.7186941
     max_latitude: -32.919451
     max_longitude: -69.7689944
-  name: Región Metropolitana de Santiago
+  name: Santiago Metropolitan
 TA:
   unofficial_names: Tarapacá
   translations:

--- a/lib/countries/data/subdivisions/CM.yaml
+++ b/lib/countries/data/subdivisions/CM.yaml
@@ -11,7 +11,7 @@ AD:
     min_longitude: 11.173742
     max_latitude: 8.1690449
     max_longitude: 15.2492441
-  name: Adamaoua
+  name: Adamawa
 CE:
   unofficial_names: Centre
   translations:
@@ -84,7 +84,7 @@ NW:
     min_longitude: 9.6307759
     max_latitude: 7.1616911
     max_longitude: 11.194967
-  name: North-West
+  name: Northwest
 OU:
   unofficial_names: West
   translations:
@@ -120,4 +120,4 @@ SW:
     min_longitude: 8.4947634
     max_latitude: 6.530783899999999
     max_longitude: 10.15105
-  name: South-West
+  name: Southwest

--- a/lib/countries/data/subdivisions/CN.yaml
+++ b/lib/countries/data/subdivisions/CN.yaml
@@ -62,7 +62,7 @@
     min_longitude: 97.17276269999999
     max_latitude: 53.33717799999999
     max_longitude: 126.0755856
-  name: Nei Mongol (mn)
+  name: Inner Mongolia
 '21':
   unofficial_names: Liaoning
   translations:
@@ -317,7 +317,7 @@
     min_longitude: 78.3955448
     max_latitude: 36.4833345
     max_longitude: 99.116241
-  name: Xizang
+  name: Tibet
 '61':
   unofficial_names: Shaanxi
   translations:
@@ -392,7 +392,7 @@
     min_longitude: 116.7118602
     max_latitude: 26.3836884
     max_longitude: 123.4934282
-  name: Taiwan *
+  name: Taiwan
 '91':
   unofficial_names:
   - Xianggang
@@ -406,7 +406,7 @@
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Xianggang (zh) **
+  name: Hong Kong SAR China
 '92':
   unofficial_names: Aomen (zh) ***
   translations:
@@ -418,4 +418,4 @@
     min_longitude: 4.3130354
     max_latitude: 52.0766395
     max_longitude: 4.313068599999999
-  name: Aomen (zh) ***
+  name: Macau SAR China

--- a/lib/countries/data/subdivisions/CO.yaml
+++ b/lib/countries/data/subdivisions/CO.yaml
@@ -179,7 +179,7 @@ DC:
     min_longitude: -74.45177
     max_latitude: 4.8371
     max_longitude: -73.99631
-  name: Distrito Capital de Bogotá
+  name: Capital District
 GUA:
   unofficial_names: Guainía
   translations:
@@ -335,7 +335,7 @@ SAP:
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: San Andrés, Providencia y Santa Catalina
+  name: San Andrés & Providencia
 SUC:
   unofficial_names: Sucre
   translations:

--- a/lib/countries/data/subdivisions/CU.yaml
+++ b/lib/countries/data/subdivisions/CU.yaml
@@ -34,7 +34,7 @@
     min_longitude: -82.5742877
     max_latitude: 23.1812734
     max_longitude: -82.0911311
-  name: La Habana
+  name: Havana
 '04':
   unofficial_names: Matanzas
   translations:
@@ -83,7 +83,7 @@
     max_latitude: 22.6677195
     max_longitude: -78.92516309999999
   name: Sancti Spíritus
-08:
+'08':
   unofficial_names: Ciego de Ávila
   translations:
     en: Ciego de Ávila
@@ -95,7 +95,7 @@
     max_latitude: 22.6132385
     max_longitude: -78.067293
   name: Ciego de Ávila
-09:
+'09':
   unofficial_names: Camagüey
   translations:
     en: Camagüey

--- a/lib/countries/data/subdivisions/CV.yaml
+++ b/lib/countries/data/subdivisions/CV.yaml
@@ -94,7 +94,7 @@ PA:
     min_longitude: -25.075462
     max_latitude: 17.153166
     max_longitude: -24.967329
-  name: Paúl
+  name: Paul
 PN:
   unofficial_names: Porto Novo
   translations:

--- a/lib/countries/data/subdivisions/CY.yaml
+++ b/lib/countries/data/subdivisions/CY.yaml
@@ -10,7 +10,7 @@
     min_longitude: 33.3186151
     max_latitude: 35.2323172
     max_longitude: 33.4762216
-  name: Lefkosia
+  name: Nicosia
 '02':
   unofficial_names: Lemesos
   translations:
@@ -22,7 +22,7 @@
     min_longitude: 32.986418
     max_latitude: 34.7400842
     max_longitude: 33.0705513
-  name: Lemesos
+  name: Limassol
 '03':
   unofficial_names: Larnaka
   translations:
@@ -34,7 +34,7 @@
     min_longitude: 33.125832
     max_latitude: 35.1124949
     max_longitude: 33.791904
-  name: Larnaka
+  name: Larnaca
 '04':
   unofficial_names: Ammochostos
   translations:
@@ -46,7 +46,7 @@
     min_longitude: 33.8847113
     max_latitude: 35.1608203
     max_longitude: 33.9829874
-  name: Ammochostos
+  name: Famagusta
 '05':
   unofficial_names: Pafos
   translations:
@@ -58,7 +58,7 @@
     min_longitude: 32.3999583
     max_latitude: 34.8011783
     max_longitude: 32.4666024
-  name: Pafos
+  name: Paphos
 '06':
   unofficial_names: Keryneia
   translations:
@@ -70,4 +70,4 @@
     min_longitude: 33.9222729
     max_latitude: 35.072638
     max_longitude: 34.0006899
-  name: Keryneia
+  name: Kyrenia

--- a/lib/countries/data/subdivisions/CZ.yaml
+++ b/lib/countries/data/subdivisions/CZ.yaml
@@ -12,7 +12,7 @@ JC:
     min_longitude: 13.5363203
     max_latitude: 49.6212548
     max_longitude: 15.6041293
-  name: Jihočeský kraj
+  name: South Bohemia
 JM:
   unofficial_names:
   - Brněnský
@@ -25,7 +25,7 @@ JM:
     min_longitude: 15.5424287
     max_latitude: 49.63325469999999
     max_longitude: 17.6458148
-  name: 'Jihomoravský kraj '
+  name: South Moravia
 KA:
   unofficial_names: Karlovarský kraj
   translations:
@@ -37,7 +37,7 @@ KA:
     min_longitude: 12.0906263
     max_latitude: 50.4602991
     max_longitude: 13.3011974
-  name: Karlovarský kraj
+  name: Karlovy Vary Region
 KR:
   unofficial_names: Královéhradecký kraj
   translations:
@@ -49,7 +49,7 @@ KR:
     min_longitude: 15.1051615
     max_latitude: 50.7804396
     max_longitude: 16.5855247
-  name: Královéhradecký kraj
+  name: Hradec Králové Region
 LI:
   unofficial_names: Liberecký kraj
   translations:
@@ -61,7 +61,7 @@ LI:
     min_longitude: 14.3435357
     max_latitude: 51.0231974
     max_longitude: 15.6330293
-  name: Liberecký kraj
+  name: Liberec Region
 MO:
   unofficial_names:
   - Ostravský
@@ -74,7 +74,7 @@ MO:
     min_longitude: 17.1462629
     max_latitude: 50.3279579
     max_longitude: 18.8592548
-  name: Moravskoslezský kraj
+  name: Moravian-Silesia
 OL:
   unofficial_names: Olomoucký kraj
   translations:
@@ -86,7 +86,7 @@ OL:
     min_longitude: 16.7115968
     max_latitude: 50.4494346
     max_longitude: 17.9172214
-  name: Olomoucký kraj
+  name: Olomouc Region
 PA:
   unofficial_names: Pardubický kraj
   translations:
@@ -98,7 +98,7 @@ PA:
     min_longitude: 15.3630765
     max_latitude: 50.20763729999999
     max_longitude: 16.8665452
-  name: Pardubický kraj
+  name: Pardubice Region
 PL:
   unofficial_names: Plzeňský kraj
   translations:
@@ -110,7 +110,7 @@ PL:
     min_longitude: 12.400522
     max_latitude: 50.1033335
     max_longitude: 13.835103
-  name: Plzeňský kraj
+  name: Plzeň Region
 PR:
   unofficial_names:
   - Hlavní město Praha
@@ -126,7 +126,7 @@ PR:
     min_longitude: 14.2244533
     max_latitude: 50.177403
     max_longitude: 14.7067945
-  name: Praha, hlavní město
+  name: Prague
 ST:
   unofficial_names:
   - Central Bohemia
@@ -141,7 +141,7 @@ ST:
     min_longitude: 13.3973366
     max_latitude: 50.6190994
     max_longitude: 15.5345257
-  name: Středočeský kraj
+  name: Central Bohemia
 US:
   unofficial_names: Ústecký kraj
   translations:
@@ -153,7 +153,7 @@ US:
     min_longitude: 12.940246
     max_latitude: 51.0557757
     max_longitude: 14.6528592
-  name: Ústecký kraj
+  name: Ústí nad Labem Region
 VY:
   unofficial_names:
   - Jihlavský
@@ -178,4 +178,4 @@ ZL:
     min_longitude: 17.1108595
     max_latitude: 49.5399786
     max_longitude: 18.4155308
-  name: Zlínský kraj
+  name: Zlín Region

--- a/lib/countries/data/subdivisions/DE.yaml
+++ b/lib/countries/data/subdivisions/DE.yaml
@@ -52,7 +52,7 @@ BY:
     min_longitude: 8.9763497
     max_latitude: 50.5647142
     max_longitude: 13.8396371
-  name: Bayern
+  name: Bavaria
 HB:
   unofficial_names:
   - Brème
@@ -79,7 +79,7 @@ HE:
     min_longitude: 7.7724675
     max_latitude: 51.6575571
     max_longitude: 10.2363207
-  name: Hessen
+  name: Hesse
 HH:
   unofficial_names:
   - Amburgo
@@ -120,7 +120,7 @@ NI:
     min_longitude: 6.6539671
     max_latitude: 53.89221329999999
     max_longitude: 11.5982055
-  name: Niedersachsen
+  name: Lower Saxony
 NW:
   unofficial_names:
   - Nordrhein-Westfalen
@@ -134,7 +134,7 @@ NW:
     min_longitude: 5.8663425
     max_latitude: 52.53146959999999
     max_longitude: 9.461634900000002
-  name: Nordrhein-Westfalen
+  name: North Rhine-Westphalia
 RP:
   unofficial_names:
   - Rheinland-Pfalz
@@ -149,7 +149,7 @@ RP:
     min_longitude: 6.1122659
     max_latitude: 50.9423053
     max_longitude: 8.5083135
-  name: Rheinland-Pfalz
+  name: Rhineland-Palatinate
 SH:
   unofficial_names: Schleswig-Holstein
   translations:
@@ -186,7 +186,7 @@ SN:
     min_longitude: 11.8714358
     max_latitude: 51.6847089
     max_longitude: 15.0418962
-  name: Sachsen
+  name: Saxony
 ST:
   unofficial_names: Sachsen-Anhalt
   translations:
@@ -198,7 +198,7 @@ ST:
     min_longitude: 10.5608391
     max_latitude: 53.0404507
     max_longitude: 13.1869875
-  name: Sachsen-Anhalt
+  name: Saxony-Anhalt
 TH:
   unofficial_names:
   - Thüringen
@@ -211,4 +211,4 @@ TH:
     min_longitude: 9.876984000000002
     max_latitude: 51.6489359
     max_longitude: 12.6539327
-  name: Thüringen
+  name: Thuringia

--- a/lib/countries/data/subdivisions/DK.yaml
+++ b/lib/countries/data/subdivisions/DK.yaml
@@ -155,7 +155,7 @@
     max_latitude: 56.5302259
     max_longitude: 9.5634978
   name: Viborg
-080:
+'080':
   unofficial_names: Nordjylland
   translations:
     en: Nordjylland
@@ -203,7 +203,7 @@
     min_longitude: 8.2120049
     max_latitude: 57.7518131
     max_longitude: 11.200088
-  name: North Jutland
+  name: Northern Denmark
 '82':
   unofficial_names:
   - Midtjylland
@@ -216,7 +216,7 @@
     min_longitude: 8.0976872
     max_latitude: 56.846539
     max_longitude: 11.6613
-  name: Central Jutland
+  name: Central Denmark
 '83':
   unofficial_names:
   - Syddanmark
@@ -229,7 +229,7 @@
     min_longitude: 8.072240899999999
     max_latitude: 57.8794382
     max_longitude: 15.1972813
-  name: South Denmark
+  name: Southern Denmark
 '84':
   unofficial_names:
   - Region Hovedstaden
@@ -242,7 +242,7 @@
     min_longitude: 11.694833
     max_latitude: 56.200283
     max_longitude: 15.157218
-  name: Capital
+  name: Capital Region
 '85':
   unofficial_names:
   - Sjælland
@@ -255,4 +255,4 @@
     min_longitude: 10.8682958
     max_latitude: 56.129846
     max_longitude: 12.6244919
-  name: Zeeland
+  name: Zealand

--- a/lib/countries/data/subdivisions/DM.yaml
+++ b/lib/countries/data/subdivisions/DM.yaml
@@ -71,7 +71,7 @@
     max_latitude: 15.2727258
     max_longitude: -61.34495099999999
   name: Saint Luke
-08:
+'08':
   unofficial_names: Saint Mark
   translations:
     en: Saint Mark
@@ -83,7 +83,7 @@
     max_latitude: 15.254047
     max_longitude: -61.329852
   name: Saint Mark
-09:
+'09':
   unofficial_names: Saint Patrick
   translations:
     en: Saint Patrick

--- a/lib/countries/data/subdivisions/DO.yaml
+++ b/lib/countries/data/subdivisions/DO.yaml
@@ -10,7 +10,7 @@
     min_longitude: -70.0187874
     max_latitude: 18.5475279
     max_longitude: -69.8750532
-  name: Distrito Nacional (Santo Domingo)
+  name: Distrito Nacional
 '02':
   unofficial_names: Azua
   translations:
@@ -36,7 +36,7 @@
     min_longitude: -71.628498
     max_latitude: 18.6551589
     max_longitude: -70.99380289999999
-  name: Bahoruco
+  name: Baoruco
 '04':
   unofficial_names: Barahona
   translations:
@@ -84,8 +84,8 @@
     min_longitude: -71.71033849999999
     max_latitude: 18.8846859
     max_longitude: -71.6910266
-  name: La Estrelleta [Elías Piña]
-08:
+  name: Elías Piña
+'08':
   unofficial_names: El Seybo [El Seibo]
   translations:
     en: El Seybo [El Seibo]
@@ -96,8 +96,8 @@
     min_longitude: -69.0513898
     max_latitude: 18.7788351
     max_longitude: -69.0306616
-  name: El Seybo [El Seibo]
-09:
+  name: El Seibo
+'09':
   unofficial_names: Espaillat
   translations:
     en: Espaillat
@@ -228,7 +228,7 @@
     min_longitude: -70.462923
     max_latitude: 19.574569
     max_longitude: -70.2323139
-  name: Salcedo
+  name: Hermanas Mirabal
 '20':
   unofficial_names: Samaná
   translations:
@@ -372,4 +372,4 @@
     min_longitude: -70.5147601
     max_latitude: 18.555543
     max_longitude: -70.4983234
-  name: San Jose de Ocoa
+  name: San José de Ocoa

--- a/lib/countries/data/subdivisions/DZ.yaml
+++ b/lib/countries/data/subdivisions/DZ.yaml
@@ -58,7 +58,7 @@
     min_longitude: 6.1793371
     max_latitude: 36.167782
     max_longitude: 7.932361999999999
-  name: Oum el Bouaghi
+  name: Oum El Bouaghi
 '05':
   unofficial_names:
   - Batna
@@ -102,7 +102,7 @@
     max_latitude: 34.9172558
     max_longitude: 5.794816
   name: Biskra
-08:
+'08':
   unofficial_names:
   - Béchar
   translations:
@@ -115,7 +115,7 @@
     max_latitude: 32.166313
     max_longitude: -1.352005
   name: Béchar
-09:
+'09':
   unofficial_names:
   - El Boulaida
   - Blida
@@ -229,7 +229,7 @@
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Alger
+  name: Algiers
 '17':
   unofficial_names:
   - El Djelfa
@@ -405,7 +405,7 @@
     min_longitude: 4.431953399999999
     max_latitude: 35.8723598
     max_longitude: 4.605503199999999
-  name: Msila
+  name: M’Sila
 '29':
   unofficial_names:
   - Mouaskar
@@ -597,7 +597,7 @@
     min_longitude: 2.3005308
     max_latitude: 36.6454234
     max_longitude: 2.5180149
-  name: Tipaza
+  name: Tipasa
 '43':
   unofficial_names:
   - Mila

--- a/lib/countries/data/subdivisions/EE.yaml
+++ b/lib/countries/data/subdivisions/EE.yaml
@@ -10,7 +10,7 @@
     min_longitude: 23.7301295
     max_latitude: 59.68570260000001
     max_longitude: 25.9551028
-  name: Harjumaa
+  name: Harju
 '39':
   unofficial_names:
   - Dagden
@@ -24,7 +24,7 @@
     min_longitude: 22.0388167
     max_latitude: 59.09294079999999
     max_longitude: 23.1801319
-  name: Hiiumaa
+  name: Hiiu
 '44':
   unofficial_names: Ida-Virumaa
   translations:
@@ -36,7 +36,7 @@
     min_longitude: 26.7023311
     max_latitude: 59.5005651
     max_longitude: 28.2090051
-  name: Ida-Virumaa
+  name: Ida-Viru
 '49':
   unofficial_names:
   - Jogevamaa
@@ -49,7 +49,7 @@
     min_longitude: 25.750229
     max_latitude: 58.96892199999999
     max_longitude: 27.1633907
-  name: Jõgevamaa
+  name: Jõgeva
 '51':
   unofficial_names: Järvamaa
   translations:
@@ -61,7 +61,7 @@
     min_longitude: 25.1950171
     max_latitude: 59.2696539
     max_longitude: 26.1688011
-  name: Järvamaa
+  name: Järva
 '57':
   unofficial_names: Läänemaa
   translations:
@@ -73,7 +73,7 @@
     min_longitude: 23.0778348
     max_latitude: 59.304363
     max_longitude: 24.1925961
-  name: Läänemaa
+  name: Lääne
 '59':
   unofficial_names: Lääne-Virumaa
   translations:
@@ -85,7 +85,7 @@
     min_longitude: 25.5363979
     max_latitude: 59.822016
     max_longitude: 26.9527359
-  name: Lääne-Virumaa
+  name: Lääne-Viru
 '65':
   unofficial_names:
   - Polvamaa
@@ -98,7 +98,7 @@
     min_longitude: 26.566258
     max_latitude: 58.2682399
     max_longitude: 27.8189979
-  name: Põlvamaa
+  name: Põlva
 '67':
   unofficial_names: Pärnumaa
   translations:
@@ -110,7 +110,7 @@
     min_longitude: 23.6090122
     max_latitude: 58.7569807
     max_longitude: 25.3071801
-  name: Pärnumaa
+  name: Pärnu
 '70':
   unofficial_names: Raplamaa
   translations:
@@ -122,7 +122,7 @@
     min_longitude: 24.0706308
     max_latitude: 59.22798409999999
     max_longitude: 25.3339442
-  name: Raplamaa
+  name: Rapla
 '74':
   unofficial_names:
   - Saare
@@ -136,7 +136,7 @@
     min_longitude: 21.8281004
     max_latitude: 58.64212449999999
     max_longitude: 23.328579
-  name: Saaremaa
+  name: Saare
 '78':
   unofficial_names: Tartumaa
   translations:
@@ -148,7 +148,7 @@
     min_longitude: 26.078548
     max_latitude: 58.682793
     max_longitude: 27.5323021
-  name: Tartumaa
+  name: Tartu
 '82':
   unofficial_names: Valgamaa
   translations:
@@ -160,7 +160,7 @@
     min_longitude: 25.5805171
     max_latitude: 58.184323
     max_longitude: 26.6250823
-  name: Valgamaa
+  name: Valga
 '84':
   unofficial_names: Viljandimaa
   translations:
@@ -172,7 +172,7 @@
     min_longitude: 24.9719397
     max_latitude: 58.69011700000001
     max_longitude: 26.190842
-  name: Viljandimaa
+  name: Viljandi
 '86':
   unofficial_names:
   - Vorumaa
@@ -185,4 +185,4 @@
     min_longitude: 26.3708779
     max_latitude: 57.9571869
     max_longitude: 27.554923
-  name: Võrumaa
+  name: Võru

--- a/lib/countries/data/subdivisions/EG.yaml
+++ b/lib/countries/data/subdivisions/EG.yaml
@@ -16,7 +16,7 @@ ALX:
     min_longitude: 29.8233701
     max_latitude: 31.330904
     max_longitude: 30.0864016
-  name: Al Iskandariyah
+  name: Alexandria
 ASN:
   unofficial_names:
   - Aswān
@@ -62,7 +62,7 @@ BA:
     min_longitude: 30.741445
     max_latitude: 29.3923378
     max_longitude: 36.8945141
-  name: Al Bahr al Ahmar
+  name: Red Sea
 BH:
   unofficial_names:
   - El Buhayra
@@ -76,7 +76,7 @@ BH:
     min_longitude: 29.5338788
     max_latitude: 31.4683007
     max_longitude: 30.8513688
-  name: Al Buhayrah
+  name: Beheira
 BNS:
   unofficial_names:
   - Bani Suwayf
@@ -90,7 +90,7 @@ BNS:
     min_longitude: 31.0616271
     max_latitude: 29.0958994
     max_longitude: 31.1423418
-  name: Bani Suwayf
+  name: Beni Suef
 C:
   unofficial_names:
   - El Qahira
@@ -108,7 +108,7 @@ C:
     min_longitude: 31.2149558
     max_latitude: 30.1106024
     max_longitude: 31.3019729
-  name: Al Qahirah
+  name: Cairo
 DK:
   unofficial_names:
   - Dakahlia
@@ -123,7 +123,7 @@ DK:
     min_longitude: 31.2086064
     max_latitude: 31.5452581
     max_longitude: 32.0835976
-  name: Ad Daqahliyah
+  name: Dakahlia
 DT:
   unofficial_names:
   - Damiat
@@ -139,7 +139,7 @@ DT:
     min_longitude: 31.7816078
     max_latitude: 31.4417822
     max_longitude: 31.8280067
-  name: Dumyat
+  name: Damietta
 FYM:
   unofficial_names:
   - El Faiyūm
@@ -154,7 +154,7 @@ FYM:
     min_longitude: 30.8206875
     max_latitude: 29.3299673
     max_longitude: 30.86388549999999
-  name: Al Fayyum
+  name: Faiyum
 GH:
   unofficial_names:
   - El Gharbiya
@@ -170,7 +170,7 @@ GH:
     min_longitude: 30.7465372
     max_latitude: 31.1583532
     max_longitude: 31.3105264
-  name: Al Gharbiyah
+  name: Gharbia
 GZ:
   unofficial_names:
   - El Giza
@@ -191,7 +191,7 @@ GZ:
     min_longitude: 31.1472406
     max_latitude: 30.0714063
     max_longitude: 31.2320457
-  name: Al Jizah
+  name: Giza
 IS:
   unofficial_names:
   - El Ismailia
@@ -207,7 +207,7 @@ IS:
     min_longitude: 31.6954456
     max_latitude: 31.0059587
     max_longitude: 32.7520118
-  name: Al Ismā`īlīyah
+  name: Ismailia
 JS:
   unofficial_names:
   - Sina al-Janūbīyah
@@ -222,7 +222,7 @@ JS:
     min_longitude: 32.6094505
     max_latitude: 29.9494465
     max_longitude: 34.9076691
-  name: Janub Sina'
+  name: South Sinai
 KB:
   unofficial_names:
   - El Qalubiya
@@ -236,7 +236,7 @@ KB:
     min_longitude: 31.0542669
     max_latitude: 30.6076595
     max_longitude: 31.4157302
-  name: Al Qalyubiyah
+  name: Qalyubia
 KFS:
   unofficial_names:
   - Kafr-ash-Shaykh
@@ -250,7 +250,7 @@ KFS:
     min_longitude: 30.3653976
     max_latitude: 31.6016217
     max_longitude: 31.3122298
-  name: Kafr ash Shaykh
+  name: Kafr el-Sheikh
 KN:
   unofficial_names:
   - Qina
@@ -264,7 +264,7 @@ KN:
     min_longitude: 32.6828284
     max_latitude: 26.2104418
     max_longitude: 32.7601361
-  name: Qina
+  name: Qena
 LX:
   unofficial_names:
   - al-Uqsur
@@ -280,7 +280,7 @@ LX:
     min_longitude: 32.6225071
     max_latitude: 25.7358046
     max_longitude: 32.6964268
-  name: al-Uqsur
+  name: Luxor
 MN:
   unofficial_names:
   - El Minya
@@ -296,7 +296,7 @@ MN:
     min_longitude: 30.7170696
     max_latitude: 28.1318404
     max_longitude: 30.7843728
-  name: Al Minya
+  name: Minya
 MNF:
   unofficial_names:
   - El Minufiya
@@ -312,7 +312,7 @@ MNF:
     min_longitude: 30.4745556
     max_latitude: 30.7480879
     max_longitude: 31.2559327
-  name: Al Minufiyah
+  name: Monufia
 MT:
   unofficial_names:
   - Matrah
@@ -326,7 +326,7 @@ MT:
     min_longitude: 27.156232
     max_latitude: 31.3761768
     max_longitude: 27.3544331
-  name: Matrūh
+  name: Matrouh
 PTS:
   unofficial_names:
   - Bur Said
@@ -340,7 +340,7 @@ PTS:
     min_longitude: 32.2490287
     max_latitude: 31.2784705
     max_longitude: 32.3213102
-  name: Būr Sa`īd
+  name: Port Said
 SHG:
   unofficial_names:
   - Sawhaj
@@ -357,7 +357,7 @@ SHG:
     min_longitude: 31.3415418
     max_latitude: 26.9343956
     max_longitude: 32.1707085
-  name: Suhaj
+  name: Sohag
 SHR:
   unofficial_names:
   - ash-Sharqiyah
@@ -371,7 +371,7 @@ SHR:
     min_longitude: 31.2607672
     max_latitude: 31.168795
     max_longitude: 32.1782565
-  name: Ash Sharqiyah
+  name: Al Sharqia
 SIN:
   unofficial_names:
   - Shamal Sina
@@ -387,7 +387,7 @@ SIN:
     min_longitude: 32.554564
     max_latitude: 31.3314092
     max_longitude: 34.8774622
-  name: Shamal Sina'
+  name: North Sinai
 SUZ:
   unofficial_names:
   - El Suweiz
@@ -401,7 +401,7 @@ SUZ:
     min_longitude: 32.4374941
     max_latitude: 30.0211813
     max_longitude: 32.5854957
-  name: As Suways
+  name: Suez
 WAD:
   unofficial_names:
   - El Wadi el Jadid
@@ -415,4 +415,4 @@ WAD:
     min_longitude: 25.0003101
     max_latitude: 27.6966292
     max_longitude: 32.9224299
-  name: Al Wadi al Jadid
+  name: New Valley

--- a/lib/countries/data/subdivisions/ER.yaml
+++ b/lib/countries/data/subdivisions/ER.yaml
@@ -22,7 +22,7 @@ DK:
     min_longitude: 40.329559
     max_latitude: 15.0200658
     max_longitude: 43.1486397
-  name: Debubawi Keyih Bahri [Debub-Keih-Bahri]
+  name: Southern Red Sea
 DU:
   unofficial_names: Debub
   translations:
@@ -58,7 +58,7 @@ MA:
     min_longitude: 38.693163
     max_latitude: 15.587143
     max_longitude: 39.0490999
-  name: Maakel [Maekel]
+  name: Maekel
 SK:
   unofficial_names: Semenawi Keyih Bahri [Semien-Keih-Bahri]
   translations:
@@ -70,4 +70,4 @@ SK:
     min_longitude: 37.9696809
     max_latitude: 18.003086
     max_longitude: 41.2974091
-  name: Semenawi Keyih Bahri [Semien-Keih-Bahri]
+  name: Northern Red Sea

--- a/lib/countries/data/subdivisions/ES.yaml
+++ b/lib/countries/data/subdivisions/ES.yaml
@@ -13,7 +13,7 @@ A:
     min_longitude: -0.5416291999999999
     max_latitude: 38.3909328
     max_longitude: -0.4034191
-  name: Alicante/Alacant
+  name: Alicante
 AB:
   unofficial_names: Albacete
   translations:
@@ -87,7 +87,7 @@ BI:
     min_longitude: -3.4492758
     max_latitude: 43.4572451
     max_longitude: -2.4127155
-  name: Bizkaia
+  name: Biscay
 BU:
   unofficial_names: Burgos
   translations:
@@ -115,7 +115,7 @@ C:
     min_longitude: -8.4382592
     max_latitude: 43.38640729999999
     max_longitude: -8.3871082
-  name: Coruña, A
+  name: A Coruña
 CA:
   unofficial_names: Cádiz
   translations:
@@ -192,7 +192,7 @@ CS:
     min_longitude: -0.0797563
     max_latitude: 40.0041729
     max_longitude: -0.0163697
-  name: Castellón/Castelló
+  name: Castellón
 CU:
   unofficial_names: Cuenca
   translations:
@@ -219,7 +219,7 @@ GC:
     min_longitude: -15.467486
     max_latitude: 28.1563403
     max_longitude: -15.4117481
-  name: Palmas, Las
+  name: Las Palmas
 GI:
   unofficial_names:
   - Girona
@@ -334,7 +334,7 @@ LO:
     min_longitude: -3.1342713
     max_latitude: 42.6442647
     max_longitude: -1.6787014
-  name: Rioja, La
+  name: La Rioja Province
 LU:
   unofficial_names: Lugo
   translations:
@@ -358,7 +358,7 @@ M:
     min_longitude: -3.8341618
     max_latitude: 40.5635903
     max_longitude: -3.5249115
-  name: Madrid
+  name: Madrid Province
 MA:
   unofficial_names: Málaga
   translations:
@@ -422,7 +422,7 @@ O:
     min_longitude: -7.1824889
     max_latitude: 43.6665323
     max_longitude: -4.5105944
-  name: Asturias
+  name: Asturias Province
 OR:
   unofficial_names:
   - Ourense
@@ -465,7 +465,7 @@ PM:
     min_longitude: 1.1572495
     max_latitude: 40.0945744
     max_longitude: 4.3277839
-  name: Balears, Illes
+  name: Balears Province
 PO:
   unofficial_names: Pontevedra
   translations:
@@ -491,7 +491,7 @@ S:
     min_longitude: -4.8517782
     max_latitude: 43.5136929
     max_longitude: -3.149652
-  name: Cantabria
+  name: Cantabria Province
 SA:
   unofficial_names: Salamanca
   translations:
@@ -515,7 +515,7 @@ SE:
     min_longitude: -6.0216578
     max_latitude: 37.4355212
     max_longitude: -5.8884587
-  name: Sevilla
+  name: Seville
 SG:
   unofficial_names: Segovia
   translations:
@@ -618,7 +618,7 @@ V:
     min_longitude: -0.4315448
     max_latitude: 39.5073225
     max_longitude: -0.2914778
-  name: Valencia/València
+  name: Valencia
 VA:
   unofficial_names: Valladolid
   translations:
@@ -645,7 +645,7 @@ VI:
     min_longitude: -3.2867669
     max_latitude: 43.216969
     max_longitude: -2.2326871
-  name: Araba/Álava
+  name: Álava
 Z:
   unofficial_names: Zaragoza
   translations:

--- a/lib/countries/data/subdivisions/ET.yaml
+++ b/lib/countries/data/subdivisions/ET.yaml
@@ -10,7 +10,7 @@ AA:
     min_longitude: 38.6560823
     max_latitude: 9.0856549
     max_longitude: 38.90020730000001
-  name: Adis Abeba
+  name: Addis Ababa
 AF:
   unofficial_names:
   - Affar
@@ -35,7 +35,7 @@ AM:
     min_longitude: 35.275204
     max_latitude: 13.7641961
     max_longitude: 40.206138
-  name: Amara
+  name: Amhara
 BE:
   unofficial_names: Binshangul Gumuz
   translations:
@@ -47,7 +47,7 @@ BE:
     min_longitude: 34.106831
     max_latitude: 12.054975
     max_longitude: 37.0327991
-  name: Binshangul Gumuz
+  name: Benishangul-Gumuz
 DD:
   unofficial_names: Dire Dawa
   translations:
@@ -72,7 +72,7 @@ GA:
     min_longitude: 32.999939
     max_latitude: 8.6091941
     max_longitude: 35.364433
-  name: Gambela Hizboch
+  name: Gambela
 HA:
   unofficial_names: Hareri Hizb
   translations:
@@ -84,7 +84,7 @@ HA:
     min_longitude: 42.07599099999999
     max_latitude: 9.378494
     max_longitude: 42.2893491
-  name: Hareri Hizb
+  name: Harari
 OR:
   unofficial_names: Oromiya
   translations:
@@ -96,7 +96,7 @@ OR:
     min_longitude: 34.13031
     max_latitude: 10.3866009
     max_longitude: 42.933914
-  name: Oromiya
+  name: Oromia
 SN:
   unofficial_names: YeDebub Biheroch Bihereseboch na Hizboch
   translations:
@@ -108,7 +108,7 @@ SN:
     min_longitude: 34.187561
     max_latitude: 8.455644999999999
     max_longitude: 39.143376
-  name: YeDebub Biheroch Bihereseboch na Hizboch
+  name: Southern Nations, Nationalities, and Peoples
 SO:
   unofficial_names: Sumale
   translations:
@@ -120,7 +120,7 @@ SO:
     min_longitude: 40.6923869
     max_latitude: 11.088964
     max_longitude: 47.9861791
-  name: Sumale
+  name: Somali
 TI:
   unofficial_names: Tigray
   translations:

--- a/lib/countries/data/subdivisions/FR.yaml
+++ b/lib/countries/data/subdivisions/FR.yaml
@@ -83,7 +83,7 @@
     max_latitude: 45.3662
     max_longitude: 4.8864709
   name: Ardèche
-08:
+'08':
   unofficial_names: Ardennes
   translations:
     en: Ardennes
@@ -95,7 +95,7 @@
     max_latitude: 50.169162
     max_longitude: 5.394246
   name: Ardennes
-09:
+'09':
   unofficial_names: Ariège
   translations:
     en: Ariège
@@ -238,7 +238,7 @@
     min_longitude: 4.065189999999999
     max_latitude: 48.0313109
     max_longitude: 5.518767
-  name: Côte-d'Or
+  name: Côte-d’Or
 '22':
   unofficial_names:
   - Côtes-du-Nord
@@ -251,7 +251,7 @@
     min_longitude: -3.665906
     max_latitude: 48.90093599999999
     max_longitude: -1.909064
-  name: Côtes-d'Armor
+  name: Côtes-d’Armor
 '23':
   unofficial_names: Creuse
   translations:
@@ -1151,7 +1151,7 @@
     min_longitude: 1.6087331
     max_latitude: 49.241504
     max_longitude: 2.5949791
-  name: Val-d'Oise
+  name: Val-d’Oise
 NC:
   unofficial_names: Nouvelle-Calédonie
   translations:
@@ -1163,7 +1163,7 @@ NC:
     min_longitude: -84.32186899999999
     max_latitude: 36.5881568
     max_longitude: -75.4599515
-  name: Nouvelle-Calédonie
+  name: New Caledonia
 PF:
   unofficial_names: Polynésie française
   translations:
@@ -1175,7 +1175,7 @@ PF:
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Polynésie française
+  name: French Polynesia
 PM:
   unofficial_names: Saint-Pierre-et-Miquelon
   translations:
@@ -1187,7 +1187,7 @@ PM:
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Saint-Pierre-et-Miquelon
+  name: St. Pierre & Miquelon
 TF:
   unofficial_names: Terres Australes Françaises
   translations:
@@ -1199,7 +1199,7 @@ TF:
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Terres Australes Françaises
+  name: French Southern Territories
 WF:
   unofficial_names: Wallis et Futuna
   translations:
@@ -1211,7 +1211,7 @@ WF:
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Wallis et Futuna
+  name: Wallis & Futuna
 YT:
   unofficial_names: Mayotte
   translations:

--- a/lib/countries/data/subdivisions/GB.yaml
+++ b/lib/countries/data/subdivisions/GB.yaml
@@ -24,7 +24,7 @@ ABE:
     min_longitude: -2.2058926
     max_latitude: 57.19565069999999
     max_longitude: -2.0461811
-  name: Aberdeen City
+  name: Aberdeen
 AGB:
   unofficial_names: Argyll and Bute
   translations:
@@ -49,7 +49,7 @@ AGY:
     min_longitude: -4.5885415
     max_latitude: 53.4300953
     max_longitude: -4.0401791
-  name: Isle of Anglesey [Sir Ynys Môn GB-YNM]
+  name: Anglesey
 ANS:
   unofficial_names: Angus
   translations:
@@ -133,7 +133,7 @@ BDF:
     min_longitude: -0.6687744
     max_latitude: 52.3229384
     max_longitude: -0.2407452
-  name: Bedfordshire
+  name: Bedford
 BDG:
   unofficial_names: Barking and Dagenham
   translations:
@@ -194,7 +194,7 @@ BGE:
     min_longitude: -3.6716169
     max_latitude: 51.5336115
     max_longitude: -3.5250057
-  name: Bridgend [Pen-y-bont ar Ogwr GB-POG]
+  name: Bridgend
 BGW:
   unofficial_names: Blaenau Gwent
   translations:
@@ -387,7 +387,7 @@ BST:
     min_longitude: -2.7305164
     max_latitude: 51.5444326
     max_longitude: -2.4509024
-  name: Bristol, City of
+  name: Bristol
 BUR:
   unofficial_names: Bury
   translations:
@@ -424,7 +424,7 @@ CAY:
     min_longitude: -3.2555854
     max_latitude: 51.6040631
     max_longitude: -3.1765608
-  name: Caerphilly [Caerffili GB-CAF]
+  name: Caerphilly
 CGN:
   unofficial_names: Ceredigion [Sir Ceredigion]
   translations:
@@ -436,7 +436,7 @@ CGN:
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Ceredigion [Sir Ceredigion]
+  name: Ceredigion
 CGV:
   unofficial_names: Craigavon
   translations:
@@ -557,7 +557,7 @@ CMN:
     min_longitude: -4.723076
     max_latitude: 52.1423962
     max_longitude: -3.6471249
-  name: Carmarthenshire [Sir Gaerfyrddin GB-GFY]
+  name: Carmarthenshire
 CON:
   unofficial_names:
   - Cornwall and Isles of Scilly
@@ -595,7 +595,7 @@ CRF:
     min_longitude: -3.2823817
     max_latitude: 51.5609063
     max_longitude: -3.1215184
-  name: Cardiff [Caerdydd GB-CRD]
+  name: Cardiff
 CRY:
   unofficial_names: Croydon
   translations:
@@ -669,7 +669,7 @@ DEN:
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Denbighshire [Sir Ddinbych GB-DDB]
+  name: Denbighshire
 DER:
   unofficial_names: Derby
   translations:
@@ -705,7 +705,7 @@ DGN:
     min_longitude: -6.7986841
     max_latitude: 54.5238203
     max_longitude: -6.730650799999999
-  name: Dungannon
+  name: Dungannon and South Tyrone
 DGY:
   unofficial_names: Dumfries and Galloway
   translations:
@@ -742,7 +742,7 @@ DND:
     min_longitude: -3.0980246
     max_latitude: 56.50559699999999
     max_longitude: -2.8356419
-  name: Dundee City
+  name: Dundee
 DOR:
   unofficial_names: Dorset
   translations:
@@ -839,7 +839,7 @@ EDH:
     min_longitude: -3.3330187
     max_latitude: 55.9917083
     max_longitude: -3.0777484
-  name: Edinburgh, City of
+  name: Edinburgh
 EDU:
   unofficial_names: East Dunbartonshire
   translations:
@@ -876,7 +876,7 @@ ELS:
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Eilean Siar
+  name: Outer Hebrides
 ENF:
   unofficial_names: Enfield
   translations:
@@ -985,7 +985,7 @@ FLN:
     min_longitude: -3.4005971
     max_latitude: 53.35624079999999
     max_longitude: -2.9202759
-  name: Flintshire [Sir y Fflint GB-FFL]
+  name: Flintshire
 GAT:
   unofficial_names: Gateshead
   translations:
@@ -1010,7 +1010,7 @@ GLG:
     min_longitude: -4.3932005
     max_latitude: 55.9296413
     max_longitude: -4.0717167
-  name: Glasgow City
+  name: Glasgow
 GLS:
   unofficial_names: Gloucestershire
   translations:
@@ -1107,7 +1107,7 @@ HEF:
     min_longitude: -3.1419149
     max_latitude: 52.3954718
     max_longitude: -2.3379667
-  name: Herefordshire, County of
+  name: Herefordshire
 HIL:
   unofficial_names: Hillingdon
   translations:
@@ -1288,7 +1288,7 @@ KHL:
     min_longitude: -0.4225751
     max_latitude: 53.8132502
     max_longitude: -0.2413964
-  name: Kingston upon Hull, City of
+  name: Kingston upon Hull
 KIR:
   unofficial_names: Kirklees
   translations:
@@ -1444,7 +1444,7 @@ LND:
     min_longitude: -0.3514683
     max_latitude: 51.6723432
     max_longitude: 0.148271
-  name: London, City of
+  name: London
 LRN:
   unofficial_names: Larne
   translations:
@@ -1565,7 +1565,7 @@ MON:
     min_longitude: -3.0161242
     max_latitude: 51.8200766
     max_longitude: -3.00958
-  name: Monmouthshire [Sir Fynwy GB-FYN]
+  name: Monmouthshire
 MRT:
   unofficial_names: Merton
   translations:
@@ -1602,7 +1602,7 @@ MTY:
     min_longitude: -3.400272
     max_latitude: 51.7696031
     max_longitude: -3.3561396
-  name: Merthyr Tydfil [Merthyr Tudful GB-MTU]
+  name: Merthyr Tydfil
 MYL:
   unofficial_names: Moyle
   translations:
@@ -1771,7 +1771,7 @@ NTL:
     min_longitude: -3.8580652
     max_latitude: 51.6982626
     max_longitude: -3.7612876
-  name: Neath Port Talbot [Castell-nedd Port Talbot GB-CTL]
+  name: Neath Port Talbot
 NTT:
   unofficial_names: Nottinghamshire
   translations:
@@ -1820,7 +1820,7 @@ NWP:
     min_longitude: -3.0381005
     max_latitude: 51.6213929
     max_longitude: -2.9204637
-  name: Newport [Casnewydd GB-CNW]
+  name: Newport
 NYK:
   unofficial_names: North Yorkshire
   translations:
@@ -1905,7 +1905,7 @@ PEM:
     min_longitude: -5.670226899999999
     max_latitude: 52.1176059
     max_longitude: -4.485517499999999
-  name: Pembrokeshire [Sir Benfro GB-BNF]
+  name: Pembrokeshire
 PKN:
   unofficial_names: Perth and Kinross
   translations:
@@ -1977,7 +1977,7 @@ PTE:
     min_longitude: -0.4976634
     max_latitude: 52.6637708
     max_longitude: -0.1032429
-  name: Peterborough
+  name: Peter
 RCC:
   unofficial_names: Redcar and Cleveland
   translations:
@@ -2014,7 +2014,7 @@ RCT:
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Rhondda, Cynon, Taff [Rhondda, Cynon,Taf]
+  name: Rhondda Cynon Taf
 RDB:
   unofficial_names: Redbridge
   translations:
@@ -2123,7 +2123,7 @@ SCB:
     min_longitude: -3.539803
     max_latitude: 55.9462394
     max_longitude: -2.0343537
-  name: Scottish Borders, The
+  name: Scottish Borders
 SFK:
   unofficial_names: Suffolk
   translations:
@@ -2183,7 +2183,7 @@ SHN:
     min_longitude: -2.780963
     max_latitude: 53.486025
     max_longitude: -2.677342
-  name: St. Helens
+  name: Saint Helens
 SHR:
   unofficial_names: Shropshire
   translations:
@@ -2412,7 +2412,7 @@ SWA:
     min_longitude: -3.967001
     max_latitude: 51.6391493
     max_longitude: -3.9289927
-  name: Swansea [Abertawe GB-ATA]
+  name: Swansea
 SWD:
   unofficial_names: Swindon
   translations:
@@ -2497,7 +2497,7 @@ TOF:
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Torfaen [Tor-faen]
+  name: Torfaen
 TRF:
   unofficial_names: Trafford
   translations:
@@ -2534,7 +2534,7 @@ VGL:
     min_longitude: -3.6439086
     max_latitude: 51.5153438
     max_longitude: -3.1637876
-  name: Vale of Glamorgan, The [Bro Morgannwg GB-BMG]
+  name: Vale of Glamorgan
 WAR:
   unofficial_names: Warwickshire
   translations:
@@ -2739,7 +2739,7 @@ WRX:
     min_longitude: -3.0308429
     max_latitude: 53.0730607
     max_longitude: -2.9454931
-  name: Wrexham [Wrecsam GB-WRC]
+  name: Wrexham
 WSM:
   unofficial_names: Westminster
   translations:
@@ -2787,4 +2787,4 @@ ZET:
     min_longitude: -2.1174404
     max_latitude: 60.86076139999999
     max_longitude: -0.7245408999999999
-  name: Shetland Islands
+  name: Shetland

--- a/lib/countries/data/subdivisions/GD.yaml
+++ b/lib/countries/data/subdivisions/GD.yaml
@@ -82,4 +82,4 @@
     min_longitude: -61.4989469
     max_latitude: 12.5298576
     max_longitude: -61.378178
-  name: Southern Grenadine Islands
+  name: Carriacou and Petite Martinique

--- a/lib/countries/data/subdivisions/GE.yaml
+++ b/lib/countries/data/subdivisions/GE.yaml
@@ -26,7 +26,7 @@ AJ:
     min_longitude: 41.54839399999999
     max_latitude: 41.9110457
     max_longitude: 42.602322
-  name: Ajaria
+  name: Adjara
 GU:
   unofficial_names: Guria
   translations:
@@ -102,7 +102,7 @@ RL:
     min_longitude: 42.35788900000001
     max_latitude: 42.9666309
     max_longitude: 43.948078
-  name: Racha-Lechkhumi [and] Kvemo Svaneti
+  name: Racha-Lechkhumi and Kvemo Svaneti
 SJ:
   unofficial_names:
   - Samche-Žavaheti

--- a/lib/countries/data/subdivisions/GM.yaml
+++ b/lib/countries/data/subdivisions/GM.yaml
@@ -23,7 +23,7 @@ L:
     min_longitude: -16.2310245
     max_latitude: 13.554205
     max_longitude: -15.1831621
-  name: Lower River
+  name: Lower River Division
 M:
   unofficial_names: MacCarthy Island
   translations:
@@ -35,7 +35,7 @@ M:
     min_longitude: -14.8049354
     max_latitude: 13.5551381
     max_longitude: -14.7130108
-  name: MacCarthy Island
+  name: Central River Division
 N:
   unofficial_names:
   - North Bank
@@ -48,7 +48,7 @@ N:
     min_longitude: -16.5492739
     max_latitude: 13.644219
     max_longitude: -15.309071
-  name: North Bank
+  name: North Bank Division
 U:
   unofficial_names:
   - Upper River
@@ -61,7 +61,7 @@ U:
     min_longitude: -14.5469159
     max_latitude: 13.5734001
     max_longitude: -13.7977931
-  name: Upper River
+  name: Upper River Division
 W:
   unofficial_names:
   - Western
@@ -74,4 +74,4 @@ W:
     min_longitude: -16.8136312
     max_latitude: 13.4525822
     max_longitude: -15.8103241
-  name: Western
+  name: West Coast Division

--- a/lib/countries/data/subdivisions/GN.yaml
+++ b/lib/countries/data/subdivisions/GN.yaml
@@ -167,7 +167,7 @@ GU:
     min_longitude: -10.1548433
     max_latitude: 8.597061199999999
     max_longitude: -10.094719
-  name: Guékédou
+  name: Guéckédou
 KA:
   unofficial_names: Kankan
   translations:

--- a/lib/countries/data/subdivisions/GQ.yaml
+++ b/lib/countries/data/subdivisions/GQ.yaml
@@ -46,7 +46,7 @@ C:
     min_longitude: 8.873045399999999
     max_latitude: 51.28056
     max_longitude: 8.8745578
-  name: Región Continental
+  name: Río Muni
 CS:
   unofficial_names: Centro Sur
   translations:
@@ -70,7 +70,7 @@ I:
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Región Insular
+  name: Insular
 KN:
   unofficial_names: Kie-Ntem
   translations:
@@ -82,7 +82,7 @@ KN:
     min_longitude: 10.401541
     max_latitude: 2.187128
     max_longitude: 11.3356839
-  name: Kie-Ntem
+  name: Kié-Ntem
 LI:
   unofficial_names: Litoral
   translations:
@@ -106,4 +106,4 @@ WN:
     min_longitude: 10.5228439
     max_latitude: 1.994745
     max_longitude: 11.3357239
-  name: Wele-Nzás
+  name: Wele-Nzas

--- a/lib/countries/data/subdivisions/GR.yaml
+++ b/lib/countries/data/subdivisions/GR.yaml
@@ -12,7 +12,7 @@
     min_longitude: 20.7186278
     max_latitude: 39.1746625
     max_longitude: 22.0265431
-  name: Aitolia-Akarnania
+  name: Aetolia-Acarnania
 '03':
   unofficial_names:
   - Boeotia
@@ -25,7 +25,7 @@
     min_longitude: 22.4874603
     max_latitude: 38.5958614
     max_longitude: 23.6925946
-  name: Voiotia
+  name: Boeotia
 '04':
   unofficial_names:
   - Euboea
@@ -39,7 +39,7 @@
     min_longitude: 22.8111273
     max_latitude: 39.0505681
     max_longitude: 24.685908
-  name: Evvoia
+  name: Euboea
 '05':
   unofficial_names:
   - Evrytania
@@ -52,7 +52,7 @@
     min_longitude: 21.3743805
     max_latitude: 39.2567999
     max_longitude: 21.9463558
-  name: Evrytania
+  name: Evritania
 '06':
   unofficial_names:
   - Phtiotis
@@ -65,7 +65,7 @@
     min_longitude: 21.8260028
     max_latitude: 39.273223
     max_longitude: 23.3779269
-  name: Fthiotis
+  name: Phthiotis
 '07':
   unofficial_names:
   - Phocis
@@ -79,7 +79,7 @@
     min_longitude: 21.8534652
     max_latitude: 38.8075967
     max_longitude: 22.6290539
-  name: Fokis
+  name: Phocis
 '11':
   unofficial_names: Argolis
   translations:
@@ -104,7 +104,7 @@
     min_longitude: 21.7909335
     max_latitude: 37.8653285
     max_longitude: 22.9852154
-  name: Arkadia
+  name: Arcadia
 '13':
   unofficial_names:
   - Achaia
@@ -118,7 +118,7 @@
     min_longitude: 21.3506248
     max_latitude: 38.34114890000001
     max_longitude: 22.3801523
-  name: Achaïa
+  name: Achaea
 '14':
   unofficial_names:
   - Elia
@@ -131,7 +131,7 @@
     min_longitude: 21.105044
     max_latitude: 38.1042772
     max_longitude: 21.9993968
-  name: Ileia
+  name: Ilia
 '15':
   unofficial_names:
   - Corinth
@@ -146,7 +146,7 @@
     min_longitude: 22.2184583
     max_latitude: 38.1430037
     max_longitude: 23.1795243
-  name: Korinthia
+  name: Corinthia
 '16':
   unofficial_names:
   - Laconia
@@ -159,7 +159,7 @@
     min_longitude: 22.2207465
     max_latitude: 37.3358025
     max_longitude: 23.2021446
-  name: Lakonia
+  name: Laconia
 '17':
   unofficial_names:
   - Messenia
@@ -172,7 +172,7 @@
     min_longitude: 21.5389289
     max_latitude: 37.485153
     max_longitude: 22.4019497
-  name: Messinia
+  name: Messenia
 '21':
   unofficial_names:
   - Zakynthos
@@ -202,7 +202,7 @@
     min_longitude: 19.8859891
     max_latitude: 39.6335922
     max_longitude: 19.9329883
-  name: Kerkyra
+  name: Corfu
 '23':
   unofficial_names:
   - Cephalonia
@@ -216,7 +216,7 @@
     min_longitude: 20.3367466
     max_latitude: 38.4754656
     max_longitude: 20.8160654
-  name: Kefallinia
+  name: Kefalonia
 '24':
   unofficial_names:
   - Leucas
@@ -231,7 +231,7 @@
     min_longitude: 20.5409505
     max_latitude: 38.8523758
     max_longitude: 20.7331319
-  name: Lefkas
+  name: Lefkada
 '31':
   unofficial_names: Arta
   translations:
@@ -305,7 +305,7 @@
     min_longitude: 22.3851797
     max_latitude: 39.66467799999999
     max_longitude: 22.4631126
-  name: Larisa
+  name: Larissa
 '43':
   unofficial_names:
   - Magnesia
@@ -319,7 +319,7 @@
     min_longitude: 22.4907616
     max_latitude: 39.6028892
     max_longitude: 23.351096
-  name: Magnisia
+  name: Magnesia
 '44':
   unofficial_names:
   - Trikala
@@ -399,7 +399,7 @@
     min_longitude: 24.3727195
     max_latitude: 40.9551573
     max_longitude: 24.4424248
-  name: Kavalla
+  name: Kavala
 '56':
   unofficial_names: Kastoria
   translations:
@@ -472,7 +472,7 @@
     min_longitude: 23.5238672
     max_latitude: 41.0995376
     max_longitude: 23.5722419
-  name: Serrai
+  name: Serres
 '63':
   unofficial_names: Florina
   translations:
@@ -516,7 +516,7 @@
     min_longitude: 23.993087
     max_latitude: 40.451581
     max_longitude: 24.3991418
-  name: Agio Oros
+  name: Mount Athos
 '71':
   unofficial_names: Evros
   translations:
@@ -553,7 +553,7 @@
     min_longitude: 25.0462171
     max_latitude: 41.3476982
     max_longitude: 25.9628848
-  name: Rodopi
+  name: Rhodope
 '81':
   unofficial_names:
   - Dodecanese
@@ -567,7 +567,7 @@
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Dodekanisos
+  name: Dodecanese
 '82':
   unofficial_names:
   - Cyclades
@@ -581,7 +581,7 @@
     min_longitude: 24.2644196
     max_latitude: 37.9996455
     max_longitude: 26.0861299
-  name: Kyklades
+  name: Cyclades
 '83':
   unofficial_names:
   - Lesbos
@@ -594,7 +594,7 @@
     min_longitude: 25.8315604
     max_latitude: 39.3901867
     max_longitude: 26.6158545
-  name: Lesvos
+  name: Lesbos
 '84':
   unofficial_names: Samos
   translations:
@@ -637,7 +637,7 @@
     min_longitude: 24.7224739
     max_latitude: 35.46693610000001
     max_longitude: 25.5503886
-  name: Irakleion
+  name: Heraklion region
 '92':
   unofficial_names:
   - Lassithi
@@ -650,7 +650,7 @@
     min_longitude: 25.3984683
     max_latitude: 35.3838124
     max_longitude: 26.352476
-  name: Lasithion
+  name: Lasithi
 '93':
   unofficial_names: Rethymnon
   translations:
@@ -662,7 +662,7 @@
     min_longitude: 24.452042
     max_latitude: 35.3739755
     max_longitude: 24.5385319
-  name: Rethymnon
+  name: Rethymno
 '94':
   unofficial_names:
   - Canea
@@ -692,4 +692,4 @@ A1:
     min_longitude: 22.8912482
     max_latitude: 38.34097939999999
     max_longitude: 24.1047417
-  name: Attiki
+  name: Attica Department

--- a/lib/countries/data/subdivisions/HN.yaml
+++ b/lib/countries/data/subdivisions/HN.yaml
@@ -118,7 +118,7 @@ IB:
     min_longitude: -86.98986409999999
     max_latitude: 17.415835
     max_longitude: -83.9287665
-  name: Islas de la Bahía
+  name: Bay Islands
 IN:
   unofficial_names: Intibucá
   translations:

--- a/lib/countries/data/subdivisions/HR.yaml
+++ b/lib/countries/data/subdivisions/HR.yaml
@@ -11,7 +11,7 @@
     min_longitude: 15.3262593
     max_latitude: 46.0695047
     max_longitude: 16.7137865
-  name: Zagrebačka županija
+  name: Zagreb County
 '02':
   unofficial_names:
   - Krapina-Zagorje
@@ -24,7 +24,7 @@
     min_longitude: 15.5954704
     max_latitude: 46.2800141
     max_longitude: 16.2571245
-  name: Krapinsko-zagorska županija
+  name: Krapina-Zagorje
 '03':
   unofficial_names:
   - Sisak-Moslavina
@@ -37,7 +37,7 @@
     min_longitude: 15.7676525
     max_latitude: 45.6699168
     max_longitude: 17.1949134
-  name: Sisačko-moslavačka županija
+  name: Sisak-Moslavina
 '04':
   unofficial_names:
   - Karlovac
@@ -50,7 +50,7 @@
     min_longitude: 14.961508
     max_latitude: 45.7628058
     max_longitude: 15.9247762
-  name: Karlovačka županija
+  name: Karlovac
 '05':
   unofficial_names:
   - Varaždin
@@ -63,7 +63,7 @@
     min_longitude: 15.8765333
     max_latitude: 46.4048343
     max_longitude: 16.7739716
-  name: Varaždinska županija
+  name: Varaždin
 '06':
   unofficial_names:
   - Koprivnica-Križevci
@@ -76,7 +76,7 @@
     min_longitude: 16.3417055
     max_latitude: 46.3551961
     max_longitude: 17.3057121
-  name: Koprivničko-križevačka županija
+  name: Koprivnica-Križevci
 '07':
   unofficial_names:
   - Bjelovar-Bilogora
@@ -89,8 +89,8 @@
     min_longitude: 16.4888635
     max_latitude: 46.088761
     max_longitude: 17.4986747
-  name: Bjelovarsko-bilogorska županija
-08:
+  name: Bjelovar-Bilogora
+'08':
   unofficial_names:
   - Primorje-Gorski Kotar
   translations:
@@ -102,8 +102,8 @@
     min_longitude: 14.1078905
     max_latitude: 45.67344840000001
     max_longitude: 15.2352703
-  name: Primorsko-goranska županija
-09:
+  name: Primorje-Gorski Kotar
+'09':
   unofficial_names:
   - Lika-Senj
   translations:
@@ -115,7 +115,7 @@
     min_longitude: 14.6828545
     max_latitude: 45.1228954
     max_longitude: 16.1408169
-  name: Ličko-senjska županija
+  name: Lika-Senj
 '10':
   unofficial_names:
   - Virovitica-Podravina
@@ -128,7 +128,7 @@
     min_longitude: 17.1197372
     max_latitude: 45.99621200000001
     max_longitude: 18.0678268
-  name: Virovitičko-podravska županija
+  name: Virovitica-Podravina
 '11':
   unofficial_names:
   - Požega-Slavonia
@@ -141,7 +141,7 @@
     min_longitude: 16.9284931
     max_latitude: 45.5801629
     max_longitude: 18.1141807
-  name: Požeško-slavonska županija
+  name: Požega-Slavonia
 '12':
   unofficial_names:
   - Brod-Posavina
@@ -154,7 +154,7 @@
     min_longitude: 17.0736625
     max_latitude: 45.39235980000001
     max_longitude: 18.5746296
-  name: Brodsko-posavska županija
+  name: Brod-Posavina
 '13':
   unofficial_names:
   - Zadar
@@ -167,7 +167,7 @@
     min_longitude: 14.5670193
     max_latitude: 44.5384474
     max_longitude: 16.2202414
-  name: Zadarska županija
+  name: Zadar
 '14':
   unofficial_names:
   - Osijek-Baranja
@@ -180,7 +180,7 @@
     min_longitude: 17.8840624
     max_latitude: 45.9217976
     max_longitude: 19.1025689
-  name: Osječko-baranjska županija
+  name: Osijek-Baranja
 '15':
   unofficial_names:
   - Šibenik-Knin
@@ -193,7 +193,7 @@
     min_longitude: 15.2068282
     max_latitude: 44.2164979
     max_longitude: 16.5426211
-  name: Šibensko-kninska županija
+  name: Šibenik-Knin
 '16':
   unofficial_names:
   - Vukovar-Sirmium
@@ -206,7 +206,7 @@
     min_longitude: 18.4948404
     max_latitude: 45.4856329
     max_longitude: 19.4480523
-  name: Vukovarsko-srijemska županija
+  name: Vukovar-Syrmia
 '17':
   unofficial_names:
   - Split-Dalmatia
@@ -219,7 +219,7 @@
     min_longitude: 15.709013
     max_latitude: 43.9736159
     max_longitude: 17.4510685
-  name: Splitsko-dalmatinska županija
+  name: Split-Dalmatia
 '18':
   unofficial_names:
   - Istria
@@ -232,7 +232,7 @@
     min_longitude: 13.4896865
     max_latitude: 45.5196036
     max_longitude: 14.2285896
-  name: Istarska županija
+  name: Istria
 '19':
   unofficial_names:
   - Dubrovnik-Neretva
@@ -245,7 +245,7 @@
     min_longitude: 16.4876151
     max_latitude: 43.17750849999999
     max_longitude: 18.5337474
-  name: Dubrovačko-neretvanska županija
+  name: Dubrovnik-Neretva
 '20':
   unofficial_names:
   - Međimurje
@@ -258,7 +258,7 @@
     min_longitude: 16.2384532
     max_latitude: 46.5552234
     max_longitude: 16.8580089
-  name: Međimurska županija
+  name: Međimurje
 '21':
   unofficial_names:
   - City of Zagreb
@@ -271,4 +271,4 @@
     min_longitude: 15.8216904
     max_latitude: 45.9395392
     max_longitude: 16.1069727
-  name: Grad Zagreb
+  name: Zagreb

--- a/lib/countries/data/subdivisions/HT.yaml
+++ b/lib/countries/data/subdivisions/HT.yaml
@@ -36,7 +36,7 @@ GA:
     min_longitude: -74.4768955
     max_latitude: 18.6759873
     max_longitude: -73.69869899999999
-  name: Grande-Anse
+  name: Grand’Anse
 ND:
   unofficial_names: Nord
   translations:

--- a/lib/countries/data/subdivisions/HU.yaml
+++ b/lib/countries/data/subdivisions/HU.yaml
@@ -478,7 +478,7 @@ VE:
     min_longitude: 17.8207858
     max_latitude: 47.205633
     max_longitude: 17.9937111
-  name: Veszprém
+  name: Veszprém County
 VM:
   unofficial_names: Veszprém
   translations:

--- a/lib/countries/data/subdivisions/ID.yaml
+++ b/lib/countries/data/subdivisions/ID.yaml
@@ -35,7 +35,7 @@ BB:
     min_longitude: 105.108396
     max_latitude: -1.500617
     max_longitude: 108.8479921
-  name: Bangka Belitung
+  name: Bangka–Belitung Islands
 BE:
   unofficial_names: Bengkulu
   translations:
@@ -95,7 +95,7 @@ JB:
     min_longitude: 106.370508
     max_latitude: -5.914709999999999
     max_longitude: 108.839768
-  name: Jawa Barat
+  name: West Java
 JI:
   unofficial_names: Jawa Timur
   translations:
@@ -107,7 +107,7 @@ JI:
     min_longitude: 110.8987199
     max_latitude: -5.048902099999999
     max_longitude: 116.267761
-  name: Jawa Timur
+  name: East Java
 JK:
   unofficial_names: Jakarta Raya
   translations:
@@ -119,7 +119,7 @@ JK:
     min_longitude: 106.3831259
     max_latitude: -5.1843219
     max_longitude: 106.972825
-  name: Jakarta Raya
+  name: Jakarta
 JT:
   unofficial_names: Jawa Tengah
   translations:
@@ -131,7 +131,7 @@ JT:
     min_longitude: 108.555502
     max_latitude: -5.725698
     max_longitude: 111.6914889
-  name: Jawa Tengah
+  name: Central Java
 KB:
   unofficial_names: Kalimantan Barat
   translations:
@@ -143,7 +143,7 @@ KB:
     min_longitude: 108.020782
     max_latitude: 2.011464
     max_longitude: 114.1991139
-  name: Kalimantan Barat
+  name: West Kalimantan
 KI:
   unofficial_names: Kalimantan Timur
   translations:
@@ -155,7 +155,7 @@ KI:
     min_longitude: 113.836634
     max_latitude: 2.606556
     max_longitude: 119.025528
-  name: Kalimantan Timur
+  name: East Kalimantan
 KR:
   unofficial_names: Kepulauan Riau
   translations:
@@ -167,7 +167,7 @@ KR:
     min_longitude: 103.278237
     max_latitude: 4.2665521
     max_longitude: 109.164018
-  name: Kepulauan Riau
+  name: Riau Islands
 KS:
   unofficial_names: Kalimantan Selatan
   translations:
@@ -179,7 +179,7 @@ KS:
     min_longitude: 114.345859
     max_latitude: -1.315037
     max_longitude: 116.555961
-  name: Kalimantan Selatan
+  name: South Kalimantan
 KT:
   unofficial_names: Kalimantan Tengah
   translations:
@@ -191,7 +191,7 @@ KT:
     min_longitude: 110.733665
     max_latitude: 0.793256
     max_longitude: 115.84722
-  name: Kalimantan Tengah
+  name: Central Kalimantan
 LA:
   unofficial_names: Lampung
   translations:
@@ -231,7 +231,7 @@ MU:
     min_longitude: 124.2830601
     max_latitude: 2.645167
     max_longitude: 129.6574671
-  name: Maluku Utara
+  name: North Maluku
 NB:
   unofficial_names: Nusa Tenggara Barat
   translations:
@@ -243,7 +243,7 @@ NB:
     min_longitude: 115.821074
     max_latitude: -8.08049
     max_longitude: 119.335274
-  name: Nusa Tenggara Barat
+  name: West Nusa Tenggara
 NT:
   unofficial_names: Nusa Tenggara Timur
   translations:
@@ -255,7 +255,7 @@ NT:
     min_longitude: 118.927002
     max_latitude: -8.063516
     max_longitude: 125.188149
-  name: Nusa Tenggara Timur
+  name: East Nusa Tenggara
 PA:
   unofficial_names: Papua
   translations:
@@ -291,7 +291,7 @@ SA:
     min_longitude: 123.110851
     max_latitude: 5.565783
     max_longitude: 127.1815781
-  name: Sulawesi Utara
+  name: North Sulawesi
 SB:
   unofficial_names: Sumatera Barat
   translations:
@@ -303,7 +303,7 @@ SB:
     min_longitude: 98.59692190000001
     max_latitude: 0.907389
     max_longitude: 101.8929181
-  name: Sumatera Barat
+  name: West Sumatra
 SG:
   unofficial_names: Sulawesi Tenggara
   translations:
@@ -315,7 +315,7 @@ SG:
     min_longitude: 119.446937
     max_latitude: 1.375153
     max_longitude: 124.1825231
-  name: Sulawesi Tenggara
+  name: Southeast Sulawesi
 SN:
   unofficial_names: Sulawesi Selatan
   translations:
@@ -327,7 +327,7 @@ SN:
     min_longitude: 117.0385149
     max_latitude: -1.895236
     max_longitude: 121.8402099
-  name: Sulawesi Selatan
+  name: South Sulawesi
 SR:
   unofficial_names: Sulawesi Barat
   translations:
@@ -339,7 +339,7 @@ SR:
     min_longitude: 118.754871
     max_latitude: -0.8498319999999999
     max_longitude: 119.8754601
-  name: Sulawesi Barat
+  name: West Sulawesi
 SS:
   unofficial_names: Sumatera Selatan
   translations:
@@ -351,7 +351,7 @@ SS:
     min_longitude: 102.0674489
     max_latitude: -1.6254409
     max_longitude: 106.0968391
-  name: Sumatera Selatan
+  name: South Sumatra
 ST:
   unofficial_names: Sulawesi Tengah
   translations:
@@ -363,7 +363,7 @@ ST:
     min_longitude: 119.446937
     max_latitude: 1.375153
     max_longitude: 124.1825231
-  name: Sulawesi Tengah
+  name: Central Sulawesi
 SU:
   unofficial_names: Sumatera Utara
   translations:
@@ -375,7 +375,7 @@ SU:
     min_longitude: 97.0585893
     max_latitude: 4.3013451
     max_longitude: 100.4257811
-  name: Sumatera Utara
+  name: North Sumatra
 X1~:
   unofficial_names:
   - Papua Barat/ Irian Jaya Barat

--- a/lib/countries/data/subdivisions/IE.yaml
+++ b/lib/countries/data/subdivisions/IE.yaml
@@ -11,7 +11,7 @@ C:
     min_longitude: -8.54552
     max_latitude: 51.93586
     max_longitude: -8.380579899999999
-  name: Cork
+  name: Connacht
 CE:
   unofficial_names:
   - An Clár

--- a/lib/countries/data/subdivisions/IL.yaml
+++ b/lib/countries/data/subdivisions/IL.yaml
@@ -11,7 +11,7 @@ D:
     min_longitude: 34.2673871
     max_latitude: 31.8779508
     max_longitude: 35.4549186
-  name: HaDarom
+  name: Southern District
 HA:
   unofficial_names:
   - Hefa
@@ -28,7 +28,7 @@ HA:
     min_longitude: 34.954059
     max_latitude: 32.842681
     max_longitude: 35.079493
-  name: Haifa
+  name: Haifa District
 JM:
   unofficial_names:
   - al-Quds
@@ -45,7 +45,7 @@ JM:
     min_longitude: 35.0854311
     max_latitude: 31.8829601
     max_longitude: 35.2652869
-  name: Yerushalayim
+  name: Jerusalem
 M:
   unofficial_names:
   - Central
@@ -58,7 +58,7 @@ M:
     min_longitude: 34.66654279999999
     max_latitude: 32.4126018
     max_longitude: 35.051422
-  name: HaMerkaz
+  name: Central District
 TA:
   unofficial_names: Tel-Aviv
   translations:
@@ -70,7 +70,7 @@ TA:
     min_longitude: 34.7425159
     max_latitude: 32.1465073
     max_longitude: 34.8519761
-  name: Tel-Aviv
+  name: Tel Aviv District
 Z:
   unofficial_names:
   - Northern
@@ -83,4 +83,4 @@ Z:
     min_longitude: 35.0272979
     max_latitude: 33.33280500000001
     max_longitude: 35.896244
-  name: HaZafon
+  name: Northern District

--- a/lib/countries/data/subdivisions/IN.yaml
+++ b/lib/countries/data/subdivisions/IN.yaml
@@ -314,7 +314,7 @@ OR:
     min_longitude: 81.388607
     max_latitude: 22.5700271
     max_longitude: 87.483385
-  name: Orissa
+  name: Odisha
 PB:
   unofficial_names: Punjab
   translations:
@@ -338,7 +338,7 @@ PY:
     min_longitude: 79.7857511
     max_latitude: 11.973176
     max_longitude: 79.84057229999999
-  name: Pondicherry
+  name: Puducherry
 RJ:
   unofficial_names: Rajasthan
   translations:

--- a/lib/countries/data/subdivisions/IQ.yaml
+++ b/lib/countries/data/subdivisions/IQ.yaml
@@ -26,7 +26,7 @@ AR:
     min_longitude: 43.91613
     max_latitude: 36.2661445
     max_longitude: 44.101181
-  name: Arbil
+  name: Erbil
 BA:
   unofficial_names:
   - Basra
@@ -41,7 +41,7 @@ BA:
     min_longitude: 47.6141454
     max_latitude: 30.6321515
     max_longitude: 47.9299164
-  name: Al Basrah
+  name: Basra
 BB:
   unofficial_names:
   - Babil
@@ -55,7 +55,7 @@ BB:
     min_longitude: 43.849441
     max_latitude: 33.233322
     max_longitude: 45.214476
-  name: Babil
+  name: Babylon
 BG:
   unofficial_names:
   - Baġdād
@@ -83,7 +83,7 @@ DA:
     min_longitude: 42.3622129
     max_latitude: 37.3780401
     max_longitude: 44.110214
-  name: Dahuk
+  name: Dohuk
 DI:
   unofficial_names:
   - Diyala
@@ -96,7 +96,7 @@ DI:
     min_longitude: 44.292854
     max_latitude: 35.1153911
     max_longitude: 46.01852
-  name: Diyalá
+  name: Diyala
 DQ:
   unofficial_names:
   - Dhi Qar
@@ -125,7 +125,7 @@ KA:
     min_longitude: 43.9558696
     max_latitude: 32.6572976
     max_longitude: 44.0673636
-  name: Karbala'
+  name: Karbala
 MA:
   unofficial_names: Maysan
   translations:
@@ -150,7 +150,7 @@ MU:
     min_longitude: 43.807403
     max_latitude: 31.699816
     max_longitude: 46.648625
-  name: Al Muthanná
+  name: Al Muthanna
 NA:
   unofficial_names:
   - Najaf
@@ -165,7 +165,7 @@ NA:
     min_longitude: 44.2736149
     max_latitude: 32.0761164
     max_longitude: 44.3853665
-  name: An Najaf
+  name: Najaf
 NI:
   unofficial_names:
   - Nineveh
@@ -179,7 +179,7 @@ NI:
     min_longitude: 41.218105
     max_latitude: 37.06718100000001
     max_longitude: 44.309753
-  name: Ninawá
+  name: Nineveh
 QA:
   unofficial_names:
   - al-Qadisiyah
@@ -192,7 +192,7 @@ QA:
     min_longitude: 44.376614
     max_latitude: 32.420094
     max_longitude: 45.82649199999999
-  name: Al Qadisiyah
+  name: Al-Qādisiyyah
 SD:
   unofficial_names:
   - Salah-ad-Din
@@ -205,7 +205,7 @@ SD:
     min_longitude: 42.450488
     max_latitude: 35.675014
     max_longitude: 44.955274
-  name: Salah ad Din
+  name: Saladin
 SU:
   unofficial_names:
   - Sulaymaniya
@@ -220,7 +220,7 @@ SU:
     min_longitude: 45.278778
     max_latitude: 35.6029511
     max_longitude: 45.476532
-  name: As Sulaymaniyah
+  name: Sulaymaniyah
 TS:
   unofficial_names:
   - at-Tamim

--- a/lib/countries/data/subdivisions/IR.yaml
+++ b/lib/countries/data/subdivisions/IR.yaml
@@ -12,7 +12,7 @@
     min_longitude: 47.0525068
     max_latitude: 38.473952
     max_longitude: 47.060772
-  name: Az¯arbayjan-e Sharqi
+  name: East Azerbaijan
 '02':
   unofficial_names:
   - Azarbayjān-e Bakhtari
@@ -26,7 +26,7 @@
     min_longitude: -114.8165909
     max_latitude: 37.0042599
     max_longitude: -109.0452231
-  name: Az¯arbayjan-e Gharbi
+  name: West Azarbaijan
 '03':
   unofficial_names:
   - Ardabil
@@ -53,7 +53,7 @@
     min_longitude: 51.5254498
     max_latitude: 32.8200277
     max_longitude: 51.8486024
-  name: Esfahan
+  name: Isfahan
 '05':
   unofficial_names:
   - Ilam
@@ -92,7 +92,7 @@
     max_latitude: 35.7107648
     max_longitude: 51.4861434
   name: Tehran
-08:
+'08':
   unofficial_names:
   - Chaharmahal Bakhtiari
   translations:
@@ -104,8 +104,8 @@
     min_longitude: 49.76081509999999
     max_latitude: 32.700775
     max_longitude: 51.3524481
-  name: Chahar Mah¸all va Bakhtiari
-09:
+  name: Chaharmahal and Bakhtiari
+'09':
   unofficial_names:
   - Khorasan
   translations:
@@ -167,7 +167,7 @@
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Sistan va Baluchestan
+  name: Sistan and Baluchestan
 '14':
   unofficial_names: Fars
   translations:
@@ -205,7 +205,7 @@
     min_longitude: 47.0484325
     max_latitude: 34.3188878
     max_longitude: 47.0581582
-  name: Kordestan
+  name: Kurdistan
 '17':
   unofficial_names:
   - Bakhtaran
@@ -232,7 +232,7 @@
     min_longitude: 49.913279
     max_latitude: 31.5126911
     max_longitude: 51.69622409999999
-  name: Kohkiluyeh va Buyer Ahmad
+  name: Kohgiluyeh and Boyer-Ahmad
 '19':
   unofficial_names:
   - Gilan
@@ -367,7 +367,7 @@
     min_longitude: 55.306599
     max_latitude: 35.1648275
     max_longitude: 61.144714
-  name: Khorasan-e Janubi
+  name: South Khorasan
 '30':
   unofficial_names: Khorasan-e Razavi
   translations:
@@ -379,7 +379,7 @@
     min_longitude: 56.4763309
     max_latitude: 37.7905918
     max_longitude: 61.282579
-  name: Khorasan-e Razavi
+  name: Razavi Khorasan
 '31':
   unofficial_names: Khorasan-e Shemali
   translations:
@@ -391,4 +391,4 @@
     min_longitude: 55.805023
     max_latitude: 38.2725939
     max_longitude: 58.387249
-  name: Khorasan-e Shemali
+  name: North Khorasan

--- a/lib/countries/data/subdivisions/IS.yaml
+++ b/lib/countries/data/subdivisions/IS.yaml
@@ -22,7 +22,7 @@
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Höfuðborgarsvæði utan Reykjavíkur
+  name: Capital
 '2':
   unofficial_names: Suðurnes
   translations:
@@ -34,7 +34,7 @@
     min_longitude: -22.7544665
     max_latitude: 64.08244680000001
     max_longitude: -21.7119429
-  name: Suðurnes
+  name: Southern Peninsula
 '3':
   unofficial_names: Vesturland
   translations:
@@ -46,7 +46,7 @@
     min_longitude: -24.0609395
     max_latitude: 65.51733899999999
     max_longitude: -19.7810714
-  name: Vesturland
+  name: Western
 '4':
   unofficial_names: Vestfirðir
   translations:
@@ -58,7 +58,7 @@
     min_longitude: -24.5465237
     max_latitude: 66.46997069999999
     max_longitude: -20.9746663
-  name: Vestfirðir
+  name: Westfjords
 '5':
   unofficial_names: Norðurland vestra
   translations:
@@ -70,7 +70,7 @@
     min_longitude: -21.1190769
     max_latitude: 66.1600471
     max_longitude: -18.295774
-  name: Norðurland vestra
+  name: Northwestern
 '6':
   unofficial_names: Norðurland eystra
   translations:
@@ -82,7 +82,7 @@
     min_longitude: -19.0427822
     max_latitude: 66.5637741
     max_longitude: -14.5419811
-  name: Norðurland eystra
+  name: Northeastern
 '7':
   unofficial_names: Austurland
   translations:
@@ -94,7 +94,7 @@
     min_longitude: -17.3681851
     max_latitude: 66.1899378
     max_longitude: -13.4958154
-  name: Austurland
+  name: Eastern
 '8':
   unofficial_names: Suðurland
   translations:
@@ -106,4 +106,4 @@
     min_longitude: -21.9220031
     max_latitude: 64.87730599999999
     max_longitude: -17.2659519
-  name: Suðurland
+  name: Southern

--- a/lib/countries/data/subdivisions/IT.yaml
+++ b/lib/countries/data/subdivisions/IT.yaml
@@ -70,7 +70,7 @@ AQ:
     min_longitude: 13.336641
     max_latitude: 42.388588
     max_longitude: 13.4348911
-  name: L'Aquila
+  name: L’Aquila
 AR:
   unofficial_names: Arezzo
   translations:
@@ -226,7 +226,7 @@ BZ:
     min_longitude: 11.3136675
     max_latitude: 46.5154347
     max_longitude: 11.3806479
-  name: Bolzano
+  name: South Tyrol
 CA:
   unofficial_names: Cagliari
   translations:
@@ -418,7 +418,7 @@ FI:
     min_longitude: 11.1540365
     max_latitude: 43.8329368
     max_longitude: 11.3278993
-  name: Firenze
+  name: Florence
 FC:
   unofficial_names: Forlì-Cesena
   translations:
@@ -466,7 +466,7 @@ GE:
     min_longitude: 8.7160912
     max_latitude: 44.514882
     max_longitude: 9.065572999999999
-  name: Genova
+  name: Genoa
 GO:
   unofficial_names: Gorizia
   translations:
@@ -610,7 +610,7 @@ MB:
     min_longitude: 9.0505239
     max_latitude: 45.7427334
     max_longitude: 9.4966723
-  name: Monza e Brianza
+  name: Monza and Brianza
 MC:
   unofficial_names: Macerata
   translations:
@@ -646,7 +646,7 @@ MI:
     min_longitude: 9.065118199999999
     max_latitude: 45.535689
     max_longitude: 9.2903463
-  name: Milano
+  name: Milan
 MN:
   unofficial_names: Mantova
   translations:
@@ -658,7 +658,7 @@ MN:
     min_longitude: 10.7404198
     max_latitude: 45.1863062
     max_longitude: 10.8060815
-  name: Mantova
+  name: Mantua
 MO:
   unofficial_names: Modena
   translations:
@@ -682,7 +682,7 @@ MS:
     min_longitude: 10.0280523
     max_latitude: 44.0927356
     max_longitude: 10.108908
-  name: Massa-Carrara
+  name: Massa and Carrara
 MT:
   unofficial_names: Matera
   translations:
@@ -706,7 +706,7 @@ NA:
     min_longitude: 14.1394899
     max_latitude: 40.9159348
     max_longitude: 14.3537148
-  name: Napoli
+  name: Naples
 'NO':
   unofficial_names: Novara
   translations:
@@ -802,7 +802,7 @@ PD:
     min_longitude: 11.809626
     max_latitude: 45.4575002
     max_longitude: 11.9728649
-  name: Padova
+  name: Padua
 PE:
   unofficial_names: Pescara
   translations:
@@ -886,7 +886,7 @@ PU:
     min_longitude: 12.1854509
     max_latitude: 43.9692744
     max_longitude: 13.1725197
-  name: Pesaro e Urbino
+  name: Pesaro and Urbino
 PT:
   unofficial_names: Pistoia
   translations:
@@ -994,7 +994,7 @@ RM:
     min_longitude: 12.341707
     max_latitude: 42.0505462
     max_longitude: 12.7302888
-  name: Roma
+  name: Rome
 RN:
   unofficial_names: Rimini
   translations:
@@ -1078,7 +1078,7 @@ SR:
     min_longitude: 15.2405306
     max_latitude: 37.1056629
     max_longitude: 15.3012622
-  name: Siracusa
+  name: Syracuse
 SS:
   unofficial_names: Sassari
   translations:
@@ -1138,7 +1138,7 @@ TN:
     min_longitude: 11.0826925
     max_latitude: 46.1327915
     max_longitude: 11.1580189
-  name: Trento
+  name: Trentino
 TO:
   unofficial_names: Torino
   translations:
@@ -1150,7 +1150,7 @@ TO:
     min_longitude: 7.5778502
     max_latitude: 45.1335014
     max_longitude: 7.7623282
-  name: Torino
+  name: Turin
 TP:
   unofficial_names: Trapani
   translations:
@@ -1258,7 +1258,7 @@ VE:
     min_longitude: 12.1668278
     max_latitude: 45.5779746
     max_longitude: 12.5966574
-  name: Venezia
+  name: Venice
 VI:
   unofficial_names: Vicenza
   translations:

--- a/lib/countries/data/subdivisions/JM.yaml
+++ b/lib/countries/data/subdivisions/JM.yaml
@@ -83,7 +83,7 @@
     max_latitude: 18.511424
     max_longitude: -77.44148299999999
   name: Trelawny
-08:
+'08':
   unofficial_names: Saint James
   translations:
     en: Saint James
@@ -95,7 +95,7 @@
     max_latitude: 18.5253104
     max_longitude: -77.737876
   name: Saint James
-09:
+'09':
   unofficial_names: Hanover
   translations:
     en: Hanover

--- a/lib/countries/data/subdivisions/JO.yaml
+++ b/lib/countries/data/subdivisions/JO.yaml
@@ -12,7 +12,7 @@ AJ:
     min_longitude: 35.606699
     max_latitude: 32.40349
     max_longitude: 35.904965
-  name: Ajlun
+  name: Ajloun
 AM:
   unofficial_names:
   - Amman
@@ -56,7 +56,7 @@ AT:
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: At Tafilah
+  name: Tafilah
 AZ:
   unofficial_names:
   - Zarka
@@ -71,7 +71,7 @@ AZ:
     min_longitude: 35.8889939
     max_latitude: 32.196324
     max_longitude: 37.780864
-  name: Az Zarqa'
+  name: Zarqa
 BA:
   unofficial_names: Al Balqa'
   translations:
@@ -83,7 +83,7 @@ BA:
     min_longitude: 35.519307
     max_latitude: 32.183978
     max_longitude: 35.934166
-  name: Al Balqa'
+  name: Balqa
 IR:
   unofficial_names:
   - Irbit
@@ -110,7 +110,7 @@ JA:
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Jarash
+  name: Jerash
 KA:
   unofficial_names:
   - Karak
@@ -124,7 +124,7 @@ KA:
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Al Karak
+  name: Karak
 MA:
   unofficial_names:
   - Mafraq
@@ -137,7 +137,7 @@ MA:
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Al Mafraq
+  name: Mafraq
 MD:
   unofficial_names:
   - Madaba
@@ -166,4 +166,4 @@ MN:
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Ma`an
+  name: Ma’an

--- a/lib/countries/data/subdivisions/JP.yaml
+++ b/lib/countries/data/subdivisions/JP.yaml
@@ -13,7 +13,7 @@
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Hokkaido
+  name: Hokkaidō
 '02':
   unofficial_names: Aomori
   translations:
@@ -94,7 +94,7 @@
     max_latitude: 37.9766402
     max_longitude: 140.570933
   name: Fukushima
-08:
+'08':
   unofficial_names: Ibaraki
   translations:
     en: Ibaraki
@@ -107,7 +107,7 @@
     max_latitude: 36.9439966
     max_longitude: 140.8495266
   name: Ibaraki
-09:
+'09':
   unofficial_names:
   - Totigi
   - Tochigi
@@ -361,7 +361,7 @@
     min_longitude: 135.5589842
     max_latitude: 35.321192
     max_longitude: 135.8787786
-  name: Kyoto
+  name: Kyōto
 '27':
   unofficial_names:
   - Osaka
@@ -375,7 +375,7 @@
     min_longitude: 135.3728875
     max_latitude: 34.7687542
     max_longitude: 135.599171
-  name: Osaka
+  name: Ōsaka
 '28':
   unofficial_names:
   - Hyogo
@@ -389,7 +389,7 @@
     min_longitude: 134.2527119
     max_latitude: 35.674731
     max_longitude: 135.4685529
-  name: Hyogo
+  name: Hyōgo
 '29':
   unofficial_names: Nara
   translations:
@@ -541,7 +541,7 @@
     min_longitude: 133.3942252
     max_latitude: 33.6813748
     max_longitude: 133.6254958
-  name: Kochi
+  name: Kōchi
 '40':
   unofficial_names:
   - Hukuoka
@@ -609,7 +609,7 @@
     min_longitude: 131.418656
     max_latitude: 33.2805132
     max_longitude: 131.9568311
-  name: Oita
+  name: Ōita
 '45':
   unofficial_names: Miyazaki
   translations:

--- a/lib/countries/data/subdivisions/KG.yaml
+++ b/lib/countries/data/subdivisions/KG.yaml
@@ -26,7 +26,7 @@ C:
     min_longitude: 75.82733019999999
     max_latitude: 42.5099156
     max_longitude: 75.83318299999999
-  name: Chü
+  name: Chuy
 GB:
   unofficial_names:
   - Bishkek
@@ -78,7 +78,7 @@ O:
     min_longitude: 72.7557564
     max_latitude: 40.5649378
     max_longitude: 72.8613282
-  name: Osh
+  name: Osh Region
 T:
   unofficial_names: Talas
   translations:
@@ -106,4 +106,4 @@ Y:
     min_longitude: 75.5835659
     max_latitude: 42.951714
     max_longitude: 80.2831801
-  name: Ysyk-Köl
+  name: Issyk-Kul

--- a/lib/countries/data/subdivisions/KH.yaml
+++ b/lib/countries/data/subdivisions/KH.yaml
@@ -15,7 +15,7 @@
     min_longitude: 102.3400039
     max_latitude: 14.24883
     max_longitude: 103.44429
-  name: Banteay Mean Chey [Bântéay Méanchey]
+  name: Banteay Meanchey
 '10':
   unofficial_names:
   - Kratié
@@ -32,7 +32,7 @@
     min_longitude: 105.9990121
     max_latitude: 12.7869431
     max_longitude: 106.409197
-  name: Kracheh [Krâchéh]
+  name: Kratié
 '11':
   unofficial_names:
   - Mondolkiri
@@ -49,7 +49,7 @@
     min_longitude: 106.3519529
     max_latitude: 13.423394
     max_longitude: 107.606102
-  name: Mondol Kiri [Môndól Kiri]
+  name: Mondulkiri
 '12':
   unofficial_names:
   - Phnom Penh
@@ -64,7 +64,7 @@
     min_longitude: 104.779653
     max_latitude: 11.682486
     max_longitude: 104.968803
-  name: Phnom Penh [Phnum Pénh]
+  name: Phnom Penh
 '13':
   unofficial_names:
   - Preah Vihear [Preah Vihéar]
@@ -80,7 +80,7 @@
     min_longitude: 104.3539239
     max_latitude: 14.434327
     max_longitude: 105.8868709
-  name: Preah Vihear [Preah Vihéar]
+  name: Preah Vihear
 '14':
   unofficial_names:
   - Prey Vêng
@@ -97,7 +97,7 @@
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Prey Veaeng [Prey Vêng]
+  name: Prey Veng
 '15':
   unofficial_names:
   - Poŭthĭsăt
@@ -113,7 +113,7 @@
     min_longitude: 103.7871553
     max_latitude: 12.5827952
     max_longitude: 104.0180611
-  name: Pousaat [Pouthisat]
+  name: Pursat
 '16':
   unofficial_names:
   - Ratanakiri
@@ -132,7 +132,7 @@
     min_longitude: 106.5465848
     max_latitude: 14.6864041
     max_longitude: 107.6277161
-  name: Rotanak Kiri [Rôtânôkiri]
+  name: Ratanakiri
 '17':
   unofficial_names:
   - Siem Reap
@@ -148,7 +148,7 @@
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Siem Reab [Siemréab]
+  name: Siem Reap
 '18':
   unofficial_names:
   - Preah Seihânu
@@ -169,7 +169,7 @@
     min_longitude: 103.1816841
     max_latitude: 10.7803603
     max_longitude: 103.5925877
-  name: Krong Preah Sihanouk [Krong Preah Sihanouk]
+  name: Sihanoukville
 '19':
   unofficial_names:
   - Stoeng Trêng
@@ -185,7 +185,7 @@
     min_longitude: 105.521177
     max_latitude: 14.587619
     max_longitude: 106.6629029
-  name: Stueng Traeng [Stœ?ng Trêng]
+  name: Stung Treng
 '2':
   unofficial_names:
   - Batdâmbâng
@@ -201,7 +201,7 @@
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Baat Dambang [Batdâmbâng]
+  name: Battambang
 '20':
   unofficial_names:
   - Svaay Rieng [Svay Rieng]
@@ -217,7 +217,7 @@
     min_longitude: 105.7366598
     max_latitude: 11.1564031
     max_longitude: 105.8909941
-  name: Svaay Rieng [Svay Rieng]
+  name: Svay Rieng
 '21':
   unofficial_names:
   - Takeo
@@ -233,7 +233,7 @@
     min_longitude: 104.4379809
     max_latitude: 11.3528621
     max_longitude: 105.0994111
-  name: Taakaev [Takêv]
+  name: Takéo
 '22':
   unofficial_names:
   - 'Otdar Mean Chey [Otdâr Méanchey] '
@@ -250,7 +250,7 @@
     min_longitude: 103.0405579
     max_latitude: 14.4395071
     max_longitude: 104.4748511
-  name: 'Otdar Mean Chey [Otdâr Méanchey] '
+  name: Oddar Meanchey
 '23':
   unofficial_names:
   - Krong Kep [Krong Kêb]
@@ -264,7 +264,7 @@
     min_longitude: 104.2153591
     max_latitude: 10.5781139
     max_longitude: 104.3620275
-  name: Krong Kep [Krong Kêb]
+  name: Kep
 '24':
   unofficial_names:
   - Krong Pailin [Krong Pailin]
@@ -280,7 +280,7 @@
     min_longitude: 102.4972057
     max_latitude: 12.8922183
     max_longitude: 102.7534103
-  name: Krong Pailin [Krong Pailin]
+  name: Pailin
 '3':
   unofficial_names:
   - Kompong Cham
@@ -298,7 +298,7 @@
     min_longitude: 105.4002787
     max_latitude: 12.0178724
     max_longitude: 105.4737067
-  name: Kampong Chaam [Kâmpóng Cham]
+  name: Kampong Cham
 '4':
   unofficial_names:
   - Kompong Chhnang
@@ -314,7 +314,7 @@
     min_longitude: 104.6459342
     max_latitude: 12.3243638
     max_longitude: 104.7148133
-  name: Kampong Chhnang [Kâmpóng Chhnang]
+  name: Kampong Chhnang
 '5':
   unofficial_names:
   - Kompong Speu
@@ -333,7 +333,7 @@
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Kampong Spueu [Kâmpóng Spœ]
+  name: Kampong Speu
 '6':
   unofficial_names:
   - Kompong Thom
@@ -352,7 +352,7 @@
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Kampong Thum [Kâmpóng Thum]
+  name: Kampong Thom
 '7':
   unofficial_names:
   - Kampot [Kâmpôt]
@@ -368,7 +368,7 @@
     min_longitude: 103.8328105
     max_latitude: 11.1730128
     max_longitude: 104.7244262
-  name: Kampot [Kâmpôt]
+  name: Kampot
 '8':
   unofficial_names:
   - Kandaal [Kândal]
@@ -385,7 +385,7 @@
     min_longitude: 104.6909094
     max_latitude: 11.4589902
     max_longitude: 104.6949489
-  name: Kandaal [Kândal]
+  name: Kandal
 '9':
   unofficial_names:
   - Koh Kong
@@ -400,4 +400,4 @@
     min_longitude: 102.7800221
     max_latitude: 12.1494559
     max_longitude: 104.146877
-  name: Kaoh Kong [Kaôh Kong]
+  name: Koh Kong

--- a/lib/countries/data/subdivisions/KN.yaml
+++ b/lib/countries/data/subdivisions/KN.yaml
@@ -83,7 +83,7 @@
     max_latitude: 17.1527401
     max_longitude: -62.5767418
   name: Saint John Figtree
-08:
+'08':
   unofficial_names: Saint Mary Cayon
   translations:
     en: Saint Mary Cayon
@@ -95,7 +95,7 @@
     max_latitude: 17.371466
     max_longitude: -62.70542499999999
   name: Saint Mary Cayon
-09:
+'09':
   unofficial_names: Saint Paul Capisterre
   translations:
     en: Saint Paul Capisterre

--- a/lib/countries/data/subdivisions/KR.yaml
+++ b/lib/countries/data/subdivisions/KR.yaml
@@ -12,7 +12,7 @@
     min_longitude: 126.7645827
     max_latitude: 37.7017495
     max_longitude: 127.18359
-  name: Seoul Teugbyeolsi [Seoul-T'ukpyolshi]
+  name: Seoul
 '26':
   unofficial_names:
   - Busan
@@ -25,7 +25,7 @@
     min_longitude: 128.787197
     max_latitude: 35.3874414
     max_longitude: 129.3100483
-  name: Busan Gwang'yeogsi [Pusan-Kwangyokshi]
+  name: Busan
 '27':
   unofficial_names:
   - Daegu
@@ -38,7 +38,7 @@
     min_longitude: 128.3497208
     max_latitude: 36.0172827
     max_longitude: 128.7632175
-  name: Daegu Gwang'yeogsi [Taegu-Kwangyokshi]
+  name: Daegu
 '28':
   unofficial_names:
   - Incheon
@@ -52,7 +52,7 @@
     min_longitude: 124.608139
     max_latitude: 37.982666
     max_longitude: 126.7936273
-  name: Incheon Gwang'yeogsi [Inch'n-Kwangyokshi]
+  name: Incheon
 '29':
   unofficial_names:
   - Gwangju
@@ -65,7 +65,7 @@
     min_longitude: 126.6449036
     max_latitude: 35.2589426
     max_longitude: 127.0229414
-  name: Gwangju Gwang'yeogsi [Kwangju-Kwangyokshi]
+  name: Gwangju City
 '30':
   unofficial_names:
   - Daejeon
@@ -80,7 +80,7 @@
     min_longitude: 127.2464501
     max_latitude: 36.4999477
     max_longitude: 127.5590437
-  name: Daejeon Gwang'yeogsi [Taejon-Kwangyokshi]
+  name: Daejeon
 '31':
   unofficial_names: Ulsan Gwang'yeogsi [Ulsan-Kwangyokshi]
   translations:
@@ -92,7 +92,7 @@
     min_longitude: 128.9756829
     max_latitude: 35.7252482
     max_longitude: 129.4666138
-  name: Ulsan Gwang'yeogsi [Ulsan-Kwangyokshi]
+  name: Ulsan
 '41':
   unofficial_names: Gyeonggido [Kyonggi-do]
   translations:
@@ -104,7 +104,7 @@
     min_longitude: 126.3763885
     max_latitude: 38.3026711
     max_longitude: 127.8582527
-  name: Gyeonggido [Kyonggi-do]
+  name: Gyeonggi
 '42':
   unofficial_names:
   - Kangwon
@@ -117,7 +117,7 @@
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Gang'weondo [Kang-won-do]
+  name: Gangwon
 '43':
   unofficial_names:
   - North Chungchong
@@ -130,7 +130,7 @@
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Chungcheongbugdo [Ch'ungch'ongbuk-do]
+  name: North Chungcheong
 '44':
   unofficial_names:
   - South Chungchong
@@ -143,7 +143,7 @@
     min_longitude: 125.9581375
     max_latitude: 37.0618896
     max_longitude: 127.6396353
-  name: Chungcheongnamdo [Ch'ungch'ongnam-do]
+  name: South Chungcheong
 '45':
   unofficial_names:
   - Chollapuk
@@ -157,7 +157,7 @@
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Jeonrabugdo[Chollabuk-do]
+  name: North Jeolla
 '46':
   unofficial_names:
   - South Cholla
@@ -170,7 +170,7 @@
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Jeonranamdo [Chollanam-do]
+  name: South Jeolla
 '47':
   unofficial_names:
   - North Kyongsang
@@ -183,7 +183,7 @@
     min_longitude: 127.7938878
     max_latitude: 37.542778
     max_longitude: 130.9232178
-  name: Gyeongsangbugdo [Kyongsangbuk-do]
+  name: North Gyeongsang
 '48':
   unofficial_names:
   - Gyeongsangnamdo/ Kyongsang-namdo/ South Kyongsang
@@ -196,7 +196,7 @@
     min_longitude: 127.5622163
     max_latitude: 35.9099572
     max_longitude: 129.2198762
-  name: Gyeongsangnamdo [Kyongsangnam-do]
+  name: South Gyeongsang
 '49':
   unofficial_names:
   - Jeju
@@ -210,4 +210,4 @@
     min_longitude: 126.1637192
     max_latitude: 34.0062218
     max_longitude: 126.9742813
-  name: Jejudo [Cheju-do]
+  name: Jeju

--- a/lib/countries/data/subdivisions/KW.yaml
+++ b/lib/countries/data/subdivisions/KW.yaml
@@ -54,7 +54,7 @@ JA:
     min_longitude: 47.6289382
     max_latitude: 29.3745747
     max_longitude: 47.7926787
-  name: Al Jahrah
+  name: Al Jahra
 KU:
   unofficial_names:
   - Capital
@@ -71,7 +71,7 @@ KU:
     min_longitude: 47.95796259999999
     max_latitude: 29.3933479
     max_longitude: 48.0058081
-  name: Al Kuwayt
+  name: Al Asimah
 MU:
   unofficial_names: Mubarak al-Kabir
   translations:
@@ -83,4 +83,4 @@ MU:
     min_longitude: 47.983255
     max_latitude: 29.2734889
     max_longitude: 48.1176184
-  name: Mubarak al-Kabir
+  name: Mubarak Al-Kabeer

--- a/lib/countries/data/subdivisions/KZ.yaml
+++ b/lib/countries/data/subdivisions/KZ.yaml
@@ -15,7 +15,7 @@ AKM:
     min_longitude: 65.2571501
     max_latitude: 53.708545
     max_longitude: 74.19755889999999
-  name: Aqmola oblysy
+  name: Akmola
 AKT:
   unofficial_names:
   - Aktjubinsk
@@ -31,7 +31,7 @@ AKT:
     min_longitude: 53.5261182
     max_latitude: 51.339557
     max_longitude: 64.1807611
-  name: Aqtöbe oblysy
+  name: Aktobe
 ALA:
   unofficial_names:
   - Almati Oblasti
@@ -58,7 +58,7 @@ ALM:
     min_longitude: 74.0447233
     max_latitude: 47.329847
     max_longitude: 82.63085889999999
-  name: Almaty oblysy
+  name: Almaty Region
 AST:
   unofficial_names: Astana
   translations:
@@ -88,7 +88,7 @@ ATY:
     min_longitude: 46.994003
     max_latitude: 49.270703
     max_longitude: 56.37093609999999
-  name: Atyrau oblysy
+  name: Atyrau
 BAY:
   unofficial_names: Bayqongyr
   translations:
@@ -117,7 +117,7 @@ KAR:
     min_longitude: 62.6005359
     max_latitude: 51.38928199999999
     max_longitude: 77.6211869
-  name: Qaraghandy oblysy
+  name: Karagandy
 KUS:
   unofficial_names:
   - Kostanay
@@ -134,7 +134,7 @@ KUS:
     min_longitude: 60.0529098
     max_latitude: 54.7125819
     max_longitude: 68.02896299999999
-  name: Qostanay oblysy
+  name: Kostanay
 KZY:
   unofficial_names:
   - Ak-Mechet
@@ -153,7 +153,7 @@ KZY:
     min_longitude: 58.7882902
     max_latitude: 47.854687
     max_longitude: 68.0135679
-  name: Qyzylorda oblysy
+  name: Kyzylorda
 MAN:
   unofficial_names:
   - Mangghystau
@@ -169,7 +169,7 @@ MAN:
     min_longitude: 50.0048314
     max_latitude: 46.461712
     max_longitude: 56.696327
-  name: Mangghystau oblysy
+  name: Mangystau
 PAV:
   unofficial_names: Pavlodar oblysy
   translations:
@@ -181,7 +181,7 @@ PAV:
     min_longitude: 73.282956
     max_latitude: 54.4579159
     max_longitude: 79.590622
-  name: Pavlodar oblysy
+  name: Pavlodar
 SEV:
   unofficial_names:
   - Northern Kazakhstan
@@ -196,7 +196,7 @@ SEV:
     min_longitude: 69.35711859999999
     max_latitude: 53.3444028
     max_longitude: 69.4638061
-  name: Soltüstik Qazaqstan oblysy
+  name: North Kazakhstan
 VOS:
   unofficial_names:
   - Eastern Kazakhstan
@@ -211,7 +211,7 @@ VOS:
     min_longitude: 76.76924199999999
     max_latitude: 51.4008139
     max_longitude: 87.3126599
-  name: Shyghys Qazaqstan oblysy
+  name: East Kazakhstan
 YUZ:
   unofficial_names:
   - Ongtüstik Qazaqstan
@@ -226,7 +226,7 @@ YUZ:
     min_longitude: 46.4918561
     max_latitude: 51.76659799999999
     max_longitude: 54.5574649
-  name: Ongtüstik Qazaqstan oblysy
+  name: South Kazakhstan
 ZAP:
   unofficial_names:
   - Batis Kazakstan
@@ -243,7 +243,7 @@ ZAP:
     min_longitude: 46.4918561
     max_latitude: 51.76659799999999
     max_longitude: 54.5574649
-  name: Batys Qazaqstan oblysy
+  name: West Kazakhstan
 ZHA:
   unofficial_names:
   - Aulie-Ata
@@ -264,4 +264,4 @@ ZHA:
     min_longitude: 68.9939081
     max_latitude: 46.0366224
     max_longitude: 75.77342999999999
-  name: Zhambyl oblysy
+  name: Jambyl

--- a/lib/countries/data/subdivisions/LA.yaml
+++ b/lib/countries/data/subdivisions/LA.yaml
@@ -13,7 +13,7 @@ AT:
     min_longitude: 106.8068505
     max_latitude: 14.8316255
     max_longitude: 106.8385219
-  name: Attapu [Attopeu]
+  name: Attapeu
 BK:
   unofficial_names: Bokèo
   translations:
@@ -25,7 +25,7 @@ BK:
     min_longitude: 100.093056
     max_latitude: 20.838158
     max_longitude: 101.2517739
-  name: Bokèo
+  name: Bokeo
 BL:
   unofficial_names:
   - Bolikhamsai
@@ -40,7 +40,7 @@ BL:
     min_longitude: 102.806132
     max_latitude: 19.123211
     max_longitude: 105.26368
-  name: Bolikhamxai [Borikhane]
+  name: Bolikhamsai
 CH:
   unofficial_names:
   - Champasack
@@ -54,7 +54,7 @@ CH:
     min_longitude: 105.8406544
     max_latitude: 14.9311844
     max_longitude: 105.8913803
-  name: Champasak [Champassak]
+  name: Champasak
 HO:
   unofficial_names:
   - Houaphan
@@ -67,7 +67,7 @@ HO:
     min_longitude: 103.105952
     max_latitude: 20.981848
     max_longitude: 104.9918211
-  name: Houaphan
+  name: Houaphanh
 KH:
   unofficial_names: Khammouan
   translations:
@@ -79,7 +79,7 @@ KH:
     min_longitude: 104.2752
     max_latitude: 18.26511
     max_longitude: 106.4278179
-  name: Khammouan
+  name: Khammouane
 LM:
   unofficial_names:
   - Louang Namtha
@@ -95,7 +95,7 @@ LM:
     min_longitude: 101.3745403
     max_latitude: 21.0397262
     max_longitude: 101.4444065
-  name: Louang Namtha
+  name: Luang Namtha
 LP:
   unofficial_names:
   - Louang Phrabang
@@ -111,7 +111,7 @@ LP:
     min_longitude: 102.1182632
     max_latitude: 19.906138
     max_longitude: 102.1728516
-  name: Louangphabang [Louang Prabang]
+  name: Luang Prabang
 OU:
   unofficial_names:
   - Oudomsai
@@ -125,7 +125,7 @@ OU:
     min_longitude: 100.7239439
     max_latitude: 21.2127588
     max_longitude: 102.35669
-  name: Oudômxai [Oudomsai]
+  name: Oudomxay
 PH:
   unofficial_names:
   - Phongsali
@@ -138,7 +138,7 @@ PH:
     min_longitude: 102.0874929
     max_latitude: 21.6996212
     max_longitude: 102.1256446
-  name: Phôngsali [Phong Saly]
+  name: Phongsaly
 SL:
   unofficial_names:
   - Saravane
@@ -151,7 +151,7 @@ SL:
     min_longitude: 106.393404
     max_latitude: 15.725096
     max_longitude: 106.4305044
-  name: Salavan [Saravane]
+  name: Salavan
 SV:
   unofficial_names: Savannakhét
   translations:
@@ -163,7 +163,7 @@ SV:
     min_longitude: 104.7402586
     max_latitude: 16.6266521
     max_longitude: 104.7958841
-  name: Savannakhét
+  name: Savannakhet
 VI:
   unofficial_names:
   - Vientiane Province
@@ -176,7 +176,7 @@ VI:
     min_longitude: 102.5341096
     max_latitude: 18.0318289
     max_longitude: 102.6774216
-  name: Vientiane
+  name: Vientiane Province
 VT:
   unofficial_names:
   - Viangchan City
@@ -190,7 +190,7 @@ VT:
     min_longitude: 102.0385339
     max_latitude: 18.43515
     max_longitude: 103.101063
-  name: Vientiane Prefecture
+  name: Vientiane
 XA:
   unofficial_names:
   - Sayaboury
@@ -205,7 +205,7 @@ XA:
     min_longitude: 100.4117971
     max_latitude: 19.9302149
     max_longitude: 101.8970158
-  name: Xaignabouli [Sayaboury]
+  name: Sainyabuli
 XE:
   unofficial_names:
   - Xékong
@@ -218,7 +218,7 @@ XE:
     min_longitude: 106.6949272
     max_latitude: 15.3708533
     max_longitude: 106.7550086
-  name: Xékong [Sékong]
+  name: Sekong
 XI:
   unofficial_names:
   - Xiang Khouang
@@ -234,7 +234,7 @@ XI:
     min_longitude: 102.661909
     max_latitude: 20.040053
     max_longitude: 104.279344
-  name: Xiangkhoang [Xieng Khouang]
+  name: Xiangkhouang
 XN:
   unofficial_names:
   - Xaisômboun
@@ -247,4 +247,4 @@ XN:
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Xaisômboun
+  name: Xaisomboun

--- a/lib/countries/data/subdivisions/LB.yaml
+++ b/lib/countries/data/subdivisions/LB.yaml
@@ -12,7 +12,7 @@ AS:
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Loubnâne ech Chemâli
+  name: North
 BA:
   unofficial_names:
   - Bayrout
@@ -43,7 +43,7 @@ BI:
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: El Béqaa
+  name: Beqaa
 JA:
   unofficial_names:
   - South
@@ -56,7 +56,7 @@ JA:
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Loubnâne ej Jnoûbi
+  name: South
 JL:
   unofficial_names:
   - Mount Lebanon
@@ -69,7 +69,7 @@ JL:
     min_longitude: 35.3858701
     max_latitude: 34.2113502
     max_longitude: 36.0150637
-  name: Jabal Loubnâne
+  name: Mount Lebanon
 NA:
   unofficial_names:
   - Nabatiyeh
@@ -82,4 +82,4 @@ NA:
     min_longitude: 35.2418835
     max_latitude: 33.5112517
     max_longitude: 35.86385569999999
-  name: Nabatîyé
+  name: Nabatieh

--- a/lib/countries/data/subdivisions/LI.yaml
+++ b/lib/countries/data/subdivisions/LI.yaml
@@ -84,7 +84,7 @@
     max_latitude: 
     max_longitude: 
   name: Schaan
-08:
+'08':
   unofficial_names: Schellenberg
   translations:
     en: Schellenberg
@@ -96,7 +96,7 @@
     max_latitude: 47.25243
     max_longitude: 9.56735
   name: Schellenberg
-09:
+'09':
   unofficial_names: Triesen
   translations:
     en: Triesen

--- a/lib/countries/data/subdivisions/LK.yaml
+++ b/lib/countries/data/subdivisions/LK.yaml
@@ -179,7 +179,7 @@
     min_longitude: 80.8070613
     max_latitude: 9.2764461
     max_longitude: 80.8227488
-  name: Mullaittivu
+  name: Mullaitivu
 '51':
   unofficial_names:
   - Mad̨akalpūwa
@@ -298,7 +298,7 @@
     min_longitude: 81.3208008
     max_latitude: 6.9151796
     max_longitude: 81.3671493
-  name: Monaragala
+  name: Moneragala
 '91':
   unofficial_names:
   - Ratnapūraya
@@ -324,4 +324,4 @@
     min_longitude: 80.3318596
     max_latitude: 7.264479499999999
     max_longitude: 80.3595828
-  name: Kegalla
+  name: Kegalle

--- a/lib/countries/data/subdivisions/LS.yaml
+++ b/lib/countries/data/subdivisions/LS.yaml
@@ -70,7 +70,7 @@ F:
     min_longitude: 27.4296428
     max_latitude: -30.1215401
     max_longitude: 27.4988436
-  name: Mohale's Hoek
+  name: Mohale’s Hoek
 G:
   unofficial_names: Quthing
   translations:
@@ -94,7 +94,7 @@ H:
     min_longitude: 28.6603689
     max_latitude: -30.09698209999999
     max_longitude: 28.700881
-  name: Qacha's Nek
+  name: Qacha’s Nek
 J:
   unofficial_names: Mokhotlong
   translations:

--- a/lib/countries/data/subdivisions/LT.yaml
+++ b/lib/countries/data/subdivisions/LT.yaml
@@ -10,7 +10,7 @@ AL:
     min_longitude: 23.3125978
     max_latitude: 54.5634689
     max_longitude: 25.025222
-  name: Alytaus Apskritis
+  name: Alytus County
 KL:
   unofficial_names:
   - Klaipedos
@@ -23,7 +23,7 @@ KL:
     min_longitude: 20.9531999
     max_latitude: 56.38402379999999
     max_longitude: 22.0260791
-  name: Klaipedos Apskritis
+  name: Klaipėda County
 KU:
   unofficial_names: Kauno Apskritis
   translations:
@@ -35,7 +35,7 @@ KU:
     min_longitude: 22.6715098
     max_latitude: 55.57691699999999
     max_longitude: 24.811666
-  name: Kauno Apskritis
+  name: Kaunas County
 MR:
   unofficial_names:
   - Mariampoles
@@ -48,7 +48,7 @@ MR:
     min_longitude: 22.58981
     max_latitude: 55.104489
     max_longitude: 23.7938401
-  name: Marijampoles Apskritis
+  name: Marijampolė County
 PN:
   unofficial_names:
   - Panevezhio
@@ -61,7 +61,7 @@ PN:
     min_longitude: 23.8790478
     max_latitude: 56.45032089999999
     max_longitude: 26.0457081
-  name: Panevežio Apskritis
+  name: Panevėžys County
 SA:
   unofficial_names:
   - Shiauliu
@@ -74,7 +74,7 @@ SA:
     min_longitude: 22.4657018
     max_latitude: 56.41505489999999
     max_longitude: 24.1824539
-  name: Šiauliu Apskritis
+  name: Šiauliai County
 TA:
   unofficial_names:
   - Taurages
@@ -87,7 +87,7 @@ TA:
     min_longitude: 21.649398
     max_latitude: 55.68873199999999
     max_longitude: 23.5038912
-  name: Taurages Apskritis
+  name: Tauragė County
 TE:
   unofficial_names:
   - Telshiu
@@ -100,7 +100,7 @@ TE:
     min_longitude: 21.5120119
     max_latitude: 56.4320116
     max_longitude: 22.7381388
-  name: Telšiu Apskritis
+  name: Telšiai County
 UT:
   unofficial_names: Utenos Apskritis
   translations:
@@ -112,7 +112,7 @@ UT:
     min_longitude: 24.653176
     max_latitude: 55.94378
     max_longitude: 26.8355798
-  name: Utenos Apskritis
+  name: Utena County
 VL:
   unofficial_names: Vilniaus Apskritis
   translations:
@@ -124,4 +124,4 @@ VL:
     min_longitude: 24.3863751
     max_latitude: 55.5174369
     max_longitude: 26.760213
-  name: Vilniaus Apskritis
+  name: Vilnius County

--- a/lib/countries/data/subdivisions/LU.yaml
+++ b/lib/countries/data/subdivisions/LU.yaml
@@ -35,4 +35,4 @@ L:
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Luxembourg (fr)
+  name: Luxembourg

--- a/lib/countries/data/subdivisions/LV.yaml
+++ b/lib/countries/data/subdivisions/LV.yaml
@@ -154,7 +154,7 @@ JUR:
     min_longitude: 23.47297
     max_latitude: 57.007044
     max_longitude: 23.9693479
-  name: Jurmala
+  name: Jūrmala
 KR:
   unofficial_names: Kraslavas Aprinkis
   translations:
@@ -214,7 +214,7 @@ LPX:
     min_longitude: 20.971237
     max_latitude: 56.60919999999999
     max_longitude: 21.1057334
-  name: Liepaja
+  name: Liepāja
 LU:
   unofficial_names: Ludzas Aprinkis
   translations:
@@ -287,7 +287,7 @@ REZ:
     min_longitude: 27.3038497
     max_latitude: 56.53846009999999
     max_longitude: 27.379451
-  name: Rezekne
+  name: Rēzekne
 RI:
   unofficial_names: Rigas Aprinkis
   translations:

--- a/lib/countries/data/subdivisions/LY.yaml
+++ b/lib/countries/data/subdivisions/LY.yaml
@@ -22,7 +22,7 @@ BA:
     min_longitude: 19.9999527
     max_latitude: 32.2094962
     max_longitude: 20.2884299
-  name: Banghazi
+  name: Benghazi
 BU:
   unofficial_names: Al Butnan
   translations:
@@ -34,7 +34,7 @@ BU:
     min_longitude: 23.0024879
     max_latitude: 32.2137814
     max_longitude: 25.1495356
-  name: Al Butnan
+  name: Butnan
 BW:
   unofficial_names: Bani Walid
   translations:
@@ -58,7 +58,7 @@ DR:
     min_longitude: 22.6118888
     max_latitude: 32.7750619
     max_longitude: 22.6741272
-  name: Darnah
+  name: Derna
 GD:
   unofficial_names: Ghadamis
   translations:
@@ -118,7 +118,7 @@ JA:
     min_longitude: 21.3707509
     max_latitude: 32.9385909
     max_longitude: 22.0534001
-  name: Al Jabal al Akh?ar
+  name: Jabal al Akhdar
 JB:
   unofficial_names: Jaghbub
   translations:
@@ -142,7 +142,7 @@ JI:
     min_longitude: 12.678772
     max_latitude: 32.756192
     max_longitude: 13.1125019
-  name: Al Jifarah
+  name: Jafara
 JU:
   unofficial_names: Al Jufrah
   translations:
@@ -154,7 +154,7 @@ JU:
     min_longitude: 14.263115
     max_latitude: 29.8889149
     max_longitude: 18.9787859
-  name: Al Jufrah
+  name: Jufra
 KF:
   unofficial_names: Al Kufrah
   translations:
@@ -166,7 +166,7 @@ KF:
     min_longitude: 18.9363769
     max_latitude: 27.0215295
     max_longitude: 25
-  name: Al Kufrah
+  name: Kufra
 MB:
   unofficial_names: Al Marqab
   translations:
@@ -178,7 +178,7 @@ MB:
     min_longitude: 13.1125019
     max_latitude: 32.783028
     max_longitude: 14.6691879
-  name: Al Marqab
+  name: Murqub
 MI:
   unofficial_names: Misratah
   translations:
@@ -190,7 +190,7 @@ MI:
     min_longitude: 14.9191761
     max_latitude: 32.4306869
     max_longitude: 15.2752876
-  name: Misratah
+  name: Misrata
 MJ:
   unofficial_names: Al Marj
   translations:
@@ -202,7 +202,7 @@ MJ:
     min_longitude: 20.7941151
     max_latitude: 32.5197498
     max_longitude: 20.8616169
-  name: Al Marj
+  name: Marj
 MQ:
   unofficial_names: Murzuq
   translations:
@@ -250,7 +250,7 @@ NQ:
     min_longitude: 11.3924129
     max_latitude: 33.1688603
     max_longitude: 12.4340378
-  name: An Nuqat al Khams
+  name: Nuqat al Khams
 QB:
   unofficial_names: Al Qubbah
   translations:
@@ -310,7 +310,7 @@ SR:
     min_longitude: 16.5155527
     max_latitude: 31.2135519
     max_longitude: 16.6286411
-  name: Surt
+  name: Sirte
 SS:
   unofficial_names: Sabratah Surman
   translations:
@@ -337,7 +337,7 @@ TB:
     min_longitude: 13.1531882
     max_latitude: 32.9019297
     max_longitude: 13.2234836
-  name: Tarabulus
+  name: Tripoli
 TM:
   unofficial_names: Tarhunah-Masallatah
   translations:
@@ -373,7 +373,7 @@ WA:
     min_longitude: 14.4937963
     max_latitude: 32.3185818
     max_longitude: 14.5151013
-  name: Al Wa?ah
+  name: Al Wahat
 WD:
   unofficial_names: Wadi al ?ayat
   translations:
@@ -385,7 +385,7 @@ WD:
     min_longitude: 31.2627233
     max_latitude: 29.5447935
     max_longitude: 31.305119
-  name: Wadi al ?ayat
+  name: Wadi al Hayaa
 YJ:
   unofficial_names: Yafran-Jadu
   translations:
@@ -409,4 +409,4 @@ ZA:
     min_longitude: 11.934911
     max_latitude: 32.828812
     max_longitude: 12.9854179
-  name: Az Zawiyah
+  name: Zawiya

--- a/lib/countries/data/subdivisions/MA.yaml
+++ b/lib/countries/data/subdivisions/MA.yaml
@@ -10,7 +10,7 @@ AGD:
     min_longitude: -9.6682679
     max_latitude: 30.4702104
     max_longitude: -9.4871341
-  name: Agadir*
+  name: Agadir-Ida Ou Tanane
 AOU:
   unofficial_names: Aousserd
   translations:
@@ -70,7 +70,7 @@ BEM:
     min_longitude: -6.4301777
     max_latitude: 32.367638
     max_longitude: -6.3162803
-  name: Beni Mellal
+  name: Béni-Mellal
 BER:
   unofficial_names: Berkane
   translations:
@@ -106,7 +106,7 @@ BOD:
     min_longitude: -13.1729662
     max_latitude: 28.2162268
     max_longitude: -11.50715
-  name: Boujdour (EH)
+  name: Boujdour
 BOM:
   unofficial_names: Boulemane
   translations:
@@ -130,7 +130,7 @@ CAS:
     min_longitude: -7.7164613
     max_latitude: 33.649659
     max_longitude: -7.4582757
-  name: Casablanca [Dar el Beïda]*
+  name: Casablanca
 CHE:
   unofficial_names: Chefchaouene
   translations:
@@ -142,7 +142,7 @@ CHE:
     min_longitude: -5.287148999999999
     max_latitude: 35.185559
     max_longitude: -5.2556705
-  name: Chefchaouene
+  name: Chefchaouen
 CHI:
   unofficial_names: Chichaoua
   translations:
@@ -166,7 +166,7 @@ CHT:
     min_longitude: -9.166395699999999
     max_latitude: 30.0738757
     max_longitude: -9.1488218
-  name: Chtouka-Ait Baha
+  name: Chtouka Aït Baha
 ERR:
   unofficial_names: Errachidia
   translations:
@@ -202,7 +202,7 @@ ESM:
     min_longitude: -11.1281028
     max_latitude: 30.4073509
     max_longitude: -6.263147
-  name: Es Smara (EH)
+  name: Es Semara
 FAH:
   unofficial_names: Fahs-Beni Makada
   translations:
@@ -226,7 +226,7 @@ FES:
     min_longitude: -5.0755978
     max_latitude: 34.075377
     max_longitude: -4.927883
-  name: Fès*
+  name: Fès-Dar-Dbibegh
 FIG:
   unofficial_names: Figuig
   translations:
@@ -370,7 +370,7 @@ KHN:
     min_longitude: -5.691261300000001
     max_latitude: 32.9613621
     max_longitude: -5.6215668
-  name: Khenifra
+  name: Khénifra
 KHO:
   unofficial_names: Khouribga
   translations:
@@ -394,7 +394,7 @@ LAA:
     min_longitude: -13.2541466
     max_latitude: 27.1669433
     max_longitude: -13.0969906
-  name: Laâyoune* (EH)
+  name: Laâyoune
 LAR:
   unofficial_names: Larache
   translations:
@@ -442,7 +442,7 @@ MEK:
     min_longitude: -5.6096258
     max_latitude: 33.9281185
     max_longitude: -5.466414599999999
-  name: Meknès*
+  name: Meknès
 MEL:
   unofficial_names: Aït Melloul
   translations:
@@ -514,7 +514,7 @@ OUD:
     min_longitude: -16.9578964
     max_latitude: 21.3696659
     max_longitude: -16.9564694
-  name: Oued ed Dahab (EH)
+  name: Oued Ed-Dahab
 OUJ:
   unofficial_names: Oujda*
   translations:
@@ -526,7 +526,7 @@ OUJ:
     min_longitude: -1.963159
     max_latitude: 34.7273116
     max_longitude: -1.8517972
-  name: Oujda*
+  name: Oujda-Angad
 RBA:
   unofficial_names: Rabat-Salé*
   translations:
@@ -610,7 +610,7 @@ SKH:
     min_longitude: -7.0053398
     max_latitude: 33.9586252
     max_longitude: -6.877097999999999
-  name: Skhirate-Témara
+  name: Skhirat-Témara
 SYB:
   unofficial_names: Sidi Youssef Ben Ali
   translations:
@@ -658,7 +658,7 @@ TAR:
     min_longitude: -8.9028739
     max_latitude: 30.497608
     max_longitude: -8.8509464
-  name: Taroudannt
+  name: Taroudant
 TAT:
   unofficial_names: Tata
   translations:
@@ -694,7 +694,7 @@ TET:
     min_longitude: -5.4377174
     max_latitude: 35.6139067
     max_longitude: -5.2952385
-  name: Tétouan*
+  name: Tétouan
 TIZ:
   unofficial_names: Tiznit
   translations:
@@ -718,7 +718,7 @@ TNG:
     min_longitude: -5.9487488
     max_latitude: 35.8257368
     max_longitude: -5.718555500000001
-  name: Tanger
+  name: Tangier-Assilah
 TNT:
   unofficial_names: Tan-Tan
   translations:

--- a/lib/countries/data/subdivisions/MD.yaml
+++ b/lib/countries/data/subdivisions/MD.yaml
@@ -10,7 +10,7 @@ BA:
     min_longitude: 27.8344632
     max_latitude: 47.81119469999999
     max_longitude: 27.9682947
-  name: Balti
+  name: Bălţi
 CA:
   unofficial_names: Cahul
   translations:
@@ -46,7 +46,7 @@ CU:
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Chisinau
+  name: Chișinău
 ED:
   unofficial_names: Edinet
   translations:
@@ -58,7 +58,7 @@ ED:
     min_longitude: 27.2787093
     max_latitude: 48.1892079
     max_longitude: 27.3280621
-  name: Edinet
+  name: Edineț
 GA:
   unofficial_names: Gagauzia, Unitate Teritoriala Autonoma (UTAG)
   translations:
@@ -70,7 +70,7 @@ GA:
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Gagauzia, Unitate Teritoriala Autonoma (UTAG)
+  name: Gagauzia
 LA:
   unofficial_names: Lapusna
   translations:
@@ -106,7 +106,7 @@ SN:
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Stînga Nistrului, unitatea teritoriala din
+  name: Transnistria
 SO:
   unofficial_names: Soroca
   translations:

--- a/lib/countries/data/subdivisions/ME.yaml
+++ b/lib/countries/data/subdivisions/ME.yaml
@@ -83,7 +83,7 @@
     max_latitude: 42.5631326
     max_longitude: 19.1203737
   name: Danilovgrad
-08:
+'08':
   unofficial_names: Herceg-Novi
   translations:
     en: Herceg-Novi
@@ -94,8 +94,8 @@
     min_longitude: 18.5141516
     max_latitude: 42.4661614
     max_longitude: 18.5613638
-  name: Herceg-Novi
-09:
+  name: Herceg Novi
+'09':
   unofficial_names: Kolašin
   translations:
     en: Kolašin
@@ -142,7 +142,7 @@
     min_longitude: 18.897965
     max_latitude: 42.8094439
     max_longitude: 18.9982796
-  name: Nikšic´
+  name: Nikšić
 '13':
   unofficial_names: Plav
   translations:

--- a/lib/countries/data/subdivisions/MH.yaml
+++ b/lib/countries/data/subdivisions/MH.yaml
@@ -10,7 +10,7 @@ ALK:
     min_longitude: 169.8527981
     max_latitude: 10.4770933
     max_longitude: 169.9918842
-  name: Ailuk
+  name: Ailuk Atoll
 ALL:
   unofficial_names:
   - Ailinglaplap
@@ -23,7 +23,7 @@ ALL:
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Ailinglapalap
+  name: Ailinglaplap Atoll
 ARN:
   unofficial_names: Arno
   translations:
@@ -47,7 +47,7 @@ AUR:
     min_longitude: 171.0095787
     max_latitude: 8.3719296
     max_longitude: 171.1815612
-  name: Aur
+  name: Aur Atoll
 EBO:
   unofficial_names:
   - Epoon
@@ -60,7 +60,7 @@ EBO:
     min_longitude: 168.645512
     max_latitude: 4.679086
     max_longitude: 168.771286
-  name: Ebon
+  name: Ebon Atoll
 ENI:
   unofficial_names:
   - Eniwetok
@@ -73,7 +73,7 @@ ENI:
     min_longitude: 162.3176258
     max_latitude: 11.3603022
     max_longitude: 162.3477857
-  name: Eniwetok
+  name: Enewetak Atoll
 JAB:
   unofficial_names:
   - Jabat
@@ -86,7 +86,7 @@ JAB:
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Jabat
+  name: Jabat Island
 JAL:
   unofficial_names:
   - Jālwōj
@@ -99,7 +99,7 @@ JAL:
     min_longitude: 169.6336838
     max_latitude: 5.9135236
     max_longitude: 169.6408152
-  name: Jaluit
+  name: Jaluit Atoll
 KIL:
   unofficial_names:
   - Kōle
@@ -112,7 +112,7 @@ KIL:
     min_longitude: 169.1113473
     max_latitude: 5.6515189
     max_longitude: 169.13229
-  name: Kili
+  name: Kili Island
 KWA:
   unofficial_names:
   - Kuwajleen
@@ -137,7 +137,7 @@ LAE:
     min_longitude: 166.2089826
     max_latitude: 8.967658199999999
     max_longitude: 166.2777327
-  name: Lae
+  name: Lae Atoll
 LIB:
   unofficial_names:
   - Ellep
@@ -150,7 +150,7 @@ LIB:
     min_longitude: 167.3744881
     max_latitude: 8.3155625
     max_longitude: 167.3767197
-  name: Lib
+  name: Lib Island
 LIK:
   unofficial_names: Likiep
   translations:
@@ -162,7 +162,7 @@ LIK:
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Likiep
+  name: Likiep Atoll
 MAJ:
   unofficial_names:
   - Mājro
@@ -187,7 +187,7 @@ MAL:
     min_longitude: 170.827446
     max_latitude: 8.9118677
     max_longitude: 171.2449265
-  name: Maloelap
+  name: Maloelap Atoll
 MEJ:
   unofficial_names:
   - Mājeej
@@ -200,7 +200,7 @@ MEJ:
     min_longitude: 170.8581735
     max_latitude: 10.306897
     max_longitude: 170.8803177
-  name: Mejit
+  name: Mejit Island
 MIL:
   unofficial_names: Mili
   translations:
@@ -212,7 +212,7 @@ MIL:
     min_longitude: 171.7130469
     max_latitude: 6.263768799999999
     max_longitude: 172.1221161
-  name: Mili
+  name: Mili Atoll
 NMK:
   unofficial_names: Namorik
   translations:
@@ -224,7 +224,7 @@ NMK:
     min_longitude: 168.0974954
     max_latitude: 5.6431987
     max_longitude: 168.1334145
-  name: Namorik
+  name: Namdrik Atoll
 NMU:
   unofficial_names:
   - Namo
@@ -237,7 +237,7 @@ NMU:
     min_longitude: 167.9631042
     max_latitude: 8.2196454
     max_longitude: 168.3132935
-  name: Namu
+  name: Namu Atoll
 RON:
   unofficial_names: Rongelap
   translations:
@@ -249,7 +249,7 @@ RON:
     min_longitude: 166.6118289
     max_latitude: 11.5044166
     max_longitude: 167.0652294
-  name: Rongelap
+  name: Rongelap Atoll
 UJA:
   unofficial_names: Ujae
   translations:
@@ -261,7 +261,7 @@ UJA:
     min_longitude: 165.5181098
     max_latitude: 9.2262549
     max_longitude: 165.7703877
-  name: Ujae
+  name: Ujae Atoll
 UJL:
   unofficial_names: Ujelang
   translations:
@@ -288,7 +288,7 @@ UTI:
     min_longitude: 169.8474976
     max_latitude: 11.2233218
     max_longitude: 169.8563474
-  name: Utirik
+  name: Utirik Atoll
 WTH:
   unofficial_names:
   - Wōtto
@@ -301,7 +301,7 @@ WTH:
     min_longitude: 165.9193897
     max_latitude: 10.1839202
     max_longitude: 166.0299827
-  name: Wotho
+  name: Wotho Atoll
 WTJ:
   unofficial_names: Wotje
   translations:
@@ -313,4 +313,4 @@ WTJ:
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Wotje
+  name: Wotje Atoll

--- a/lib/countries/data/subdivisions/MN.yaml
+++ b/lib/countries/data/subdivisions/MN.yaml
@@ -10,7 +10,7 @@
     min_longitude: 104.004139
     max_latitude: 49.1322389
     max_longitude: 104.577072
-  name: Orhon
+  name: Orkhon
 '037':
   unofficial_names: Darhan uul
   translations:
@@ -22,8 +22,8 @@
     min_longitude: 105.8157009
     max_latitude: 49.82596590000001
     max_longitude: 106.806087
-  name: Darhan uul
-039:
+  name: Darkhan-Uul
+'039':
   unofficial_names:
   - Hentii
   - Khentii
@@ -36,7 +36,7 @@
     min_longitude: 108.350123
     max_latitude: 49.4067421
     max_longitude: 112.6971711
-  name: Hentiy
+  name: Khentii
 '041':
   unofficial_names:
   - Hovsgol
@@ -50,7 +50,7 @@
     min_longitude: 96.879998
     max_latitude: 52.1542471
     max_longitude: 102.78852
-  name: Hövsgöl
+  name: Khövsgöl
 '043':
   unofficial_names:
   - Khovd
@@ -63,7 +63,7 @@
     min_longitude: 91.6108704
     max_latitude: 48.0193817
     max_longitude: 91.67026520000002
-  name: Hovd
+  name: Khovd
 '046':
   unofficial_names: Uvs
   translations:
@@ -89,7 +89,7 @@
     max_latitude: 49.1231531
     max_longitude: 109.044458
   name: Töv
-049:
+'049':
   unofficial_names: Selenge
   translations:
     en: Selenge
@@ -113,7 +113,7 @@
     min_longitude: 106.1433793
     max_latitude: 50.265753
     max_longitude: 106.2765886
-  name: Sühbaatar
+  name: Sükhbaatar
 '053':
   unofficial_names:
   - Omnogobi
@@ -140,7 +140,7 @@
     min_longitude: 101.1333329
     max_latitude: 47.414307
     max_longitude: 104.655877
-  name: Övörhangay
+  name: Övörkhangai
 '057':
   unofficial_names:
   - Zavkhan
@@ -153,8 +153,8 @@
     min_longitude: 93.17390499999999
     max_latitude: 50.041237
     max_longitude: 99.2185871
-  name: Dzavhan
-059:
+  name: Zavkhan
+'059':
   unofficial_names:
   - Dundgobi
   translations:
@@ -204,7 +204,7 @@
     min_longitude: 107.9454489
     max_latitude: 46.98451
     max_longitude: 109.0039898
-  name: Govi-Sümber
+  name: Govisümber
 '065':
   unofficial_names:
   - Gobi-Altai
@@ -218,7 +218,7 @@
     min_longitude: 93.063152
     max_latitude: 47.7823939
     max_longitude: 98.466612
-  name: Govi-Altay
+  name: Govi-Altai
 '067':
   unofficial_names: Bulgan
   translations:
@@ -231,7 +231,7 @@
     max_latitude: 48.8664087
     max_longitude: 103.587513
   name: Bulgan
-069:
+'069':
   unofficial_names:
   - Bayanhongor
   - Bayankhongor
@@ -244,7 +244,7 @@
     min_longitude: 100.6864358
     max_latitude: 46.2142884
     max_longitude: 100.7368184
-  name: Bayanhongor
+  name: Bayankhongor
 '071':
   unofficial_names:
   - Bayan-Olgii
@@ -258,7 +258,7 @@
     min_longitude: 87.74966409999999
     max_latitude: 50.009587
     max_longitude: 91.9268699
-  name: Bayan-Ölgiy
+  name: Bayan-Ölgii
 '073':
   unofficial_names:
   - Arhangai
@@ -273,7 +273,7 @@
     min_longitude: 98.166168
     max_latitude: 49.1983439
     max_longitude: 103.673478
-  name: Arhangay
+  name: Arkhangai
 '1':
   unofficial_names: Ulaanbaatar
   translations:

--- a/lib/countries/data/subdivisions/MR.yaml
+++ b/lib/countries/data/subdivisions/MR.yaml
@@ -13,7 +13,7 @@
     min_longitude: -9.1601299
     max_latitude: 23.0624689
     max_longitude: -5.327115099999999
-  name: Hodh ech Chargui
+  name: Hodh Ech Chargui
 '02':
   unofficial_names:
   - Hud-al-Garbi
@@ -28,7 +28,7 @@
     min_longitude: -11.087025
     max_latitude: 17.681594
     max_longitude: -8.2803349
-  name: Hodh el Gharbi
+  name: Hodh El Gharbi
 '03':
   unofficial_names:
   - aş-Şabah
@@ -92,7 +92,7 @@
     max_latitude: 24.0316981
     max_longitude: -6.343229
   name: Adrar
-08:
+'08':
   unofficial_names:
   - Dakhlat Nawadibu
   - Đaẖlat Nawadību
@@ -106,8 +106,8 @@
     min_longitude: -17.066521
     max_latitude: 21.3397559
     max_longitude: -15.624716
-  name: Dakhlet Nouâdhibou
-09:
+  name: Dakhlet Nouadhibou
+'09':
   unofficial_names:
   - Tagant
   translations:

--- a/lib/countries/data/subdivisions/MT.yaml
+++ b/lib/countries/data/subdivisions/MT.yaml
@@ -70,7 +70,7 @@
     min_longitude: 14.5123392
     max_latitude: 35.8860872
     max_longitude: 14.5293837
-  name: Bormla
+  name: Cospicua
 '07':
   unofficial_names: Dingli
   translations:
@@ -83,7 +83,7 @@
     max_latitude: 35.8726379
     max_longitude: 14.3980764
   name: Dingli
-08:
+'08':
   unofficial_names: Fgura
   translations:
     en: Fgura
@@ -95,7 +95,7 @@
     max_latitude: 35.8788395
     max_longitude: 14.5309181
   name: Fgura
-09:
+'09':
   unofficial_names: Floriana
   translations:
     en: Floriana
@@ -238,7 +238,7 @@
     min_longitude: 14.5136331
     max_latitude: 35.8910731
     max_longitude: 14.5201882
-  name: Isla
+  name: Senglea
 '21':
   unofficial_names: Kalkara
   translations:
@@ -418,7 +418,7 @@
     min_longitude: 14.3903946
     max_latitude: 35.8959687
     max_longitude: 14.4045888
-  name: Mtarfa
+  name: Imtarfa
 '36':
   unofficial_names: Munxar
   translations:
@@ -540,7 +540,7 @@
     min_longitude: 14.2268663
     max_latitude: 36.053097
     max_longitude: 14.2537264
-  name: Rabat Gozo
+  name: Victoria
 '46':
   unofficial_names: Rabat Malta
   translations:
@@ -552,7 +552,7 @@
     min_longitude: 14.3280307
     max_latitude: 35.9101514
     max_longitude: 14.41697
-  name: Rabat Malta
+  name: Rabat
 '47':
   unofficial_names: Safi
   translations:
@@ -578,7 +578,7 @@
     min_longitude: 14.4825501
     max_latitude: 35.93031149999999
     max_longitude: 14.4966906
-  name: Saint Julian's
+  name: St. Julian’s
 '49':
   unofficial_names:
   - Saint John
@@ -592,7 +592,7 @@
     min_longitude: 14.5005065
     max_latitude: 35.9168314
     max_longitude: 14.501465
-  name: Saint John
+  name: San Ġwann
 '50':
   unofficial_names:
   - Saint Lawrence
@@ -620,7 +620,7 @@
     min_longitude: 14.3684005
     max_latitude: 35.95977000000001
     max_longitude: 14.4262694
-  name: Saint Paul's Bay
+  name: St. Paul’s Bay
 '52':
   unofficial_names: Sannat
   translations:
@@ -646,7 +646,7 @@
     min_longitude: 14.510846
     max_latitude: 35.9002424
     max_longitude: 14.5142606
-  name: Saint Lucia's
+  name: Santa Luċija
 '54':
   unofficial_names: Santa Venera
   translations:
@@ -706,7 +706,7 @@
     min_longitude: 14.4907093
     max_latitude: 35.9018784
     max_longitude: 14.5006294
-  name: Ta' Xbiex
+  name: Ta’ Xbiex
 '59':
   unofficial_names: Tarxien
   translations:
@@ -804,7 +804,7 @@
     min_longitude: 14.4119275
     max_latitude: 35.886147
     max_longitude: 14.4665909
-  name: Żebbuġ Malta
+  name: Żebbuġ
 '67':
   unofficial_names: Żejtun
   translations:

--- a/lib/countries/data/subdivisions/MU.yaml
+++ b/lib/countries/data/subdivisions/MU.yaml
@@ -10,7 +10,7 @@ AG:
     min_longitude: 56.58613399999999
     max_latitude: -10.343819
     max_longitude: 56.7038727
-  name: Agalega Islands
+  name: Agaléga
 BL:
   unofficial_names: Black River
   translations:
@@ -22,7 +22,7 @@ BL:
     min_longitude: 57.3608296
     max_latitude: -20.3339857
     max_longitude: 57.3702022
-  name: Black River
+  name: Rivière Noire
 BR:
   unofficial_names: Beau Bassin-Rose Hill
   translations:
@@ -34,7 +34,7 @@ BR:
     min_longitude: 57.44771590000001
     max_latitude: -20.1898941
     max_longitude: 57.48024589999999
-  name: Beau Bassin-Rose Hill
+  name: Beau-Bassin Rose-Hill
 CC:
   unofficial_names: Cargados Carajos Shoals [Saint Brandon Islands]
   translations:
@@ -46,7 +46,7 @@ CC:
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Cargados Carajos Shoals [Saint Brandon Islands]
+  name: Cargados Carajos
 CU:
   unofficial_names: Curepipe
   translations:
@@ -118,7 +118,7 @@ PL:
     min_longitude: 57.42768760000001
     max_latitude: -20.124287
     max_longitude: 57.5659989
-  name: Port Louis City
+  name: Port Louis District
 PU:
   unofficial_names: Port Louis District
   translations:
@@ -130,7 +130,7 @@ PU:
     min_longitude: 57.42768760000001
     max_latitude: -20.124287
     max_longitude: 57.5659989
-  name: Port Louis District
+  name: Port Louis
 PW:
   unofficial_names: Plaines Wilhems
   translations:
@@ -166,7 +166,7 @@ RO:
     min_longitude: 63.328886
     max_latitude: -19.6657049
     max_longitude: 63.5035945
-  name: Rodrigues Island
+  name: Rodrigues
 RR:
   unofficial_names: Rivière du Rempart
   translations:

--- a/lib/countries/data/subdivisions/MV.yaml
+++ b/lib/countries/data/subdivisions/MV.yaml
@@ -15,7 +15,7 @@
     min_longitude: 73.0761462
     max_latitude: -0.5765364
     max_longitude: 73.2395624
-  name: Seenu
+  name: Addu
 '02':
   unofficial_names:
   - Alif Atoll Dhekunu
@@ -30,7 +30,7 @@
     min_longitude: 72.8088748
     max_latitude: 7.1063277
     max_longitude: 73.23589319999999
-  name: Alif
+  name: Alif Alif
 '03':
   unofficial_names:
   - Faadhippolhu
@@ -98,7 +98,7 @@
     max_latitude: 7.1063277
     max_longitude: 73.23589319999999
   name: Haa Alif
-08:
+'08':
   unofficial_names:
   - Kolhumadhulu
   - Kolhumadulu
@@ -282,7 +282,7 @@
     min_longitude: 73.092454
     max_latitude: 0.8975593000000001
     max_longitude: 73.5735378
-  name: Gaaf Alif
+  name: Gaafu Alif
 '28':
   unofficial_names:
   - Gaafu Dhaalu
@@ -333,7 +333,7 @@ MLE:
     min_longitude: 73.4821147
     max_latitude: 4.202356
     max_longitude: 73.5313615
-  name: Male
+  name: Malé
 X1~:
   unofficial_names:
   - Alif Atoll Uthuru

--- a/lib/countries/data/subdivisions/MW.yaml
+++ b/lib/countries/data/subdivisions/MW.yaml
@@ -130,7 +130,7 @@ LK:
     min_longitude: 34.7087596
     max_latitude: -12.0311794
     max_longitude: 34.7604815
-  name: Likoma Island
+  name: Likoma
 MC:
   unofficial_names: Mchinji
   translations:

--- a/lib/countries/data/subdivisions/MX.yaml
+++ b/lib/countries/data/subdivisions/MX.yaml
@@ -106,7 +106,7 @@ DIF:
     min_longitude: -99.36492419999999
     max_latitude: 19.5927571
     max_longitude: -98.94030269999999
-  name: Distrito Federal
+  name: Mexico City
 DUR:
   unofficial_names: Durango
   translations:
@@ -178,7 +178,7 @@ MEX:
     min_longitude: -99.3641835
     max_latitude: 19.5919189
     max_longitude: -98.9401855
-  name: México
+  name: Mexico State
 MIC:
   unofficial_names: Michoacán
   translations:

--- a/lib/countries/data/subdivisions/MY.yaml
+++ b/lib/countries/data/subdivisions/MY.yaml
@@ -46,7 +46,7 @@
     min_longitude: 102.1557088
     max_latitude: 2.309435
     max_longitude: 102.4327931
-  name: Melaka
+  name: Malacca
 '05':
   unofficial_names:
   - Negri Sembilan
@@ -83,8 +83,8 @@
     min_longitude: 100.1751347
     max_latitude: 5.585334899999999
     max_longitude: 100.55062
-  name: Pulau Pinang
-08:
+  name: Penang
+'08':
   unofficial_names: Perak
   translations:
     en: Perak
@@ -96,7 +96,7 @@
     max_latitude: 5.93451
     max_longitude: 101.7526549
   name: Perak
-09:
+'09':
   unofficial_names: Perlis
   translations:
     en: Perlis
@@ -167,7 +167,7 @@
     min_longitude: 101.61545
     max_latitude: 3.2433789
     max_longitude: 101.758529
-  name: Wilayah Persekutuan Kuala Lumpur
+  name: Kuala Lumpur
 '15':
   unofficial_names: Wilayah Persekutuan Labuan
   translations:
@@ -179,7 +179,7 @@
     min_longitude: 115.1209787
     max_latitude: 5.3877618
     max_longitude: 115.3263058
-  name: Wilayah Persekutuan Labuan
+  name: Labuan
 '16':
   unofficial_names: Wilayah Persekutuan Putrajaya
   translations:
@@ -191,4 +191,4 @@
     min_longitude: 101.6600299
     max_latitude: 2.9765179
     max_longitude: 101.7328308
-  name: Wilayah Persekutuan Putrajaya
+  name: Putrajaya

--- a/lib/countries/data/subdivisions/MZ.yaml
+++ b/lib/countries/data/subdivisions/MZ.yaml
@@ -58,7 +58,7 @@ L:
     min_longitude: 32.5233079
     max_latitude: -25.8085457
     max_longitude: 32.6980592
-  name: Maputo
+  name: Maputo Province
 MPM:
   unofficial_names: Maputo City
   translations:
@@ -70,7 +70,7 @@ MPM:
     min_longitude: 32.5233079
     max_latitude: -25.8085457
     max_longitude: 32.6980592
-  name: Maputo City
+  name: Maputo
 N:
   unofficial_names: Nampula
   translations:
@@ -106,7 +106,7 @@ Q:
     min_longitude: 35.147209
     max_latitude: -14.989042
     max_longitude: 39.1333621
-  name: Zambézia
+  name: Zambezia
 S:
   unofficial_names: Sofala
   translations:

--- a/lib/countries/data/subdivisions/NG.yaml
+++ b/lib/countries/data/subdivisions/NG.yaml
@@ -181,7 +181,7 @@ FC:
     min_longitude: 6.749135
     max_latitude: 9.3574219
     max_longitude: 7.617400000000001
-  name: Abuja Capital Territory
+  name: Federal Capital Territory
 GO:
   unofficial_names: Gombe
   translations:
@@ -314,7 +314,7 @@ NA:
     min_longitude: 6.924008
     max_latitude: 9.365964000000002
     max_longitude: 9.605724
-  name: Nassarawa
+  name: Nasarawa
 NI:
   unofficial_names: Niger
   translations:

--- a/lib/countries/data/subdivisions/NI.yaml
+++ b/lib/countries/data/subdivisions/NI.yaml
@@ -13,7 +13,7 @@ AN:
     min_longitude: -85.483689
     max_latitude: 15.0259089
     max_longitude: -82.59207239999999
-  name: Atlántico Norte*
+  name: Atlántico Norte
 AS:
   unofficial_names:
   - RAAS
@@ -28,7 +28,7 @@ AS:
     min_longitude: -85.21458009999999
     max_latitude: 13.277237
     max_longitude: -82.97150719999999
-  name: Atlántico Sur*
+  name: Atlántico Sur
 BO:
   unofficial_names: Boaco
   translations:

--- a/lib/countries/data/subdivisions/NL.yaml
+++ b/lib/countries/data/subdivisions/NL.yaml
@@ -85,7 +85,7 @@ NB:
     min_longitude: 4.190081
     max_latitude: 51.8307142
     max_longitude: 6.047724
-  name: Noord-Brabant
+  name: North Brabant
 NH:
   unofficial_names: Noord-Holland
   translations:
@@ -97,7 +97,7 @@ NH:
     min_longitude: 4.4937415
     max_latitude: 53.1833322
     max_longitude: 5.328279999999999
-  name: Noord-Holland
+  name: North Holland
 OV:
   unofficial_names: Overijssel
   translations:
@@ -145,4 +145,4 @@ ZH:
     min_longitude: 3.8393205
     max_latitude: 52.3282742
     max_longitude: 5.1492625
-  name: Zuid-Holland
+  name: South Holland

--- a/lib/countries/data/subdivisions/NP.yaml
+++ b/lib/countries/data/subdivisions/NP.yaml
@@ -82,7 +82,7 @@ KO:
     min_longitude: 86.4182005
     max_latitude: 26.8262154
     max_longitude: 87.26650049999999
-  name: Kosi [Koshi]
+  name: Kosi
 LU:
   unofficial_names: Lumbini
   translations:

--- a/lib/countries/data/subdivisions/NR.yaml
+++ b/lib/countries/data/subdivisions/NR.yaml
@@ -83,7 +83,7 @@
     max_latitude: -0.5264839
     max_longitude: 166.936519
   name: Buada
-08:
+'08':
   unofficial_names:
   - Denigomodu
   translations:
@@ -96,7 +96,7 @@
     max_latitude: -0.5191129
     max_longitude: 166.925101
   name: Denigomodu
-09:
+'09':
   unofficial_names: Ewa
   translations:
     en: Ewa

--- a/lib/countries/data/subdivisions/NZ.yaml
+++ b/lib/countries/data/subdivisions/NZ.yaml
@@ -58,7 +58,7 @@ HKB:
     min_longitude: 175.8300119
     max_latitude: -38.1752186
     max_longitude: 178.002017
-  name: Hawke's Bay
+  name: Hawke’s Bay
 MBH:
   unofficial_names: Marlborough
   translations:
@@ -70,7 +70,7 @@ MBH:
     min_longitude: 172.7185518
     max_latitude: -40.66335100000001
     max_longitude: 174.3922804
-  name: Marlborough
+  name: Marl
 MWT:
   unofficial_names:
   - Wanganui-Manawatu

--- a/lib/countries/data/subdivisions/OM.yaml
+++ b/lib/countries/data/subdivisions/OM.yaml
@@ -53,7 +53,7 @@ MA:
     min_longitude: 58.2283758
     max_latitude: 23.6455689
     max_longitude: 58.6189567
-  name: Masqat
+  name: Muscat
 MU:
   unofficial_names: Musandam
   translations:
@@ -90,7 +90,7 @@ WU:
     min_longitude: 54.9999999
     max_latitude: 21.420908
     max_longitude: 58.3227421
-  name: Al Wustá
+  name: Al Wusta
 X1~:
   unofficial_names: Al Buraymi
   translations:
@@ -115,4 +115,4 @@ ZA:
     min_longitude: 55.2069211
     max_latitude: 24.019926
     max_longitude: 57.116874
-  name: Adh Dhahirah
+  name: Ad Dhahirah

--- a/lib/countries/data/subdivisions/PE.yaml
+++ b/lib/countries/data/subdivisions/PE.yaml
@@ -99,7 +99,7 @@ CUS:
     min_longitude: -72.02516560000001
     max_latitude: -13.4973908
     max_longitude: -71.8533325
-  name: Cuzco [Cusco]
+  name: Cusco
 HUC:
   unofficial_names: Huánuco
   translations:
@@ -183,7 +183,7 @@ LIM:
     min_longitude: -77.0883395
     max_latitude: -12.0308632
     max_longitude: -77.0020311
-  name: Lima
+  name: Lima Region
 LOR:
   unofficial_names: Loreto
   translations:

--- a/lib/countries/data/subdivisions/PG.yaml
+++ b/lib/countries/data/subdivisions/PG.yaml
@@ -151,7 +151,7 @@ NCD:
     min_longitude: 147.136652
     max_latitude: -9.3703217
     max_longitude: 147.2438668
-  name: National Capital District (Port Moresby)
+  name: Port Moresby
 NIK:
   unofficial_names:
   - Niu Ailan
@@ -177,7 +177,7 @@ NPP:
     min_longitude: 147.0030289
     max_latitude: -8.002543
     max_longitude: 149.439636
-  name: Northern
+  name: Oro
 NSA:
   unofficial_names:
   - Bougainville
@@ -205,7 +205,7 @@ SAN:
     min_longitude: 140.998795
     max_latitude: -2.6086511
     max_longitude: 143.1048729
-  name: Sandaun [West Sepik]
+  name: Sandaun
 SHM:
   unofficial_names:
   - Highlands South

--- a/lib/countries/data/subdivisions/PH.yaml
+++ b/lib/countries/data/subdivisions/PH.yaml
@@ -575,7 +575,7 @@ MDC:
     min_longitude: 120.0174402
     max_latitude: 13.8989589
     max_longitude: 121.250199
-  name: Mindoro Occidental
+  name: Occidental Mindoro
 MDR:
   unofficial_names: Mindoro Oriental
   translations:
@@ -587,7 +587,7 @@ MDR:
     min_longitude: 120.8007199
     max_latitude: 13.5314771
     max_longitude: 121.5576218
-  name: Mindoro Oriental
+  name: Oriental Mindoro
 MOU:
   unofficial_names: Mountain Province
   translations:
@@ -599,7 +599,7 @@ MOU:
     min_longitude: 120.770595
     max_latitude: 17.306318
     max_longitude: 121.5659461
-  name: Mountain Province
+  name: Mountain
 MSC:
   unofficial_names: Misamis Occidental
   translations:
@@ -636,7 +636,7 @@ NCO:
     min_longitude: 124.3334349
     max_latitude: 7.681884999999999
     max_longitude: 125.31497
-  name: North Cotabato
+  name: Cotabato
 NEC:
   unofficial_names: Negros Occidental
   translations:
@@ -926,7 +926,7 @@ WSA:
     min_longitude: 124.1477429
     max_latitude: 12.334325
     max_longitude: 125.307814
-  name: Western Samar
+  name: Samar
 X1~:
   unofficial_names: Dinagat
   translations:
@@ -998,7 +998,7 @@ ZSI:
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Zamboanga Sibuguey [Zamboanga Sibugay]
+  name: Zamboanga Sibugay
 '00':
   unofficial_names:
   - National Capital Region
@@ -1012,4 +1012,4 @@ ZSI:
     min_longitude: 120.9172569
     max_latitude: 14.781217
     max_longitude: 121.132012
-  name: National Capital Region
+  name: Metro Manila

--- a/lib/countries/data/subdivisions/PK.yaml
+++ b/lib/countries/data/subdivisions/PK.yaml
@@ -10,7 +10,7 @@ BA:
     min_longitude: 60.87859700000001
     max_latitude: 32.064602
     max_longitude: 70.259517
-  name: Baluchistan (en)
+  name: Balochistan
 IS:
   unofficial_names: Islamabad
   translations:
@@ -82,7 +82,7 @@ SD:
     min_longitude: 66.6546894
     max_latitude: 28.5015481
     max_longitude: 71.12440509999999
-  name: Sind (en)
+  name: Sindh
 TA:
   unofficial_names: Federally Administered Tribal Areas
   translations:

--- a/lib/countries/data/subdivisions/PL.yaml
+++ b/lib/countries/data/subdivisions/PL.yaml
@@ -12,7 +12,7 @@ DS:
     min_longitude: 14.816831
     max_latitude: 51.8047592
     max_longitude: 17.798917
-  name: Dolnośląskie
+  name: Lower Silesian
 KP:
   unofficial_names:
   - kujawsko-pomorskie
@@ -26,7 +26,7 @@ KP:
     min_longitude: 17.2472674
     max_latitude: 53.7809987
     max_longitude: 19.7618466
-  name: Kujawsko-pomorskie
+  name: Kuyavian-Pomerania
 LU:
   unofficial_names:
   - lubelskie
@@ -40,7 +40,7 @@ LU:
     min_longitude: 21.6171249
     max_latitude: 52.2879201
     max_longitude: 24.1458931
-  name: Lubelskie
+  name: Lublin
 LB:
   unofficial_names:
   - lubuskie
@@ -54,7 +54,7 @@ LB:
     min_longitude: 14.534127
     max_latitude: 53.1239582
     max_longitude: 16.4163811
-  name: Lubuskie
+  name: Lubusz
 LD:
   unofficial_names:
   - łódzkie
@@ -68,7 +68,7 @@ LD:
     min_longitude: 18.0750521
     max_latitude: 52.3940561
     max_longitude: 20.6591903
-  name: Łódzkie
+  name: Łódź
 MA:
   unofficial_names:
   - małopolskie
@@ -82,7 +82,7 @@ MA:
     min_longitude: 19.083192
     max_latitude: 50.5200442
     max_longitude: 21.4213826
-  name: Małopolskie
+  name: Lesser Poland
 MZ:
   unofficial_names:
   - mazowieckie
@@ -96,7 +96,7 @@ MZ:
     min_longitude: 19.2592569
     max_latitude: 53.4818919
     max_longitude: 23.1283212
-  name: Mazowieckie
+  name: Mazovia
 OP:
   unofficial_names:
   - opolskie
@@ -110,7 +110,7 @@ OP:
     min_longitude: 16.9087264
     max_latitude: 51.1945111
     max_longitude: 18.6957862
-  name: Opolskie
+  name: Opole
 PK:
   unofficial_names:
   - podkarpackie
@@ -124,7 +124,7 @@ PK:
     min_longitude: 21.1423457
     max_latitude: 50.8181161
     max_longitude: 23.5476409
-  name: Podkarpackie
+  name: Subcarpathia
 PD:
   unofficial_names:
   - podlaskie
@@ -152,7 +152,7 @@ PM:
     min_longitude: 16.699129
     max_latitude: 54.83572969999999
     max_longitude: 19.6493699
-  name: Pomorskie
+  name: Federal Capital Territory
 SL:
   unofficial_names:
   - śląskie
@@ -166,7 +166,7 @@ SL:
     min_longitude: 18.03475
     max_latitude: 51.0993559
     max_longitude: 19.9739915
-  name: Śląskie
+  name: Silesia
 SK:
   unofficial_names:
   - świętokrzyskie
@@ -194,7 +194,7 @@ WN:
     min_longitude: 19.128516
     max_latitude: 54.4533097
     max_longitude: 22.8058724
-  name: Warmińsko-mazurskie
+  name: Warmian-Masuria
 WP:
   unofficial_names:
   - wielkopolskie
@@ -208,7 +208,7 @@ WP:
     min_longitude: 15.7789647
     max_latitude: 53.6559175
     max_longitude: 19.103349
-  name: Wielkopolskie
+  name: Greater Poland
 ZP:
   unofficial_names:
   - zachodniopomorskie
@@ -222,4 +222,4 @@ ZP:
     min_longitude: 14.1223531
     max_latitude: 54.5690916
     max_longitude: 16.9822089
-  name: Zachodniopomorskie
+  name: West Pomerania

--- a/lib/countries/data/subdivisions/PT.yaml
+++ b/lib/countries/data/subdivisions/PT.yaml
@@ -83,7 +83,7 @@
     max_latitude: 38.6169193
     max_longitude: -7.843514600000001
   name: Évora
-08:
+'08':
   unofficial_names: Faro
   translations:
     en: Faro
@@ -95,7 +95,7 @@
     max_latitude: 37.0738998
     max_longitude: -7.8093544
   name: Faro
-09:
+'09':
   unofficial_names: Guarda
   translations:
     en: Guarda
@@ -130,7 +130,7 @@
     min_longitude: -9.2298356
     max_latitude: 38.7958538
     max_longitude: -9.0905718
-  name: Lisboa
+  name: Lisbon
 '12':
   unofficial_names: Portalegre
   translations:
@@ -226,7 +226,7 @@
     min_longitude: -31.2687948
     max_latitude: 39.7261497
     max_longitude: -25.0131855
-  name: Açores
+  name: Azores
 '30':
   unofficial_names: Madeira
   translations:

--- a/lib/countries/data/subdivisions/PW.yaml
+++ b/lib/countries/data/subdivisions/PW.yaml
@@ -46,7 +46,7 @@
     min_longitude: 131.1203134
     max_latitude: 3.0074129
     max_longitude: 131.124487
-  name: Hatobohei
+  name: Hatohobei
 '100':
   unofficial_names: Kayangel
   translations:

--- a/lib/countries/data/subdivisions/QA.yaml
+++ b/lib/countries/data/subdivisions/QA.yaml
@@ -17,7 +17,7 @@ DA:
     min_longitude: 51.4307964
     max_latitude: 25.4125783
     max_longitude: 51.6281212
-  name: Ad Dawhah
+  name: Doha
 GH:
   unofficial_names:
   - al-Ghuwayriyah
@@ -71,7 +71,7 @@ KH:
     min_longitude: 51.4761828
     max_latitude: 25.6959881
     max_longitude: 51.5287971
-  name: Al Khawr
+  name: Al Khor
 MS:
   unofficial_names:
   - ash-Shamal
@@ -98,7 +98,7 @@ RA:
     min_longitude: 50.7500553
     max_latitude: 25.8087775
     max_longitude: 51.53700079999999
-  name: Ar Rayyan
+  name: Al Rayyan
 US:
   unofficial_names:
   - Umm Shalal

--- a/lib/countries/data/subdivisions/RO.yaml
+++ b/lib/countries/data/subdivisions/RO.yaml
@@ -23,7 +23,7 @@ AG:
     min_longitude: 24.427089
     max_latitude: 45.610782
     max_longitude: 25.325839
-  name: Arges
+  name: Argeș
 AR:
   unofficial_names: Arad
   translations:
@@ -52,7 +52,7 @@ B:
     min_longitude: 25.9637001
     max_latitude: 44.541407
     max_longitude: 26.225575
-  name: Bucuresti
+  name: Bucharest
 BC:
   unofficial_names:
   - Bacau
@@ -65,7 +65,7 @@ BC:
     min_longitude: 26.8629241
     max_latitude: 46.6207201
     max_longitude: 26.9547951
-  name: Bacau
+  name: Bacău
 BH:
   unofficial_names: Bihor
   translations:
@@ -90,7 +90,7 @@ BN:
     min_longitude: 23.9229529
     max_latitude: 47.6071391
     max_longitude: 25.0916189
-  name: Bistrita-Nasaud
+  name: Bistriţa-Năsăud
 BR:
   unofficial_names:
   - Braila
@@ -103,7 +103,7 @@ BR:
     min_longitude: 27.8928493
     max_latitude: 45.3137327
     max_longitude: 28.0004168
-  name: Braila
+  name: Brăila
 BT:
   unofficial_names:
   - Botosani
@@ -116,7 +116,7 @@ BT:
     min_longitude: 26.609519
     max_latitude: 47.7705485
     max_longitude: 26.709298
-  name: Botosani
+  name: Botoşani
 BV:
   unofficial_names:
   - Brasov
@@ -129,7 +129,7 @@ BV:
     min_longitude: 25.514449
     max_latitude: 45.72210200000001
     max_longitude: 25.6784767
-  name: Brasov
+  name: Braşov
 BZ:
   unofficial_names:
   - Buzau
@@ -142,7 +142,7 @@ BZ:
     min_longitude: 26.7563438
     max_latitude: 45.1814771
     max_longitude: 26.8720435
-  name: Buzau
+  name: Buzău
 CJ:
   unofficial_names: Cluj
   translations:
@@ -167,7 +167,7 @@ CL:
     min_longitude: 27.277003
     max_latitude: 44.23818929999999
     max_longitude: 27.3725225
-  name: Calarasi
+  name: Călărași
 CS:
   unofficial_names:
   - Caras-Severin
@@ -180,7 +180,7 @@ CS:
     min_longitude: 21.3522489
     max_latitude: 45.67003099999999
     max_longitude: 22.7100121
-  name: Caras-Severin
+  name: Caraș-Severin
 CT:
   unofficial_names:
   - Constanta
@@ -194,7 +194,7 @@ CT:
     min_longitude: 28.5510205
     max_latitude: 44.2782744
     max_longitude: 28.7076575
-  name: Constanta
+  name: Constanța
 CV:
   unofficial_names: Covasna
   translations:
@@ -221,7 +221,7 @@ DB:
     min_longitude: 25.124594
     max_latitude: 45.440805
     max_longitude: 25.992037
-  name: Dâmbovita
+  name: Dâmbovița
 DJ:
   unofficial_names: Dolj
   translations:
@@ -259,7 +259,7 @@ GL:
     min_longitude: 27.9515362
     max_latitude: 45.484793
     max_longitude: 28.1434536
-  name: Galati
+  name: Galați
 GR:
   unofficial_names: Giurgiu
   translations:
@@ -321,7 +321,7 @@ IL:
     min_longitude: 26.300869
     max_latitude: 44.86406700000001
     max_longitude: 28.1100249
-  name: Ialomita
+  name: Ialomița
 IS:
   unofficial_names:
   - Iasi
@@ -337,7 +337,7 @@ IS:
     min_longitude: 27.4769569
     max_latitude: 47.2274375
     max_longitude: 27.6969839
-  name: Iasi
+  name: Iași
 MH:
   unofficial_names:
   - Mehedinti
@@ -350,7 +350,7 @@ MH:
     min_longitude: 22.0000145
     max_latitude: 45.108286
     max_longitude: 23.458584
-  name: Mehedinti
+  name: Mehedinți
 MM:
   unofficial_names:
   - Maramures
@@ -363,7 +363,7 @@ MM:
     min_longitude: 22.965186
     max_latitude: 48.020276
     max_longitude: 25.0557001
-  name: Maramures
+  name: Maramureş
 MS:
   unofficial_names:
   - Mures
@@ -376,7 +376,7 @@ MS:
     min_longitude: 23.9577359
     max_latitude: 47.143799
     max_longitude: 25.3139161
-  name: Mures
+  name: Mureş
 NT:
   unofficial_names:
   - Neamt
@@ -389,7 +389,7 @@ NT:
     min_longitude: 25.6630821
     max_latitude: 47.337545
     max_longitude: 27.246063
-  name: Neamt
+  name: Neamţ
 OT:
   unofficial_names: Olt
   translations:
@@ -438,7 +438,7 @@ SJ:
     min_longitude: 22.493326
     max_latitude: 47.460111
     max_longitude: 23.8409952
-  name: Salaj
+  name: Sălaj
 SM:
   unofficial_names: Satu Mare
   translations:
@@ -487,7 +487,7 @@ TM:
     min_longitude: 20.2617593
     max_latitude: 46.18994
     max_longitude: 22.5461279
-  name: Timis
+  name: Timiș
 TR:
   unofficial_names: Teleorman
   translations:

--- a/lib/countries/data/subdivisions/RS.yaml
+++ b/lib/countries/data/subdivisions/RS.yaml
@@ -10,7 +10,7 @@
     min_longitude: 20.2217102
     max_latitude: 44.9424453
     max_longitude: 20.6189345
-  name: Belgrade
+  name: Beograd
 '01':
   unofficial_names: Severna Backa
   translations:
@@ -22,7 +22,7 @@
     min_longitude: 19.3011208
     max_latitude: 46.1912459
     max_longitude: 19.875136
-  name: Severna Backa
+  name: North Bačka
 '02':
   unofficial_names: Srednji Banat
   translations:
@@ -34,7 +34,7 @@
     min_longitude: 20.027785
     max_latitude: 45.811237
     max_longitude: 21.0307331
-  name: Srednji Banat
+  name: Central Banat
 '03':
   unofficial_names: Severni Banat
   translations:
@@ -46,7 +46,7 @@
     min_longitude: 19.7715084
     max_latitude: 46.178631
     max_longitude: 20.665928
-  name: Severni Banat
+  name: North Banat
 '04':
   unofficial_names: Južni Banat
   translations:
@@ -58,7 +58,7 @@
     min_longitude: 20.41565
     max_latitude: 45.334724
     max_longitude: 21.56465
-  name: Južni Banat
+  name: South Banat
 '05':
   unofficial_names: Zapadna Backa
   translations:
@@ -70,7 +70,7 @@
     min_longitude: 18.8493741
     max_latitude: 46.0410499
     max_longitude: 19.6157879
-  name: Zapadna Backa
+  name: West Bačka
 '06':
   unofficial_names: Južna Backa
   translations:
@@ -82,7 +82,7 @@
     min_longitude: 18.981784
     max_latitude: 45.7750259
     max_longitude: 20.313821
-  name: Južna Backa
+  name: South Bačka
 '07':
   unofficial_names: Srem
   translations:
@@ -95,7 +95,7 @@
     max_latitude: 45.21000900000001
     max_longitude: 20.361306
   name: Srem
-08:
+'08':
   unofficial_names: Macva
   translations:
     en: Macva
@@ -106,8 +106,8 @@
     min_longitude: 19.10721
     max_latitude: 44.94040200000001
     max_longitude: 20.000317
-  name: Macva
-09:
+  name: Mačva
+'09':
   unofficial_names: Kolubara
   translations:
     en: Kolubara
@@ -142,7 +142,7 @@
     min_longitude: 21.5239334
     max_latitude: 44.7191731
     max_longitude: 21.5884781
-  name: Branicevo
+  name: Braničevo
 '12':
   unofficial_names: Šumadija
   translations:
@@ -190,7 +190,7 @@
     min_longitude: 22.1834563
     max_latitude: 43.9716926
     max_longitude: 22.3112583
-  name: Zajecar
+  name: Zaječar
 '16':
   unofficial_names: Zlatibor
   translations:
@@ -298,7 +298,7 @@
     min_longitude: 21.526959
     max_latitude: 42.8436209
     max_longitude: 22.5690361
-  name: Pcinja
+  name: Pčinja
 '25':
   unofficial_names: Kosovo
   translations:
@@ -322,7 +322,7 @@
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Pec´
+  name: Peć
 '27':
   unofficial_names: Prizren
   translations:

--- a/lib/countries/data/subdivisions/RU.yaml
+++ b/lib/countries/data/subdivisions/RU.yaml
@@ -12,7 +12,7 @@ AD:
     min_longitude: 38.6818529
     max_latitude: 45.21684
     max_longitude: 40.7744969
-  name: Adygeya, Respublika
+  name: Adygea
 AL:
   unofficial_names:
   - Altaj
@@ -27,7 +27,7 @@ AL:
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Altay, Respublika
+  name: Altai
 ALT:
   unofficial_names:
   - Altai Kray
@@ -43,7 +43,7 @@ ALT:
     min_longitude: 77.8891551
     max_latitude: 54.45086
     max_longitude: 87.16908889999999
-  name: Altayskiy kray
+  name: Altai Krai
 AMU:
   unofficial_names:
   - Amurskaja Oblast
@@ -56,7 +56,7 @@ AMU:
     min_longitude: 119.66795
     max_latitude: 57.0585329
     max_longitude: 134.920255
-  name: Amurskaya oblast'
+  name: Amur
 ARK:
   unofficial_names:
   - Arhangelskaja Oblast
@@ -70,7 +70,7 @@ ARK:
     min_longitude: 35.502945
     max_latitude: 81.8581221
     max_longitude: 69.04823499999999
-  name: Arkhangel'skaya oblast'
+  name: Arkhangelsk
 AST:
   unofficial_names:
   - Astrahanska Oblast
@@ -84,7 +84,7 @@ AST:
     min_longitude: 44.9707619
     max_latitude: 48.8653439
     max_longitude: 49.279398
-  name: Astrakhanskaya oblast'
+  name: Astrakhan
 BA:
   unofficial_names:
   - Baškortostan
@@ -97,7 +97,7 @@ BA:
     min_longitude: 53.1579969
     max_latitude: 56.53352
     max_longitude: 60.00295010000001
-  name: Bashkortostan, Respublika
+  name: Bashkortostan
 BEL:
   unofficial_names:
   - Belgorodskaja Oblast
@@ -110,7 +110,7 @@ BEL:
     min_longitude: 35.3285271
     max_latitude: 51.4325619
     max_longitude: 39.2751271
-  name: Belgorodskaya oblast'
+  name: Belgorod
 BRY:
   unofficial_names:
   - Brjanskaja Oblast
@@ -124,7 +124,7 @@ BRY:
     min_longitude: 31.24210489999999
     max_latitude: 54.03629910000001
     max_longitude: 35.32127810000001
-  name: Bryanskaya oblast'
+  name: Bryansk
 BU:
   unofficial_names:
   - Buryat Republic
@@ -138,7 +138,7 @@ BU:
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Buryatiya, Respublika
+  name: Buryat
 CE:
   unofficial_names:
   - Chechen
@@ -157,7 +157,7 @@ CE:
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Chechenskaya Respublika
+  name: Chechen
 CHE:
   unofficial_names:
   - Cheljabinsk
@@ -172,7 +172,7 @@ CHE:
     min_longitude: 57.1300707
     max_latitude: 56.3648829
     max_longitude: 63.3492892
-  name: Chelyabinskaya oblast'
+  name: Chelyabinsk
 CHU:
   unofficial_names:
   - Chuckchi
@@ -188,7 +188,7 @@ CHU:
     min_longitude: 157.732108
     max_latitude: 71.59401129999999
     max_longitude: -168.9996789
-  name: Chukotskiy avtonomnyy okrug
+  name: Chukotka Okrug
 CU:
   unofficial_names:
   - Chuvash Republic
@@ -204,7 +204,7 @@ CU:
     min_longitude: 45.91057199999999
     max_latitude: 56.3299659
     max_longitude: 48.416765
-  name: Chuvashskaya Respublika
+  name: Chuvash
 DA:
   unofficial_names: Dagestan, Respublika
   translations:
@@ -216,7 +216,7 @@ DA:
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Dagestan, Respublika
+  name: Dagestan
 IN:
   unofficial_names:
   - Ingushetija
@@ -230,7 +230,7 @@ IN:
     min_longitude: 44.4769308
     max_latitude: 43.6107959
     max_longitude: 45.1902339
-  name: Ingushskaya Respublika [Respublika Ingushetiya]
+  name: Ingushetia
 IRK:
   unofficial_names:
   - Irkutskaja Oblast
@@ -243,7 +243,7 @@ IRK:
     min_longitude: 95.65773999999999
     max_latitude: 64.31695599999999
     max_longitude: 119.1306879
-  name: Irkutskaya oblast'
+  name: Irkutsk
 IVA:
   unofficial_names:
   - Ivanovskaja Oblast
@@ -256,7 +256,7 @@ IVA:
     min_longitude: 39.3779529
     max_latitude: 57.74272199999999
     max_longitude: 43.3058696
-  name: Ivanovskaya oblast'
+  name: Ivanovo
 KAM:
   unofficial_names:
   - Kamchatskaya Oblast
@@ -272,7 +272,7 @@ KAM:
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Kamchatskaya oblast'
+  name: Kamchatka Krai
 KB:
   unofficial_names:
   - Kabardino-Balkarian Republic
@@ -287,7 +287,7 @@ KB:
     min_longitude: 42.3981201
     max_latitude: 44.0228141
     max_longitude: 44.47055100000001
-  name: Kabardino-Balkarskaya Respublika
+  name: Kabardino-Balkar
 KC:
   unofficial_names:
   - Karachay-Cherkessian
@@ -302,7 +302,7 @@ KC:
     min_longitude: 40.6833698
     max_latitude: 44.49697889999999
     max_longitude: 42.6780321
-  name: Karachayevo-Cherkesskaya Respublika
+  name: Karachay-Cherkess
 KDA:
   unofficial_names:
   - Krasnodarskij Kraj
@@ -315,7 +315,7 @@ KDA:
     min_longitude: 36.5980539
     max_latitude: 46.8802379
     max_longitude: 41.7476441
-  name: Krasnodarskiy kray
+  name: Krasnodar Krai
 KEM:
   unofficial_names:
   - Kemerovskaja Oblast
@@ -328,7 +328,7 @@ KEM:
     min_longitude: 84.450098
     max_latitude: 56.83512
     max_longitude: 89.399602
-  name: Kemerovskaya oblast'
+  name: Kemerovo
 KGD:
   unofficial_names:
   - Kaliningradskaja Oblast
@@ -341,7 +341,7 @@ KGD:
     min_longitude: 19.6388525
     max_latitude: 55.2944458
     max_longitude: 22.886888
-  name: Kaliningradskaya oblast'
+  name: Kaliningrad
 KGN:
   unofficial_names:
   - Kurganskaja Oblast
@@ -354,7 +354,7 @@ KGN:
     min_longitude: 61.9661031
     max_latitude: 56.8420819
     max_longitude: 68.7217089
-  name: Kurganskaya oblast'
+  name: Kurgan
 KHA:
   unofficial_names:
   - Habarovskij Kray
@@ -368,7 +368,7 @@ KHA:
     min_longitude: 130.3886411
     max_latitude: 62.5246119
     max_longitude: 147.2038518
-  name: Khabarovskiy kray
+  name: Khabarovsk Krai
 KHM:
   unofficial_names:
   - Hanty-Mansijskij Avtonomnyj Okrug
@@ -382,7 +382,7 @@ KHM:
     min_longitude: 59.19747880000001
     max_latitude: 65.71070100000001
     max_longitude: 85.9728444
-  name: Khanty-Mansiyskiy avtonomnyy okrug [Yugra]
+  name: Khanty-Mansi
 KIR:
   unofficial_names:
   - Kirovskaja Oblast
@@ -395,7 +395,7 @@ KIR:
     min_longitude: 46.2618118
     max_latitude: 61.0629159
     max_longitude: 53.9431012
-  name: Kirovskaya oblast'
+  name: Kirov
 KK:
   unofficial_names:
   - Khakass Republic
@@ -409,7 +409,7 @@ KK:
     min_longitude: 87.8758369
     max_latitude: 55.43188689999999
     max_longitude: 91.9249129
-  name: Khakasiya, Respublika
+  name: Khakassia
 KL:
   unofficial_names:
   - Halmg-Tangč
@@ -425,7 +425,7 @@ KL:
     min_longitude: 41.6327159
     max_latitude: 48.2743179
     max_longitude: 47.601117
-  name: Kalmykiya, Respublika
+  name: Kalmykia
 KLU:
   unofficial_names:
   - Kaluzhskaya Oblast
@@ -439,7 +439,7 @@ KLU:
     min_longitude: 33.4465778
     max_latitude: 55.3402639
     max_longitude: 37.2756489
-  name: Kaluzhskaya oblast'
+  name: Kaluga
 KO:
   unofficial_names: Komi, Respublika
   translations:
@@ -451,7 +451,7 @@ KO:
     min_longitude: 45.4046569
     max_latitude: 68.42287689999999
     max_longitude: 66.2523211
-  name: Komi, Respublika
+  name: Komi
 KOS:
   unofficial_names:
   - Kostromskaja Oblast
@@ -464,7 +464,7 @@ KOS:
     min_longitude: 40.3997611
     max_latitude: 59.62038
     max_longitude: 47.6446471
-  name: Kostromskaya oblast'
+  name: Kostroma
 KR:
   unofficial_names:
   - Karelian Republic
@@ -478,7 +478,7 @@ KR:
     min_longitude: 29.3102922
     max_latitude: 66.6732639
     max_longitude: 37.9320522
-  name: Kareliya, Respublika
+  name: Karelia
 KRS:
   unofficial_names:
   - Kurskaja Oblast
@@ -491,7 +491,7 @@ KRS:
     min_longitude: 34.0821881
     max_latitude: 52.4405099
     max_longitude: 38.5257578
-  name: Kurskaya oblast'
+  name: Kursk
 KYA:
   unofficial_names:
   - Krasnojarsk
@@ -506,7 +506,7 @@ KYA:
     min_longitude: 76.1117517
     max_latitude: 81.2663089
     max_longitude: 113.9162833
-  name: Krasnoyarskiy kray
+  name: Krasnoyarsk Krai
 LEN:
   unofficial_names:
   - Leningradskaja Oblast
@@ -519,7 +519,7 @@ LEN:
     min_longitude: 27.740038
     max_latitude: 61.3297682
     max_longitude: 35.6959784
-  name: Leningradskaya oblast'
+  name: Leningrad
 LIP:
   unofficial_names:
   - Lipeckaja Oblast
@@ -533,7 +533,7 @@ LIP:
     min_longitude: 37.7224471
     max_latitude: 53.5848638
     max_longitude: 40.764882
-  name: Lipetskaya oblast'
+  name: Lipetsk
 MAG:
   unofficial_names:
   - Magadanskaja Oblast
@@ -546,7 +546,7 @@ MAG:
     min_longitude: 144.722207
     max_latitude: 66.33609200000001
     max_longitude: 163.4827849
-  name: Magadanskaya oblast'
+  name: Magadan
 ME:
   unofficial_names:
   - Mariy El
@@ -560,7 +560,7 @@ ME:
     min_longitude: 45.6197337
     max_latitude: 57.3436309
     max_longitude: 50.2000648
-  name: Mariy El, Respublika
+  name: Mari El
 MO:
   unofficial_names:
   - Mordovian Republic
@@ -574,7 +574,7 @@ MO:
     min_longitude: 42.170382
     max_latitude: 55.1882439
     max_longitude: 46.7113749
-  name: Mordoviya, Respublika
+  name: Mordovia
 MOS:
   unofficial_names:
   - Moskovskaja Oblast
@@ -587,7 +587,7 @@ MOS:
     min_longitude: 35.149022
     max_latitude: 56.962834
     max_longitude: 40.2060071
-  name: Moskovskaya oblast'
+  name: Moscow Province
 MOW:
   unofficial_names:
   - Moskva
@@ -603,7 +603,7 @@ MOW:
     min_longitude: 37.3193288
     max_latitude: 56.009657
     max_longitude: 37.9456611
-  name: Moskva
+  name: Moscow
 MUR:
   unofficial_names:
   - Murmanskaja Oblast
@@ -616,7 +616,7 @@ MUR:
     min_longitude: 28.4163852
     max_latitude: 69.9520907
     max_longitude: 41.4017088
-  name: Murmanskaya oblast'
+  name: Murmansk
 NEN:
   unofficial_names:
   - Nenetskij Avtonomnyj Okrug
@@ -629,7 +629,7 @@ NEN:
     min_longitude: 43.2703527
     max_latitude: 70.4649036
     max_longitude: 65.6777838
-  name: Nenetskiy avtonomnyy okrug
+  name: Nenets
 NGR:
   unofficial_names:
   - Novgorodskaja Oblast
@@ -642,7 +642,7 @@ NGR:
     min_longitude: 29.62305709999999
     max_latitude: 59.44515209999999
     max_longitude: 36.2195299
-  name: Novgorodskaya oblast'
+  name: Novgorod
 NIZ:
   unofficial_names:
   - Gorki
@@ -660,7 +660,7 @@ NIZ:
     min_longitude: 41.775117
     max_latitude: 58.0889949
     max_longitude: 47.7473761
-  name: Nizhegorodskaya oblast'
+  name: Nizhny Novgorod
 NVS:
   unofficial_names:
   - Novosibirskaja Oblast
@@ -673,7 +673,7 @@ NVS:
     min_longitude: 75.08785499999999
     max_latitude: 57.236193
     max_longitude: 85.11756299999999
-  name: Novosibirskaya oblast'
+  name: Novosibirsk
 OMS:
   unofficial_names:
   - Omskaja Oblast
@@ -686,7 +686,7 @@ OMS:
     min_longitude: 70.35473710000001
     max_latitude: 58.5741489
     max_longitude: 76.3037678
-  name: Omskaya oblast'
+  name: Omsk
 ORE:
   unofficial_names:
   - Orenburgskaja Oblast
@@ -699,7 +699,7 @@ ORE:
     min_longitude: 50.7683845
     max_latitude: 54.36583
     max_longitude: 61.6907461
-  name: Orenburgskaya oblast'
+  name: Orenburg
 ORL:
   unofficial_names:
   - Orlovskaja Oblast
@@ -713,7 +713,7 @@ ORL:
     min_longitude: 34.7917679
     max_latitude: 53.6372159
     max_longitude: 38.0644791
-  name: Orlovskaya oblast'
+  name: Oryol
 PER:
   unofficial_names:
   - Permskaja Oblast
@@ -727,7 +727,7 @@ PER:
     min_longitude: 55.8117439
     max_latitude: 58.176955
     max_longitude: 56.65680709999999
-  name: Perm
+  name: Perm Krai
 PNZ:
   unofficial_names:
   - Penzenskaja Oblast
@@ -740,7 +740,7 @@ PNZ:
     min_longitude: 42.091744
     max_latitude: 54.0281089
     max_longitude: 46.985298
-  name: Penzenskaya oblast'
+  name: Penza
 PRI:
   unofficial_names:
   - Primorskij
@@ -755,7 +755,7 @@ PRI:
     min_longitude: 130.39465
     max_latitude: 48.4587049
     max_longitude: 139.021501
-  name: Primorskiy kray
+  name: Primorsky Krai
 PSK:
   unofficial_names:
   - Pihkva
@@ -770,7 +770,7 @@ PSK:
     min_longitude: 27.323293
     max_latitude: 59.01885189999999
     max_longitude: 31.51626409999999
-  name: Pskovskaya oblast'
+  name: Pskov
 ROS:
   unofficial_names:
   - Rostovskaja Oblast
@@ -783,7 +783,7 @@ ROS:
     min_longitude: 38.2223739
     max_latitude: 50.2123279
     max_longitude: 44.3225439
-  name: Rostovskaya oblast'
+  name: Rostov
 RYA:
   unofficial_names:
   - Rjazanskaja Oblast
@@ -797,7 +797,7 @@ RYA:
     min_longitude: 38.6651351
     max_latitude: 55.3661119
     max_longitude: 42.694238
-  name: Ryazanskaya oblast'
+  name: Ryazan
 SA:
   unofficial_names:
   - Jakutija
@@ -813,7 +813,7 @@ SA:
     min_longitude: 105.529348
     max_latitude: 76.7581309
     max_longitude: 162.858423
-  name: Sakha, Respublika [Yakutiya]
+  name: Sakha
 SAK:
   unofficial_names:
   - Sahalinskaya Oblast
@@ -827,7 +827,7 @@ SAK:
     min_longitude: 141.1964501
     max_latitude: 54.416035
     max_longitude: 156.5116784
-  name: Sakhalinskaya oblast'
+  name: Sakhalin
 SAM:
   unofficial_names:
   - Samarskaja Oblast
@@ -840,7 +840,7 @@ SAM:
     min_longitude: 47.9246881
     max_latitude: 54.678024
     max_longitude: 52.555451
-  name: Samarskaya oblast'
+  name: Samara
 SAR:
   unofficial_names:
   - Saratovskaja Oblast
@@ -853,7 +853,7 @@ SAR:
     min_longitude: 42.5132981
     max_latitude: 52.814547
     max_longitude: 50.8330918
-  name: Saratovskaya oblast'
+  name: Saratov
 SE:
   unofficial_names:
   - Alania
@@ -869,7 +869,7 @@ SE:
     min_longitude: 43.4103983
     max_latitude: 43.839755
     max_longitude: 44.956779
-  name: Severnaya Osetiya, Respublika [Alaniya] [Respublika Severnaya Osetiya-Alaniya]
+  name: North Ossetia-Alania
 SMO:
   unofficial_names:
   - Smolenskaja Oblast
@@ -882,7 +882,7 @@ SMO:
     min_longitude: 30.7486752
     max_latitude: 56.07094379999999
     max_longitude: 35.3920447
-  name: Smolenskaya oblast'
+  name: Smolensk
 SPE:
   unofficial_names:
   - San Pietroburgo
@@ -899,7 +899,7 @@ SPE:
     min_longitude: 30.090332
     max_latitude: 60.089675
     max_longitude: 30.559783
-  name: Sankt-Peterburg
+  name: Saint Petersburg
 STA:
   unofficial_names:
   - Stavropolskij Kraj
@@ -912,7 +912,7 @@ STA:
     min_longitude: 40.8430621
     max_latitude: 46.2299116
     max_longitude: 45.7189749
-  name: Stavropol'skiy kray
+  name: Stavropol Krai
 SVE:
   unofficial_names:
   - Sverdlovskaja Oblast
@@ -925,7 +925,7 @@ SVE:
     min_longitude: 57.2360151
     max_latitude: 61.94590299999999
     max_longitude: 66.178652
-  name: Sverdlovskaya oblast'
+  name: Sverdlovsk
 TA:
   unofficial_names: Tatarstan, Respublika
   translations:
@@ -937,7 +937,7 @@ TA:
     min_longitude: 47.2586476
     max_latitude: 56.6772159
     max_longitude: 54.2602891
-  name: Tatarstan, Respublika
+  name: Tatarstan
 TAM:
   unofficial_names:
   - Tambovskaja Oblast
@@ -950,7 +950,7 @@ TAM:
     min_longitude: 39.9170968
     max_latitude: 53.8228889
     max_longitude: 43.244815
-  name: Tambovskaya oblast'
+  name: Tambov
 TOM:
   unofficial_names:
   - Tomskaja Oblast
@@ -963,7 +963,7 @@ TOM:
     min_longitude: 75.0574591
     max_latitude: 61.0335298
     max_longitude: 89.37532709999999
-  name: Tomskaya oblast'
+  name: Tomsk
 TUL:
   unofficial_names:
   - Tulskaja Oblast
@@ -976,7 +976,7 @@ TUL:
     min_longitude: 35.8963269
     max_latitude: 54.8505721
     max_longitude: 38.952968
-  name: Tul'skaya oblast'
+  name: Tula
 TVE:
   unofficial_names:
   - Tverskaja Oblast
@@ -989,7 +989,7 @@ TVE:
     min_longitude: 30.7768341
     max_latitude: 58.8721109
     max_longitude: 38.31839
-  name: Tverskaya oblast'
+  name: Tver
 TY:
   unofficial_names:
   - Tuva
@@ -1002,7 +1002,7 @@ TY:
     min_longitude: 88.7985341
     max_latitude: 53.727431
     max_longitude: 99.269666
-  name: Tyva, Respublika [Tuva]
+  name: Tuva
 TYU:
   unofficial_names:
   - Tjumenskaja Oblast
@@ -1017,7 +1017,7 @@ TYU:
     min_longitude: 64.8277999
     max_latitude: 59.9896339
     max_longitude: 75.19419900000001
-  name: Tyumenskaya oblast'
+  name: Tyumen
 UD:
   unofficial_names:
   - Udmurt Republic
@@ -1032,7 +1032,7 @@ UD:
     min_longitude: 51.1226019
     max_latitude: 58.545039
     max_longitude: 54.42754619999999
-  name: Udmurtskaya Respublika
+  name: Udmurt
 ULY:
   unofficial_names:
   - Uljanovskaja Oblast
@@ -1046,7 +1046,7 @@ ULY:
     min_longitude: 45.7949271
     max_latitude: 54.891972
     max_longitude: 50.2391649
-  name: Ul'yanovskaya oblast'
+  name: Ulyanovsk
 VGG:
   unofficial_names:
   - Volgogradskaja Oblast
@@ -1059,7 +1059,7 @@ VGG:
     min_longitude: 41.167564
     max_latitude: 51.2443039
     max_longitude: 47.4312876
-  name: Volgogradskaya oblast'
+  name: Volgograd
 VLA:
   unofficial_names:
   - Vladimirskaja Oblast
@@ -1072,7 +1072,7 @@ VLA:
     min_longitude: 38.272862
     max_latitude: 56.81697
     max_longitude: 42.977175
-  name: Vladimirskaya oblast'
+  name: Vladimir
 VLG:
   unofficial_names:
   - Vologodskaja Oblast
@@ -1085,7 +1085,7 @@ VLG:
     min_longitude: 34.7161178
     max_latitude: 61.607277
     max_longitude: 47.1578849
-  name: Vologodskaya oblast'
+  name: Vologda
 VOR:
   unofficial_names:
   - Voronežskaja Oblast
@@ -1099,7 +1099,7 @@ VOR:
     min_longitude: 38.13708
     max_latitude: 52.102429
     max_longitude: 42.944786
-  name: Voronezhskaya oblast'
+  name: Voronezh
 YAN:
   unofficial_names:
   - Jamalija
@@ -1114,7 +1114,7 @@ YAN:
     min_longitude: 62.0121153
     max_latitude: 73.5224935
     max_longitude: 86.01397010000001
-  name: Yamalo-Nenetskiy avtonomnyy okrug
+  name: Yamalo-Nenets Okrug
 YAR:
   unofficial_names:
   - Jaroslavskaja Oblast
@@ -1128,7 +1128,7 @@ YAR:
     min_longitude: 37.3243239
     max_latitude: 58.95002100000001
     max_longitude: 41.178673
-  name: Yaroslavskaya oblast'
+  name: Yaroslavl
 YEV:
   unofficial_names:
   - Jevrejskaja Oblast
@@ -1145,7 +1145,7 @@ YEV:
     min_longitude: 130.5212439
     max_latitude: 49.4938831
     max_longitude: 134.9953569
-  name: Yevreyskaya avtonomnaya oblast'
+  name: Jewish
 ZAB:
   unofficial_names:
   - Zabajkal'skij kraj
@@ -1160,4 +1160,4 @@ ZAB:
     min_longitude: 107.736142
     max_latitude: 58.435147
     max_longitude: 122.1303228
-  name: Zabaykal'skij kray
+  name: Zabaykalsky Krai

--- a/lib/countries/data/subdivisions/RW.yaml
+++ b/lib/countries/data/subdivisions/RW.yaml
@@ -10,7 +10,7 @@
     min_longitude: 30.0249481
     max_latitude: -1.8858746
     max_longitude: 30.1841457
-  name: Ville de Kigali
+  name: Kigali
 '02':
   unofficial_names: Est
   translations:
@@ -22,7 +22,7 @@
     min_longitude: 29.957893
     max_latitude: -1.0534809
     max_longitude: 30.895958
-  name: Est
+  name: Eastern
 '03':
   unofficial_names: Nord
   translations:
@@ -34,7 +34,7 @@
     min_longitude: 29.454336
     max_latitude: -1.3148709
     max_longitude: 30.274553
-  name: Nord
+  name: Northern
 '04':
   unofficial_names: Ouest
   translations:
@@ -46,7 +46,7 @@
     min_longitude: 28.856794
     max_latitude: -1.501001
     max_longitude: 29.671675
-  name: Ouest
+  name: Western
 '05':
   unofficial_names: Sud
   translations:
@@ -58,4 +58,4 @@
     min_longitude: 29.26116
     max_latitude: -1.7338349
     max_longitude: 30.0145421
-  name: Sud
+  name: Southern

--- a/lib/countries/data/subdivisions/SA.yaml
+++ b/lib/countries/data/subdivisions/SA.yaml
@@ -15,7 +15,7 @@
     min_longitude: 46.2981033
     max_latitude: 25.1564724
     max_longitude: 47.34695430000001
-  name: Ar Riya?
+  name: Riyadh
 '02':
   unofficial_names:
   - La Meca
@@ -57,7 +57,7 @@
     min_longitude: 44.9209199
     max_latitude: 29.1188431
     max_longitude: 55.6665879
-  name: Ash Sharqiyah
+  name: Eastern
 '05':
   unofficial_names:
   - Qaseem
@@ -70,7 +70,7 @@
     min_longitude: 41.40690499999999
     max_latitude: 27.3311671
     max_longitude: 44.8272001
-  name: Al Qasim
+  name: Al-Qassim
 '06':
   unofficial_names:
   - Hail
@@ -83,7 +83,7 @@
     min_longitude: 41.5061761
     max_latitude: 27.6987282
     max_longitude: 41.8434906
-  name: "?a'il"
+  name: Ha’il
 '07':
   unofficial_names:
   - Tabook
@@ -97,7 +97,7 @@
     max_latitude: 28.4718602
     max_longitude: 36.6991425
   name: Tabuk
-08:
+'08':
   unofficial_names:
   - Northern
   - al-Hudud ash-Shamaliyah
@@ -110,8 +110,8 @@
     min_longitude: 37.8584141
     max_latitude: 32.158333
     max_longitude: 45.92311
-  name: Al ?udud ash Shamaliyah
-09:
+  name: Northern Borders
+'09':
   unofficial_names:
   - Jizan
   translations:
@@ -148,7 +148,7 @@
     min_longitude: 39.21315860000001
     max_latitude: 21.4561942
     max_longitude: 39.2135471
-  name: Al Ba?ah
+  name: Al Bahah
 '12':
   unofficial_names: Al Jawf
   translations:
@@ -173,4 +173,4 @@
     min_longitude: 41.38029
     max_latitude: 20.970846
     max_longitude: 44.528442
-  name: "?Asir"
+  name: Asir

--- a/lib/countries/data/subdivisions/SB.yaml
+++ b/lib/countries/data/subdivisions/SB.yaml
@@ -35,7 +35,7 @@ CT:
     min_longitude: 159.9145083
     max_latitude: -9.4211729
     max_longitude: 160.0229509
-  name: Capital Territory (Honiara)
+  name: Honiara
 GU:
   unofficial_names: Guadalcanal
   translations:
@@ -72,7 +72,7 @@ MK:
     min_longitude: 161.2639239
     max_latitude: -9.714576899999999
     max_longitude: 162.4842479
-  name: Makira
+  name: Makira-Ulawa
 ML:
   unofficial_names:
   - Mala

--- a/lib/countries/data/subdivisions/SC.yaml
+++ b/lib/countries/data/subdivisions/SC.yaml
@@ -34,7 +34,7 @@
     min_longitude: 55.43989500000001
     max_latitude: -4.581683
     max_longitude: 55.462322
-  name: Anse Étoile
+  name: Anse Etoile
 '04':
   unofficial_names: Anse Louis
   translations:
@@ -46,7 +46,7 @@
     min_longitude: 55.47635450000001
     max_latitude: -4.7165001
     max_longitude: 55.4798841
-  name: Anse Louis
+  name: Au Cap
 '05':
   unofficial_names: Anse Royale
   translations:
@@ -83,7 +83,7 @@
     max_latitude: -4.276453099999999
     max_longitude: 55.7889993
   name: Baie Sainte Anne
-08:
+'08':
   unofficial_names: Beau Vallon
   translations:
     en: Beau Vallon
@@ -95,7 +95,7 @@
     max_latitude: -4.6111603
     max_longitude: 55.43984409999999
   name: Beau Vallon
-09:
+'09':
   unofficial_names: Bel Air
   translations:
     en: Bel Air
@@ -154,7 +154,7 @@
     min_longitude: 55.43838100000001
     max_latitude: -4.657465
     max_longitude: 55.486098
-  name: Grand' Anse (Mahé)
+  name: Grand’Anse Mahé
 '14':
   unofficial_names: Grand' Anse (Praslin)
   translations:
@@ -166,7 +166,7 @@
     min_longitude: 55.6446526
     max_latitude: -4.292169599999999
     max_longitude: 55.761684
-  name: Grand' Anse (Praslin)
+  name: Grand’Anse Praslin
 '15':
   unofficial_names: La Digue
   translations:

--- a/lib/countries/data/subdivisions/SD.yaml
+++ b/lib/countries/data/subdivisions/SD.yaml
@@ -99,7 +99,7 @@
     max_latitude: 15.4767249
     max_longitude: 34.3057649
   name: Al Jazirah
-08:
+'08':
   unofficial_names:
   - White Nile
   translations:
@@ -112,7 +112,7 @@
     max_latitude: 15.250874
     max_longitude: 33.2549571
   name: An Nil al Abya?
-09:
+'09':
   unofficial_names:
   - North Kordofan
   - Shimal Kurdufan

--- a/lib/countries/data/subdivisions/SE.yaml
+++ b/lib/countries/data/subdivisions/SE.yaml
@@ -10,7 +10,7 @@ AB:
     min_longitude: 17.2375371
     max_latitude: 60.2557827
     max_longitude: 19.3499043
-  name: Stockholms län
+  name: Stockholm
 AC:
   unofficial_names: Västerbottens län
   translations:
@@ -22,7 +22,7 @@ AC:
     min_longitude: 14.2568099
     max_latitude: 66.340329
     max_longitude: 21.6169479
-  name: Västerbottens län
+  name: Västerbotten
 BD:
   unofficial_names: Norrbottens län
   translations:
@@ -34,7 +34,7 @@ BD:
     min_longitude: 15.3723748
     max_latitude: 69.06307199999999
     max_longitude: 24.1624078
-  name: Norrbottens län
+  name: Norrbotten
 C:
   unofficial_names: Uppsala län
   translations:
@@ -46,7 +46,7 @@ C:
     min_longitude: 16.678336
     max_latitude: 60.7313874
     max_longitude: 18.7711579
-  name: Uppsala län
+  name: Uppsala
 D:
   unofficial_names: Södermanlands län
   translations:
@@ -58,7 +58,7 @@ D:
     min_longitude: 15.5932
     max_latitude: 59.5228374
     max_longitude: 17.7453121
-  name: Södermanlands län
+  name: Södermanland
 E:
   unofficial_names: Östergötlands län
   translations:
@@ -70,7 +70,7 @@ E:
     min_longitude: 14.5409236
     max_latitude: 59.01996210000001
     max_longitude: 17.0853315
-  name: Östergötlands län
+  name: Östergötland
 F:
   unofficial_names: Jönköpings län
   translations:
@@ -82,7 +82,7 @@ F:
     min_longitude: 13.0688452
     max_latitude: 58.153372
     max_longitude: 15.6562501
-  name: Jönköpings län
+  name: Jönköping
 G:
   unofficial_names: Kronobergs län
   translations:
@@ -94,7 +94,7 @@ G:
     min_longitude: 13.2767319
     max_latitude: 57.238187
     max_longitude: 15.844141
-  name: Kronobergs län
+  name: Kronoberg
 H:
   unofficial_names:
   - Calmar
@@ -107,7 +107,7 @@ H:
     min_longitude: 15.3360812
     max_latitude: 58.141144
     max_longitude: 17.1506084
-  name: Kalmar län
+  name: Kalmar
 I:
   unofficial_names: Gotlands län
   translations:
@@ -119,7 +119,7 @@ I:
     min_longitude: 17.9564368
     max_latitude: 58.3987317
     max_longitude: 19.3504137
-  name: Gotlands län
+  name: Gotland
 K:
   unofficial_names: Blekinge län
   translations:
@@ -131,7 +131,7 @@ K:
     min_longitude: 14.3528851
     max_latitude: 56.5022141
     max_longitude: 16.0679243
-  name: Blekinge län
+  name: Blekinge
 M:
   unofficial_names:
   - Scania
@@ -144,7 +144,7 @@ M:
     min_longitude: 12.4417552
     max_latitude: 56.54260590000001
     max_longitude: 14.5844781
-  name: Skåne län
+  name: Skåne
 N:
   unofficial_names: Hallands län
   translations:
@@ -156,7 +156,7 @@ N:
     min_longitude: 11.821994
     max_latitude: 57.5731741
     max_longitude: 13.7176809
-  name: Hallands län
+  name: Halland
 O:
   unofficial_names: Västra Götalands län
   translations:
@@ -168,7 +168,7 @@ O:
     min_longitude: 10.9631866
     max_latitude: 59.26203409999999
     max_longitude: 14.7148173
-  name: Västra Götalands län
+  name: Västra Götaland
 S:
   unofficial_names: Värmlands län
   translations:
@@ -180,7 +180,7 @@ S:
     min_longitude: 11.681877
     max_latitude: 61.06945409999999
     max_longitude: 14.48975
-  name: Värmlands län
+  name: Värmland
 T:
   unofficial_names: Örebro län
   translations:
@@ -192,7 +192,7 @@ T:
     min_longitude: 14.243871
     max_latitude: 60.1056601
     max_longitude: 15.7880099
-  name: Örebro län
+  name: Örebro
 U:
   unofficial_names: Västmanlands län
   translations:
@@ -204,7 +204,7 @@ U:
     min_longitude: 15.41747
     max_latitude: 60.1906571
     max_longitude: 16.9458588
-  name: Västmanlands län
+  name: Västmanland
 W:
   unofficial_names:
   - Dalarnas
@@ -219,7 +219,7 @@ W:
     min_longitude: 12.1331131
     max_latitude: 62.28024099999999
     max_longitude: 16.739265
-  name: Dalarnas län
+  name: Dalarna
 X:
   unofficial_names: Gävleborgs län
   translations:
@@ -231,7 +231,7 @@ X:
     min_longitude: 14.459403
     max_latitude: 62.37083
     max_longitude: 17.6414757
-  name: Gävleborgs län
+  name: Gävleborg
 Y:
   unofficial_names: Västernorrlands län
   translations:
@@ -243,7 +243,7 @@ Y:
     min_longitude: 14.776302
     max_latitude: 64.00223489999999
     max_longitude: 19.2867079
-  name: Västernorrlands län
+  name: Västernorrland
 Z:
   unofficial_names: Jämtlands län
   translations:
@@ -255,4 +255,4 @@ Z:
     min_longitude: 11.9688662
     max_latitude: 65.073133
     max_longitude: 17.0648909
-  name: Jämtlands län
+  name: Jämtland

--- a/lib/countries/data/subdivisions/SH.yaml
+++ b/lib/countries/data/subdivisions/SH.yaml
@@ -10,7 +10,7 @@ AC:
     min_longitude: -14.4202423
     max_latitude: -7.888888
     max_longitude: -14.2954026
-  name: Ascension
+  name: Ascension Island
 SH:
   unofficial_names: Saint Helena
   translations:

--- a/lib/countries/data/subdivisions/SI.yaml
+++ b/lib/countries/data/subdivisions/SI.yaml
@@ -10,7 +10,7 @@
     min_longitude: 13.8808621
     max_latitude: 45.9068796
     max_longitude: 13.9250956
-  name: Ajdovšcina
+  name: Ajdovščina
 '002':
   unofficial_names: Beltinci
   translations:
@@ -83,7 +83,7 @@
     max_latitude: 46.4788807
     max_longitude: 15.1765445
   name: Brda
-008:
+'008':
   unofficial_names: Brezovica
   translations:
     en: Brezovica
@@ -95,7 +95,7 @@
     max_latitude: 45.88924420000001
     max_longitude: 15.2499418
   name: Brezovica
-009:
+'009':
   unofficial_names: Brežice
   translations:
     en: Brežice
@@ -178,7 +178,7 @@
     min_longitude: 16.2666812
     max_latitude: 46.5852017
     max_longitude: 16.3453289
-  name: Crenšovci
+  name: Črenšovci
 '016':
   unofficial_names: Crna na Koroškem
   translations:
@@ -190,7 +190,7 @@
     min_longitude: 14.8165776
     max_latitude: 46.4825972
     max_longitude: 14.8836197
-  name: Crna na Koroškem
+  name: Črna na Koroškem
 '017':
   unofficial_names: Crnomelj
   translations:
@@ -202,8 +202,8 @@
     min_longitude: 15.165933
     max_latitude: 45.59965
     max_longitude: 15.2236525
-  name: Crnomelj
-018:
+  name: Črnomelj
+'018':
   unofficial_names: Destrnik
   translations:
     en: Destrnik
@@ -215,7 +215,7 @@
     max_latitude: 46.4972951
     max_longitude: 15.8860775
   name: Destrnik
-019:
+'019':
   unofficial_names: Divaca
   translations:
     en: Divaca
@@ -226,7 +226,7 @@
     min_longitude: 13.9333018
     max_latitude: 45.7069151
     max_longitude: 14.0009139
-  name: Divaca
+  name: Divača
 '020':
   unofficial_names: Dobrepolje
   translations:
@@ -250,7 +250,7 @@
     min_longitude: 14.1883156
     max_latitude: 46.107928
     max_longitude: 14.4427003
-  name: Dobrova-Polhov Gradec
+  name: Dobrova–Polhov Gradec
 '022':
   unofficial_names: Dol pri Ljubljani
   translations:
@@ -322,8 +322,8 @@
     min_longitude: 14.0178293
     max_latitude: 46.1809494
     max_longitude: 14.2279654
-  name: Gorenja vas-Poljane
-028:
+  name: Gorenja Vas–Poljane
+'028':
   unofficial_names: Gorišnica
   translations:
     en: Gorišnica
@@ -335,7 +335,7 @@
     max_latitude: 46.4225317
     max_longitude: 16.0357271
   name: Gorišnica
-029:
+'029':
   unofficial_names: Gornja Radgona
   translations:
     en: Gornja Radgona
@@ -418,7 +418,7 @@
     min_longitude: 13.8687912
     max_latitude: 45.6444312
     max_longitude: 14.1316015
-  name: Hrpelje-Kozina
+  name: Hrpelje–Kozina
 '036':
   unofficial_names: Idrija
   translations:
@@ -443,7 +443,7 @@
     max_latitude: 45.99051650000001
     max_longitude: 14.5590687
   name: Ig
-038:
+'038':
   unofficial_names: Ilirska Bistrica
   translations:
     en: Ilirska Bistrica
@@ -455,7 +455,7 @@
     max_latitude: 45.5976891
     max_longitude: 14.3981604
   name: Ilirska Bistrica
-039:
+'039':
   unofficial_names: Ivancna Gorica
   translations:
     en: Ivancna Gorica
@@ -466,7 +466,7 @@
     min_longitude: 14.7943209
     max_latitude: 45.9464556
     max_longitude: 14.8189485
-  name: Ivancna Gorica
+  name: Ivančna Gorica
 '040':
   unofficial_names: Izola/Isola
   translations:
@@ -478,7 +478,7 @@
     min_longitude: 13.6463316
     max_latitude: 45.5481856
     max_longitude: 13.6940814
-  name: Izola/Isola
+  name: Izola
 '041':
   unofficial_names: Jesenice
   translations:
@@ -538,7 +538,7 @@
     min_longitude: 15.7747304
     max_latitude: 46.4248816
     max_longitude: 15.8052251
-  name: Kidricevo
+  name: Kidričevo
 '046':
   unofficial_names: Kobarid
   translations:
@@ -563,7 +563,7 @@
     max_latitude: 46.7042549
     max_longitude: 16.4286219
   name: Kobilje
-048:
+'048':
   unofficial_names: Kocevje
   translations:
     en: Kocevje
@@ -574,8 +574,8 @@
     min_longitude: 14.8144785
     max_latitude: 45.6612108
     max_longitude: 14.8861107
-  name: Kocevje
-049:
+  name: Kočevje
+'049':
   unofficial_names: Komen
   translations:
     en: Komen
@@ -598,7 +598,7 @@
     min_longitude: 13.6895796
     max_latitude: 45.55769069999999
     max_longitude: 13.7607302
-  name: Koper/Capodistria
+  name: Koper
 '051':
   unofficial_names: Kozje
   translations:
@@ -683,7 +683,7 @@
     max_latitude: 46.17712179999999
     max_longitude: 15.2548406
   name: Laško
-058:
+'058':
   unofficial_names: Lenart
   translations:
     en: Lenart
@@ -695,7 +695,7 @@
     max_latitude: 46.7012008
     max_longitude: 15.9811767
   name: Lenart
-059:
+'059':
   unofficial_names: Lendava/Lendva
   translations:
     en: Lendava/Lendva
@@ -706,7 +706,7 @@
     min_longitude: 16.4138543
     max_latitude: 46.5751146
     max_longitude: 16.4729848
-  name: Lendava/Lendva
+  name: Lendava
 '060':
   unofficial_names: Litija
   translations:
@@ -778,7 +778,7 @@
     min_longitude: 14.3794264
     max_latitude: 45.7490038
     max_longitude: 14.5701394
-  name: Loška dolina
+  name: Loška Dolina
 '066':
   unofficial_names: Loški Potok
   translations:
@@ -802,8 +802,8 @@
     min_longitude: 14.7346965
     max_latitude: 46.3590009
     max_longitude: 14.7482263
-  name: Luce
-068:
+  name: Luče
+'068':
   unofficial_names: Lukovica
   translations:
     en: Lukovica
@@ -815,7 +815,7 @@
     max_latitude: 46.1794056
     max_longitude: 14.7040913
   name: Lukovica
-069:
+'069':
   unofficial_names: Majšperk
   translations:
     en: Majšperk
@@ -898,7 +898,7 @@
     min_longitude: 13.5744186
     max_latitude: 45.9038824
     max_longitude: 13.71941
-  name: Miren-Kostanjevica
+  name: Miren–Kostanjevica
 '076':
   unofficial_names: Mislinja
   translations:
@@ -922,8 +922,8 @@
     min_longitude: 14.7283915
     max_latitude: 46.1442446
     max_longitude: 14.7557551
-  name: Moravce
-078:
+  name: Moravče
+'078':
   unofficial_names: Moravske Toplice
   translations:
     en: Moravske Toplice
@@ -935,7 +935,7 @@
     max_latitude: 46.7265446
     max_longitude: 16.2623714
   name: Moravske Toplice
-079:
+'079':
   unofficial_names: Mozirje
   translations:
     en: Mozirje
@@ -947,7 +947,7 @@
     max_latitude: 46.3516621
     max_longitude: 14.9753351
   name: Mozirje
-080:
+'080':
   unofficial_names: Murska Sobota
   translations:
     en: Murska Sobota
@@ -959,7 +959,7 @@
     max_latitude: 46.6840267
     max_longitude: 16.2032004
   name: Murska Sobota
-081:
+'081':
   unofficial_names: Muta
   translations:
     en: Muta
@@ -971,7 +971,7 @@
     max_latitude: 46.6192274
     max_longitude: 15.1772468
   name: Muta
-082:
+'082':
   unofficial_names: Naklo
   translations:
     en: Naklo
@@ -983,7 +983,7 @@
     max_latitude: 46.2859105
     max_longitude: 14.3292088
   name: Naklo
-083:
+'083':
   unofficial_names: Nazarje
   translations:
     en: Nazarje
@@ -995,7 +995,7 @@
     max_latitude: 46.3264519
     max_longitude: 14.9579734
   name: Nazarje
-084:
+'084':
   unofficial_names: Nova Gorica
   translations:
     en: Nova Gorica
@@ -1007,7 +1007,7 @@
     max_latitude: 45.9668771
     max_longitude: 13.6625232
   name: Nova Gorica
-085:
+'085':
   unofficial_names: Novo mesto
   translations:
     en: Novo mesto
@@ -1018,8 +1018,8 @@
     min_longitude: 15.127425
     max_latitude: 45.8389841
     max_longitude: 15.2119462
-  name: Novo mesto
-086:
+  name: Novo Mesto
+'086':
   unofficial_names: Odranci
   translations:
     en: Odranci
@@ -1031,7 +1031,7 @@
     max_latitude: 46.6016558
     max_longitude: 16.2985609
   name: Odranci
-087:
+'087':
   unofficial_names: Ormož
   translations:
     en: Ormož
@@ -1043,7 +1043,7 @@
     max_latitude: 46.4156206
     max_longitude: 16.1776242
   name: Ormož
-088:
+'088':
   unofficial_names: Osilnica
   translations:
     en: Osilnica
@@ -1055,7 +1055,7 @@
     max_latitude: 45.5413028
     max_longitude: 14.7123838
   name: Osilnica
-089:
+'089':
   unofficial_names: Pesnica
   translations:
     en: Pesnica
@@ -1067,7 +1067,7 @@
     max_latitude: 46.64874270000001
     max_longitude: 15.5811768
   name: Pesnica
-090:
+'090':
   unofficial_names: Piran/Pirano
   translations:
     en: Piran/Pirano
@@ -1078,8 +1078,8 @@
     min_longitude: 13.5628854
     max_latitude: 45.5306107
     max_longitude: 13.5752889
-  name: Piran/Pirano
-091:
+  name: Piran
+'091':
   unofficial_names: Pivka
   translations:
     en: Pivka
@@ -1091,7 +1091,7 @@
     max_latitude: 45.6911654
     max_longitude: 14.2213455
   name: Pivka
-092:
+'092':
   unofficial_names: Podcetrtek
   translations:
     en: Podcetrtek
@@ -1102,8 +1102,8 @@
     min_longitude: 15.5724693
     max_latitude: 46.1729841
     max_longitude: 15.6142634
-  name: Podcetrtek
-093:
+  name: Podčetrtek
+'093':
   unofficial_names: Podvelka
   translations:
     en: Podvelka
@@ -1115,7 +1115,7 @@
     max_latitude: 46.5930529
     max_longitude: 15.3532612
   name: Podvelka
-094:
+'094':
   unofficial_names: Postojna
   translations:
     en: Postojna
@@ -1127,7 +1127,7 @@
     max_latitude: 45.8089095
     max_longitude: 14.326014
   name: Postojna
-095:
+'095':
   unofficial_names: Preddvor
   translations:
     en: Preddvor
@@ -1139,7 +1139,7 @@
     max_latitude: 46.3094882
     max_longitude: 14.4268728
   name: Preddvor
-096:
+'096':
   unofficial_names: Ptuj
   translations:
     en: Ptuj
@@ -1151,7 +1151,7 @@
     max_latitude: 46.4587718
     max_longitude: 15.9180402
   name: Ptuj
-097:
+'097':
   unofficial_names: Puconci
   translations:
     en: Puconci
@@ -1163,7 +1163,7 @@
     max_latitude: 46.7195726
     max_longitude: 16.1766865
   name: Puconci
-098:
+'098':
   unofficial_names: Race-Fram
   translations:
     en: Race-Fram
@@ -1174,8 +1174,8 @@
     min_longitude: 15.6198414
     max_latitude: 46.4661091
     max_longitude: 15.6586513
-  name: Race-Fram
-099:
+  name: Rače–Fram
+'099':
   unofficial_names: Radece
   translations:
     en: Radece
@@ -1186,7 +1186,7 @@
     min_longitude: 15.1550379
     max_latitude: 46.08046119999999
     max_longitude: 15.1952936
-  name: Radece
+  name: Radeče
 '100':
   unofficial_names: Radenci
   translations:
@@ -1306,7 +1306,7 @@
     min_longitude: 15.1472437
     max_latitude: 45.668519
     max_longitude: 15.2062962
-  name: Semic
+  name: Semič
 '110':
   unofficial_names: Sevnica
   translations:
@@ -1402,7 +1402,7 @@
     min_longitude: 14.396405
     max_latitude: 46.25425420000001
     max_longitude: 14.4447634
-  name: Šencur
+  name: Šenčur
 '118':
   unofficial_names: Šentilj
   translations:
@@ -1438,7 +1438,7 @@
     min_longitude: 15.3301529
     max_latitude: 46.3118567
     max_longitude: 15.5358711
-  name: Šentjur pri Celju
+  name: Šentjur
 '121':
   unofficial_names: Škocjan
   translations:
@@ -1570,7 +1570,7 @@
     min_longitude: 14.2912574
     max_latitude: 46.382076
     max_longitude: 14.3356295
-  name: Tržic
+  name: Tržič
 '132':
   unofficial_names: Turnišce
   translations:
@@ -1582,7 +1582,7 @@
     min_longitude: 16.2645197
     max_latitude: 46.6432698
     max_longitude: 16.3358325
-  name: Turnišce
+  name: Turnišče
 '133':
   unofficial_names: Velenje
   translations:
@@ -1606,7 +1606,7 @@
     min_longitude: 14.6151067
     max_latitude: 45.850463
     max_longitude: 14.6703333
-  name: Velike Lašce
+  name: Velike Lašče
 '135':
   unofficial_names: Videm
   translations:
@@ -1714,7 +1714,7 @@
     min_longitude: 16.0254542
     max_latitude: 46.392795
     max_longitude: 16.0559568
-  name: Zavrc
+  name: Zavrč
 '144':
   unofficial_names: Zrece
   translations:
@@ -1726,7 +1726,7 @@
     min_longitude: 15.3599061
     max_latitude: 46.3891589
     max_longitude: 15.4118749
-  name: Zrece
+  name: Zreče
 '146':
   unofficial_names: Železniki
   translations:
@@ -1798,7 +1798,7 @@
     min_longitude: 15.0227904
     max_latitude: 46.2958925
     max_longitude: 15.0487472
-  name: Braslovce
+  name: Braslovče
 '152':
   unofficial_names: Cankova
   translations:
@@ -1858,7 +1858,7 @@
     min_longitude: 16.3092205
     max_latitude: 46.6754685
     max_longitude: 16.3748429
-  name: Dobrovnik/Dobronak
+  name: Dobrovnik
 '157':
   unofficial_names: Dolenjske Toplice
   translations:
@@ -1906,7 +1906,7 @@
     min_longitude: 15.5359515
     max_latitude: 46.5216497
     max_longitude: 15.7108982
-  name: Hoce-Slivnica
+  name: Hoče–Slivnica
 '161':
   unofficial_names: Hodoš/Hodos
   translations:
@@ -1918,7 +1918,7 @@
     min_longitude: 16.2907565
     max_latitude: 46.8664431
     max_longitude: 16.3508332
-  name: Hodoš/Hodos
+  name: Hodoš
 '162':
   unofficial_names: Horjul
   translations:
@@ -2014,7 +2014,7 @@
     min_longitude: 15.6817881
     max_latitude: 46.5171316
     max_longitude: 15.730069
-  name: Miklavž na Dravskem polju
+  name: Miklavž na Dravskem Polju
 '170':
   unofficial_names: Mirna Pec
   translations:
@@ -2026,7 +2026,7 @@
     min_longitude: 15.0532856
     max_latitude: 45.8708266
     max_longitude: 15.1094655
-  name: Mirna Pec
+  name: Mirna Peč
 '171':
   unofficial_names: Oplotnica
   translations:
@@ -2146,7 +2146,7 @@
     min_longitude: 14.6357179
     max_latitude: 46.4311116
     max_longitude: 14.7285787
-  name: Solcava
+  name: Solčava
 '181':
   unofficial_names: Sveta Ana
   translations:
@@ -2170,7 +2170,7 @@
     min_longitude: 15.920033
     max_latitude: 46.5463902
     max_longitude: 16.0019974
-  name: Sveti Andraž v Slovenskih goricah
+  name: Sveti Andraž v Slovenskih Goricah
 '183':
   unofficial_names: Šempeter-Vrtojba
   translations:
@@ -2182,7 +2182,7 @@
     min_longitude: 13.6113664
     max_latitude: 45.93944339999999
     max_longitude: 13.6862827
-  name: Šempeter-Vrtojba
+  name: Šempeter–Vrtojba
 '184':
   unofficial_names: Tabor
   translations:
@@ -2206,7 +2206,7 @@
     min_longitude: 15.8799778
     max_latitude: 46.5376071
     max_longitude: 15.9255082
-  name: Trnovska vas
+  name: Trnovska Vas
 '186':
   unofficial_names: Trzin
   translations:

--- a/lib/countries/data/subdivisions/SK.yaml
+++ b/lib/countries/data/subdivisions/SK.yaml
@@ -10,7 +10,7 @@ BC:
     min_longitude: 18.4786941
     max_latitude: 48.946956
     max_longitude: 20.469993
-  name: Banskobystrický kraj
+  name: Banská Bystrica
 BL:
   unofficial_names: Bratislavský kraj
   translations:
@@ -22,7 +22,7 @@ BL:
     min_longitude: 16.833182
     max_latitude: 48.6543947
     max_longitude: 17.522104
-  name: Bratislavský kraj
+  name: Bratislava
 KI:
   unofficial_names: Košický kraj
   translations:
@@ -34,7 +34,7 @@ KI:
     min_longitude: 20.1811385
     max_latitude: 49.0197507
     max_longitude: 22.3877253
-  name: Košický kraj
+  name: Košice
 NI:
   unofficial_names: Nitriansky kraj
   translations:
@@ -46,7 +46,7 @@ NI:
     min_longitude: 17.7072734
     max_latitude: 48.7145252
     max_longitude: 19.0724064
-  name: Nitriansky kraj
+  name: Nitra
 PV:
   unofficial_names: Prešovský kraj
   translations:
@@ -58,7 +58,7 @@ PV:
     min_longitude: 19.8690332
     max_latitude: 49.4608248
     max_longitude: 22.5658602
-  name: Prešovský kraj
+  name: Prešov
 TA:
   unofficial_names: Trnavský kraj
   translations:
@@ -70,7 +70,7 @@ TA:
     min_longitude: 16.933916
     max_latitude: 48.8782091
     max_longitude: 17.9854498
-  name: Trnavský kraj
+  name: Trnava
 TC:
   unofficial_names: Trenciansky kraj
   translations:
@@ -82,7 +82,7 @@ TC:
     min_longitude: 17.3541989
     max_latitude: 49.31953009999999
     max_longitude: 18.8268433
-  name: Trenciansky kraj
+  name: Trenčín
 ZI:
   unofficial_names: Žilinský kraj
   translations:
@@ -94,4 +94,4 @@ ZI:
     min_longitude: 18.3226616
     max_latitude: 49.6138171
     max_longitude: 20.0600755
-  name: Žilinský kraj
+  name: Žilina

--- a/lib/countries/data/subdivisions/SL.yaml
+++ b/lib/countries/data/subdivisions/SL.yaml
@@ -46,4 +46,4 @@ W:
     min_longitude: -13.2985468
     max_latitude: 8.4996723
     max_longitude: -13.1487465
-  name: Western Area (Freetown)
+  name: Western Area

--- a/lib/countries/data/subdivisions/SM.yaml
+++ b/lib/countries/data/subdivisions/SM.yaml
@@ -85,7 +85,7 @@
     max_latitude: 43.9403789
     max_longitude: 12.4529661
   name: San Marino
-08:
+'08':
   unofficial_names: Montegiardino
   translations:
     en: Montegiardino
@@ -97,7 +97,7 @@
     max_latitude: 43.9119125
     max_longitude: 12.4898347
   name: Montegiardino
-09:
+'09':
   unofficial_names: Serravalle
   translations:
     en: Serravalle

--- a/lib/countries/data/subdivisions/SO.yaml
+++ b/lib/countries/data/subdivisions/SO.yaml
@@ -58,7 +58,7 @@ BY:
     min_longitude: 42.3411179
     max_latitude: 3.543456
     max_longitude: 44.63283209999999
-  name: Bay
+  name: Bay, Somalia
 GA:
   unofficial_names: Galguduud
   translations:
@@ -94,7 +94,7 @@ HI:
     min_longitude: 44.4159971
     max_latitude: 5.454314
     max_longitude: 46.361508
-  name: Hiiraan
+  name: Hiran
 JD:
   unofficial_names: Jubbada Dhexe
   translations:
@@ -106,7 +106,7 @@ JD:
     min_longitude: 40.990269
     max_latitude: 2.38058
     max_longitude: 43.4949649
-  name: Jubbada Dhexe
+  name: Middle Juba
 JH:
   unofficial_names: Jubbada Hoose
   translations:
@@ -118,7 +118,7 @@ JH:
     min_longitude: 40.9886321
     max_latitude: 1.382667
     max_longitude: 43.2361241
-  name: Jubbada Hoose
+  name: Lower Juba
 MU:
   unofficial_names: Mudug
   translations:
@@ -142,7 +142,7 @@ NU:
     min_longitude: 47.789005
     max_latitude: 8.9382501
     max_longitude: 50.16936099999999
-  name: Nugaal
+  name: Nugal
 SA:
   unofficial_names: Sanaag
   translations:
@@ -166,7 +166,7 @@ SD:
     min_longitude: 45.03761
     max_latitude: 4.030119
     max_longitude: 47.10182959999999
-  name: Shabeellaha Dhexe
+  name: Middle Shebelle
 SH:
   unofficial_names: Shabeellaha Hoose
   translations:
@@ -178,7 +178,7 @@ SH:
     min_longitude: 42.904155
     max_latitude: 3.320112
     max_longitude: 45.317607
-  name: Shabeellaha Hoose
+  name: Lower Shebelle
 SO:
   unofficial_names: Sool
   translations:

--- a/lib/countries/data/subdivisions/SY.yaml
+++ b/lib/countries/data/subdivisions/SY.yaml
@@ -14,7 +14,7 @@ DI:
     min_longitude: 36.1978912
     max_latitude: 33.5651386
     max_longitude: 36.3678997
-  name: Dimashq
+  name: Damascus
 DR:
   unofficial_names:
   - Dara
@@ -31,7 +31,7 @@ DR:
     min_longitude: 36.0721494
     max_latitude: 32.6466746
     max_longitude: 36.1277676
-  name: Dar?a
+  name: Daraa
 DY:
   unofficial_names:
   - Deir El-Zor
@@ -45,7 +45,7 @@ DY:
     min_longitude: 40.0813007
     max_latitude: 35.3734271
     max_longitude: 40.1946509
-  name: Dayr az Zawr
+  name: Deir ez-Zor
 HA:
   unofficial_names:
   - El Haseke
@@ -61,7 +61,7 @@ HA:
     min_longitude: 39.452599
     max_latitude: 37.319145
     max_longitude: 42.3850397
-  name: Al ?asakah
+  name: Al-Hasakah
 HI:
   unofficial_names:
   - Hims
@@ -75,7 +75,7 @@ HI:
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: "?ims"
+  name: Homs
 HL:
   unofficial_names:
   - Halab
@@ -91,7 +91,7 @@ HL:
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: "?alab"
+  name: Aleppo
 HM:
   unofficial_names:
   - Hama
@@ -105,7 +105,7 @@ HM:
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: "?amah"
+  name: Hama
 ID:
   unofficial_names: Idlib
   translations:
@@ -134,7 +134,7 @@ LA:
     min_longitude: 35.7272339
     max_latitude: 35.940891
     max_longitude: 36.2848139
-  name: Al Ladhiqiyah
+  name: Latakia
 QU:
   unofficial_names:
   - Quneitra
@@ -148,7 +148,7 @@ QU:
     min_longitude: 35.8478781
     max_latitude: 33.247301
     max_longitude: 36.003361
-  name: Al Qunaytirah
+  name: Quneitra
 RA:
   unofficial_names:
   - Raqqah
@@ -162,7 +162,7 @@ RA:
     min_longitude: 38.9259338
     max_latitude: 35.9821736
     max_longitude: 39.0682411
-  name: Ar Raqqah
+  name: Ar-Raqqah
 RD:
   unofficial_names:
   - Dimashq
@@ -192,7 +192,7 @@ SU:
     min_longitude: 36.5449906
     max_latitude: 32.7348733
     max_longitude: 36.6076899
-  name: As Suwayda'
+  name: As-Suwayda
 TA:
   unofficial_names:
   - Tartoûs

--- a/lib/countries/data/subdivisions/TD.yaml
+++ b/lib/countries/data/subdivisions/TD.yaml
@@ -58,7 +58,7 @@ HL:
     min_longitude: 14.550512
     max_latitude: 13.3501059
     max_longitude: 17.6553859
-  name: Hadjer Lamis
+  name: Hadjer-Lamis
 KA:
   unofficial_names: Kanem
   translations:
@@ -94,7 +94,7 @@ LO:
     min_longitude: 15.2746969
     max_latitude: 9.208981999999999
     max_longitude: 16.5759211
-  name: Logone-Occidental
+  name: Logone Occidental
 LR:
   unofficial_names: Logone-Oriental
   translations:
@@ -106,7 +106,7 @@ LR:
     min_longitude: 15.230739
     max_latitude: 9.115038
     max_longitude: 17.2695311
-  name: Logone-Oriental
+  name: Logone Oriental
 MA:
   unofficial_names: Mandoul
   translations:
@@ -142,7 +142,7 @@ ME:
     min_longitude: 14.0194639
     max_latitude: 10.0102089
     max_longitude: 15.44772
-  name: Mayo-Kébbi-Est
+  name: Mayo-Kebbi Est
 MO:
   unofficial_names: Mayo-Kébbi-Ouest
   translations:
@@ -154,7 +154,7 @@ MO:
     min_longitude: 14.949498
     max_latitude: 11.181067
     max_longitude: 16.2150691
-  name: Mayo-Kébbi-Ouest
+  name: Mayo-Kebbi Ouest
 ND:
   unofficial_names: Ndjamena
   translations:
@@ -166,7 +166,7 @@ ND:
     min_longitude: 14.9664874
     max_latitude: 12.1801019
     max_longitude: 15.1484305
-  name: Ndjamena
+  name: N’Djamena
 OD:
   unofficial_names: Ouaddaï
   translations:

--- a/lib/countries/data/subdivisions/TG.yaml
+++ b/lib/countries/data/subdivisions/TG.yaml
@@ -10,7 +10,7 @@ C:
     min_longitude: 0.3816739
     max_latitude: 9.296292
     max_longitude: 1.650187
-  name: Centre
+  name: Centrale
 K:
   unofficial_names: Kara
   translations:
@@ -34,7 +34,7 @@ M:
     min_longitude: 0.717368
     max_latitude: 6.918175
     max_longitude: 1.806693
-  name: Maritime (Région)
+  name: Maritime
 P:
   unofficial_names: Plateaux
   translations:
@@ -58,4 +58,4 @@ S:
     min_longitude: -0.1473239
     max_latitude: 11.138977
     max_longitude: 0.9969091000000001
-  name: Savannes
+  name: Savanes

--- a/lib/countries/data/subdivisions/TH.yaml
+++ b/lib/countries/data/subdivisions/TH.yaml
@@ -13,7 +13,7 @@
     min_longitude: 100.3278136
     max_latitude: 13.955111
     max_longitude: 100.938408
-  name: Krung Thep Maha Nakhon [Bangkok]
+  name: Bangkok
 '11':
   unofficial_names: Samut Prakan
   translations:
@@ -85,7 +85,7 @@
     min_longitude: 100.4293391
     max_latitude: 15.7481383
     max_longitude: 101.4136046
-  name: Lop Buri
+  name: Lopburi
 '17':
   unofficial_names: Sing Buri
   translations:
@@ -695,7 +695,7 @@
     min_longitude: 99.28135119999999
     max_latitude: 15.0823024
     max_longitude: 100.2832801
-  name: Suphan Buri
+  name: Suphanburi
 '73':
   unofficial_names: Nakhon Pathom
   translations:
@@ -791,7 +791,7 @@
     min_longitude: 97.6315499
     max_latitude: 9.463429099999999
     max_longitude: 98.7070776
-  name: Phangnga
+  name: Phang Nga
 '83':
   unofficial_names: Phuket
   translations:
@@ -935,4 +935,4 @@ S:
     min_longitude: 100.8558912
     max_latitude: 13.0019977
     max_longitude: 100.9896282
-  name: Phatthaya
+  name: Pattaya

--- a/lib/countries/data/subdivisions/TL.yaml
+++ b/lib/countries/data/subdivisions/TL.yaml
@@ -96,7 +96,7 @@ LA:
     min_longitude: 126.8967569
     max_latitude: -8.3597863
     max_longitude: 126.9085371
-  name: Lautem
+  name: Lautém
 LI:
   unofficial_names:
   - Likisia
@@ -109,7 +109,7 @@ LI:
     min_longitude: 125.093361
     max_latitude: -8.5633059
     max_longitude: 125.527085
-  name: Liquiça
+  name: Liquiçá
 MF:
   unofficial_names: Manufahi
   translations:
@@ -148,7 +148,7 @@ OE:
     min_longitude: 124.075439
     max_latitude: -9.174905
     max_longitude: 124.4829029
-  name: Oecussi
+  name: Oecusse
 VI:
   unofficial_names:
   - Vikeke

--- a/lib/countries/data/subdivisions/TM.yaml
+++ b/lib/countries/data/subdivisions/TM.yaml
@@ -44,7 +44,7 @@ D:
     min_longitude: 59.8845004
     max_latitude: 41.880745
     max_longitude: 60.038309
-  name: Dasoguz
+  name: Daşoguz
 L:
   unofficial_names: Lebap
   translations:

--- a/lib/countries/data/subdivisions/TN.yaml
+++ b/lib/countries/data/subdivisions/TN.yaml
@@ -30,7 +30,7 @@
     min_longitude: 9.976983899999999
     max_latitude: 37.1352458
     max_longitude: 10.2448928
-  name: L'Ariana
+  name: Ariana
 '13':
   unofficial_names:
   - Bin Arus
@@ -57,7 +57,7 @@
     min_longitude: 9.553794
     max_latitude: 36.9795789
     max_longitude: 10.081348
-  name: La Manouba
+  name: Manouba
 '21':
   unofficial_names:
   - Nabul
@@ -144,7 +144,7 @@
     min_longitude: 8.670744899999999
     max_latitude: 36.1922777
     max_longitude: 8.7338974
-  name: Le Kef
+  name: Kef
 '34':
   unofficial_names:
   - Silyanah

--- a/lib/countries/data/subdivisions/TO.yaml
+++ b/lib/countries/data/subdivisions/TO.yaml
@@ -12,7 +12,7 @@
     min_longitude: -174.9722574
     max_latitude: -21.2833727
     max_longitude: -174.9043558
-  name: "'Eua"
+  name: ʻEua
 '02':
   unofficial_names: Ha'apai
   translations:
@@ -24,7 +24,7 @@
     min_longitude: -175.417755
     max_latitude: -19.5930023
     max_longitude: -174.268463
-  name: Ha'apai
+  name: Haʻapai
 '03':
   unofficial_names: Niuas
   translations:
@@ -60,4 +60,4 @@
     min_longitude: -174.8671875
     max_latitude: -18.0082895
     max_longitude: -173.907578
-  name: Vava'u
+  name: Vavaʻu

--- a/lib/countries/data/subdivisions/TR.yaml
+++ b/lib/countries/data/subdivisions/TR.yaml
@@ -24,7 +24,7 @@
     min_longitude: 38.2312051
     max_latitude: 37.793365
     max_longitude: 38.320623
-  name: Adiyaman
+  name: Adıyaman
 '03':
   unofficial_names:
   - Afyon
@@ -37,7 +37,7 @@
     min_longitude: 30.5121179
     max_latitude: 38.796503
     max_longitude: 30.5979509
-  name: Afyon
+  name: Afyonkarahisar
 '04':
   unofficial_names:
   - Agri
@@ -50,7 +50,7 @@
     min_longitude: 42.9903562
     max_latitude: 39.751162
     max_longitude: 43.0799288
-  name: Agri
+  name: Ağrı
 '05':
   unofficial_names: Amasya
   translations:
@@ -87,7 +87,7 @@
     max_latitude: 36.975586
     max_longitude: 30.8552512
   name: Antalya
-08:
+'08':
   unofficial_names: Artvin
   translations:
     en: Artvin
@@ -99,7 +99,7 @@
     max_latitude: 41.191183
     max_longitude: 41.8366858
   name: Artvin
-09:
+'09':
   unofficial_names:
   - Aydin
   translations:
@@ -111,7 +111,7 @@
     min_longitude: 27.794327
     max_latitude: 37.867569
     max_longitude: 27.9005062
-  name: Aydin
+  name: Aydın
 '10':
   unofficial_names:
   - Balikesir
@@ -124,7 +124,7 @@
     min_longitude: 27.8383129
     max_latitude: 39.683234
     max_longitude: 27.9411919
-  name: Balikesir
+  name: Balıkesir
 '11':
   unofficial_names: Bilecik
   translations:
@@ -221,7 +221,7 @@
     min_longitude: 33.5933449
     max_latitude: 40.647551
     max_longitude: 33.635831
-  name: Çankiri
+  name: Çankırı
 '19':
   unofficial_names: Çorum
   translations:
@@ -258,7 +258,7 @@
     min_longitude: 40.078436
     max_latitude: 37.979755
     max_longitude: 40.24692
-  name: Diyarbakir
+  name: Diyarbakır
 '22':
   unofficial_names: Edirne
   translations:
@@ -283,7 +283,7 @@
     min_longitude: 39.1205639
     max_latitude: 38.697375
     max_longitude: 39.27574010000001
-  name: Elazig
+  name: Elazığ
 '24':
   unofficial_names: Erzincan
   translations:
@@ -320,7 +320,7 @@
     min_longitude: 30.4090549
     max_latitude: 39.828122
     max_longitude: 30.6805741
-  name: Eskisehir
+  name: Eskişehir
 '27':
   unofficial_names: Gaziantep
   translations:
@@ -357,7 +357,7 @@
     min_longitude: 39.4586489
     max_latitude: 40.4684801
     max_longitude: 39.5207309
-  name: Gümüshane
+  name: Gümüşhane
 '30':
   unofficial_names: Hakkâri
   translations:
@@ -407,7 +407,7 @@
     min_longitude: 32.5361768
     max_latitude: 37.435227
     max_longitude: 35.14063
-  name: Içel
+  name: Mersin
 '34':
   unofficial_names:
   - Istanbul
@@ -482,7 +482,7 @@
     min_longitude: 27.1916528
     max_latitude: 41.760377
     max_longitude: 27.244107
-  name: Kirklareli
+  name: Kırklareli
 '40':
   unofficial_names:
   - Kirsehir
@@ -495,7 +495,7 @@
     min_longitude: 34.119774
     max_latitude: 39.199712
     max_longitude: 34.21962
-  name: Kirsehir
+  name: Kırşehir
 '41':
   unofficial_names: Kocaeli
   translations:
@@ -570,7 +570,7 @@
     min_longitude: 36.8144921
     max_latitude: 37.610065
     max_longitude: 37.0086919
-  name: Kahramanmaras
+  name: Kahramanmaraş
 '47':
   unofficial_names: Mardin
   translations:
@@ -595,7 +595,7 @@
     min_longitude: 28.342408
     max_latitude: 37.225165
     max_longitude: 28.3861861
-  name: Mugla
+  name: Muğla
 '49':
   unofficial_names:
   - Mus
@@ -608,7 +608,7 @@
     min_longitude: 41.47230589999999
     max_latitude: 38.783503
     max_longitude: 41.540625
-  name: Mus
+  name: Muş
 '50':
   unofficial_names:
   - Nevsehir
@@ -621,7 +621,7 @@
     min_longitude: 34.6697521
     max_latitude: 38.676487
     max_longitude: 34.7477789
-  name: Nevsehir
+  name: Nevşehir
 '51':
   unofficial_names:
   - Nigde
@@ -634,7 +634,7 @@
     min_longitude: 34.633795
     max_latitude: 38.00588500000001
     max_longitude: 34.7289149
-  name: Nigde
+  name: Niğde
 '52':
   unofficial_names: Ordu
   translations:
@@ -731,7 +731,7 @@
     min_longitude: 27.469809
     max_latitude: 40.99954400000001
     max_longitude: 27.6462518
-  name: Tekirdag
+  name: Tekirdağ
 '60':
   unofficial_names: Tokat
   translations:
@@ -780,7 +780,7 @@
     min_longitude: 38.7599281
     max_latitude: 37.233371
     max_longitude: 38.891956
-  name: Sanliurfa
+  name: Şanlıurfa
 '64':
   unofficial_names:
   - Usak
@@ -793,7 +793,7 @@
     min_longitude: 29.3559361
     max_latitude: 38.705018
     max_longitude: 29.456464
-  name: Usak
+  name: Uşak
 '65':
   unofficial_names: Van
   translations:
@@ -878,7 +878,7 @@
     min_longitude: 33.4698919
     max_latitude: 39.869203
     max_longitude: 33.5761229
-  name: Kirikkale
+  name: Kırıkkale
 '72':
   unofficial_names: Batman
   translations:
@@ -903,7 +903,7 @@
     min_longitude: 42.440616
     max_latitude: 37.53534
     max_longitude: 42.4721549
-  name: Sirnak
+  name: Şırnak
 '74':
   unofficial_names:
   - Bartin
@@ -916,7 +916,7 @@
     min_longitude: 32.3046411
     max_latitude: 41.654625
     max_longitude: 32.37159310000001
-  name: Bartin
+  name: Bartın
 '75':
   unofficial_names: Ardahan
   translations:
@@ -941,7 +941,7 @@
     min_longitude: 43.9807291
     max_latitude: 39.950163
     max_longitude: 44.0928248
-  name: Igdir
+  name: Iğdır
 '77':
   unofficial_names: Yalova
   translations:

--- a/lib/countries/data/subdivisions/TW.yaml
+++ b/lib/countries/data/subdivisions/TW.yaml
@@ -24,7 +24,7 @@ CYI:
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Chiayi Municipality
+  name: Chiayi County
 CYQ:
   unofficial_names: Chiayi
   translations:
@@ -48,7 +48,7 @@ HSQ:
     min_longitude: 120.8794077
     max_latitude: 24.8569956
     max_longitude: 121.0335449
-  name: Hsinchu
+  name: Hsinchu County
 HSZ:
   unofficial_names: Hsinchu Municipality
   translations:
@@ -60,7 +60,7 @@ HSZ:
     min_longitude: 121.0086104
     max_latitude: 24.9337171
     max_longitude: 121.0100775
-  name: Hsinchu Municipality
+  name: Hsinchu
 HUA:
   unofficial_names:
   - Hualian
@@ -85,7 +85,7 @@ ILA:
     min_longitude: 121.3167219
     max_latitude: 25.7517095
     max_longitude: 123.4934282
-  name: Ilan
+  name: Yilan
 KEE:
   unofficial_names:
   - Chilung Shih
@@ -98,7 +98,7 @@ KEE:
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Keelung Municipality
+  name: Keelung
 KHH:
   unofficial_names: Kaohsiung Special Municipality
   translations:
@@ -110,7 +110,7 @@ KHH:
     min_longitude: 116.7118602
     max_latitude: 23.4717267
     max_longitude: 121.0490147
-  name: Kaohsiung Special Municipality
+  name: Kaohsiung
 KHQ:
   unofficial_names: Kaohsiung
   translations:
@@ -122,7 +122,7 @@ KHQ:
     min_longitude: 116.7118602
     max_latitude: 23.4717267
     max_longitude: 121.0490147
-  name: Kaohsiung
+  name: Kaohsiung County
 MIA:
   unofficial_names: Miaoli
   translations:
@@ -194,7 +194,7 @@ TNN:
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Tainan Municipality
+  name: Tainan
 TNQ:
   unofficial_names: Tainan
   translations:
@@ -206,7 +206,7 @@ TNQ:
     min_longitude: 120.0354791
     max_latitude: 23.4137568
     max_longitude: 120.6562596
-  name: Tainan
+  name: Tainan County
 TPE:
   unofficial_names: Taipei Special Municipality
   translations:
@@ -218,7 +218,7 @@ TPE:
     min_longitude: 121.2826735
     max_latitude: 25.2443731
     max_longitude: 121.7300824
-  name: Taipei Special Municipality
+  name: Taipei
 TPQ:
   unofficial_names: Taipei
   translations:
@@ -230,7 +230,7 @@ TPQ:
     min_longitude: 121.2826735
     max_latitude: 25.2443731
     max_longitude: 121.7300824
-  name: Taipei
+  name: New Taipei City
 TTT:
   unofficial_names:
   - Taidong
@@ -255,7 +255,7 @@ TXG:
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: Taichung Municipality
+  name: Taichung
 TXQ:
   unofficial_names: Taichung
   translations:
@@ -267,7 +267,7 @@ TXQ:
     min_longitude: 120.4607975
     max_latitude: 24.4416976
     max_longitude: 121.4509512
-  name: Taichung
+  name: Taichung County
 YUN:
   unofficial_names: Yunlin
   translations:

--- a/lib/countries/data/subdivisions/TZ.yaml
+++ b/lib/countries/data/subdivisions/TZ.yaml
@@ -73,7 +73,7 @@
     min_longitude: 39.6152071
     max_latitude: -4.8667473
     max_longitude: 39.875565
-  name: Kaskazini Pemba
+  name: North Pemba
 '07':
   unofficial_names:
   - Unguja
@@ -86,8 +86,8 @@
     min_longitude: 39.186363
     max_latitude: -5.721938
     max_longitude: 39.409218
-  name: Kaskazini Unguja
-08:
+  name: Zanzibar North
+'08':
   unofficial_names: Kigoma
   translations:
     en: Kigoma
@@ -99,7 +99,7 @@
     max_latitude: -4.8398476
     max_longitude: 29.7011989
   name: Kigoma
-09:
+'09':
   unofficial_names: Kilimanjaro
   translations:
     en: Kilimanjaro
@@ -122,7 +122,7 @@
     min_longitude: 39.580599
     max_latitude: -5.1784691
     max_longitude: 39.8530017
-  name: Kusini Pemba
+  name: South Pemba
 '11':
   unofficial_names: Kusini Unguja
   translations:
@@ -134,7 +134,7 @@
     min_longitude: 39.26983999999999
     max_latitude: -6.0552399
     max_longitude: 39.579086
-  name: Kusini Unguja
+  name: Zanzibar Central/South
 '12':
   unofficial_names: Lindi
   translations:
@@ -182,7 +182,7 @@
     min_longitude: 39.1856115
     max_latitude: -6.076521199999999
     max_longitude: 39.2991794
-  name: Mjini Magharibi
+  name: Zanzibar Urban/West
 '16':
   unofficial_names: Morogoro
   translations:

--- a/lib/countries/data/subdivisions/UA.yaml
+++ b/lib/countries/data/subdivisions/UA.yaml
@@ -14,7 +14,7 @@
     min_longitude: 27.37479
     max_latitude: 49.889537
     max_longitude: 30.022071
-  name: Vinnyts'ka Oblast'
+  name: Vinnychchyna
 '07':
   unofficial_names:
   - Volyn
@@ -28,8 +28,8 @@
     min_longitude: 23.603933
     max_latitude: 51.969238
     max_longitude: 26.1062831
-  name: Volyns'ka Oblast'
-09:
+  name: Volyn
+'09':
   unofficial_names:
   - Lugansk
   - Luhanska
@@ -45,7 +45,7 @@
     min_longitude: 37.83751609999999
     max_latitude: 50.088428
     max_longitude: 40.2275119
-  name: Luhans'ka Oblast'
+  name: Luhanshchyna
 '12':
   unofficial_names:
   - Dnepropetrovsk
@@ -61,7 +61,7 @@
     min_longitude: 32.959522
     max_latitude: 49.193473
     max_longitude: 36.9364431
-  name: Dnipropetrovs'ka Oblast'
+  name: Dnipropetrovshchyna
 '14':
   unofficial_names:
   - Doneck
@@ -76,7 +76,7 @@
     min_longitude: 36.541492
     max_latitude: 49.236797
     max_longitude: 39.09210179999999
-  name: Donets'ka Oblast'
+  name: Donechchyna
 '18':
   unofficial_names:
   - Zhitomir
@@ -90,7 +90,7 @@
     min_longitude: 27.1897231
     max_latitude: 51.6818959
     max_longitude: 29.7354618
-  name: Zhytomyrs'ka Oblast'
+  name: Zhytomyrshchyna
 '21':
   unofficial_names:
   - Transcarpathia
@@ -105,7 +105,7 @@
     min_longitude: 22.135906
     max_latitude: 49.09755699999999
     max_longitude: 24.627378
-  name: Zakarpats'ka Oblast'
+  name: Zakarpattia
 '23':
   unofficial_names:
   - Zaporizhzhya
@@ -121,7 +121,7 @@
     min_longitude: 34.245512
     max_latitude: 48.14402
     max_longitude: 37.2450479
-  name: Zaporiz'ka Oblast'
+  name: Zaporizhzhya
 '26':
   unofficial_names:
   - Ivano-Frankivsk
@@ -136,7 +136,7 @@
     min_longitude: 23.545547
     max_latitude: 49.559585
     max_longitude: 25.6529901
-  name: Ivano-Frankivs'ka Oblast'
+  name: Prykarpattia
 '30':
   unofficial_names:
   - Kyiv
@@ -151,7 +151,7 @@
     min_longitude: 30.2394401
     max_latitude: 50.590798
     max_longitude: 30.825941
-  name: Kyïv
+  name: Kiev
 '32':
   unofficial_names:
   - Kyyivsʿka Oblast
@@ -165,7 +165,7 @@
     min_longitude: 29.2664181
     max_latitude: 51.554014
     max_longitude: 32.160736
-  name: Kyïvs'ka Oblast'
+  name: Kyivshchyna
 '35':
   unofficial_names:
   - Kirovograd
@@ -180,7 +180,7 @@
     min_longitude: 29.749174
     max_latitude: 49.1651489
     max_longitude: 33.8891529
-  name: Kirovohrads'ka Oblast'
+  name: Kirovohradschyna
 '40':
   unofficial_names:
   - Sebastopol
@@ -194,7 +194,7 @@
     min_longitude: 33.3785472
     max_latitude: 44.841316
     max_longitude: 33.897497
-  name: Sevastopol'
+  name: Sevastopol
 '43':
   unofficial_names:
   - Crimea
@@ -208,7 +208,7 @@
     min_longitude: 32.4792759
     max_latitude: 46.2291611
     max_longitude: 36.6467392
-  name: Respublika Krym
+  name: Crimea
 '46':
   unofficial_names:
   - Lvivska
@@ -223,7 +223,7 @@
     min_longitude: 22.6406759
     max_latitude: 50.6488831
     max_longitude: 25.426912
-  name: L'vivs'ka Oblast'
+  name: Lvivshchyna
 '48':
   unofficial_names:
   - Mykolayivsk
@@ -239,7 +239,7 @@
     min_longitude: 30.2075529
     max_latitude: 48.2316741
     max_longitude: 33.183647
-  name: Mykolaïvs'ka Oblast'
+  name: Mykolayivschyna
 '51':
   unofficial_names:
   - Odesa
@@ -254,7 +254,7 @@
     min_longitude: 28.211238
     max_latitude: 48.233306
     max_longitude: 31.305305
-  name: Odes'ka Oblast'
+  name: Odeshchyna
 '53':
   unofficial_names:
   - Poltava
@@ -268,7 +268,7 @@
     min_longitude: 32.08674999999999
     max_latitude: 50.5535039
     max_longitude: 35.4904511
-  name: Poltavs'ka Oblast'
+  name: Poltavshchyna
 '56':
   unofficial_names:
   - Rivne
@@ -284,7 +284,7 @@
     min_longitude: 25.0837821
     max_latitude: 51.9498591
     max_longitude: 27.729513
-  name: Rivnens'ka Oblast'
+  name: Rivnenshchyna
 '59':
   unofficial_names:
   - Sumska
@@ -298,7 +298,7 @@
     min_longitude: 32.943534
     max_latitude: 52.367214
     max_longitude: 35.6927141
-  name: Sums'ka Oblast'
+  name: Sumshchyna
 '61':
   unofficial_names:
   - Ternopil
@@ -313,7 +313,7 @@
     min_longitude: 24.718486
     max_latitude: 50.267215
     max_longitude: 26.4434051
-  name: Ternopil's'ka Oblast'
+  name: Ternopilshchyna
 '63':
   unofficial_names:
   - Harkov
@@ -329,7 +329,7 @@
     min_longitude: 34.8563339
     max_latitude: 50.459388
     max_longitude: 38.09530609999999
-  name: Kharkivs'ka Oblast'
+  name: Kharkivshchyna
 '65':
   unofficial_names:
   - Herson
@@ -344,7 +344,7 @@
     min_longitude: 31.5124959
     max_latitude: 47.600048
     max_longitude: 35.281549
-  name: Khersons'ka Oblast'
+  name: Khersonshchyna
 '68':
   unofficial_names:
   - Hmelnickij
@@ -360,7 +360,7 @@
     min_longitude: 26.1329989
     max_latitude: 50.594764
     max_longitude: 27.8984479
-  name: Khmel'nyts'ka Oblast'
+  name: Khmelnychchyna
 '71':
   unofficial_names:
   - Cherkask
@@ -374,7 +374,7 @@
     min_longitude: 29.6063949
     max_latitude: 50.228656
     max_longitude: 32.8737981
-  name: Cherkas'ka Oblast'
+  name: Cherkashchyna
 '74':
   unofficial_names:
   - Chernigov
@@ -389,7 +389,7 @@
     min_longitude: 30.49716799999999
     max_latitude: 52.379379
     max_longitude: 33.5009611
-  name: Chernihivs'ka Oblast'
+  name: Chernihivshchyna
 '77':
   unofficial_names:
   - Cernăuţi
@@ -408,4 +408,4 @@
     min_longitude: 24.908172
     max_latitude: 48.6759141
     max_longitude: 27.533325
-  name: Chernivets'ka Oblast'
+  name: Chernivtsi Oblast

--- a/lib/countries/data/subdivisions/UG.yaml
+++ b/lib/countries/data/subdivisions/UG.yaml
@@ -46,7 +46,7 @@
     min_longitude: 32.4716377
     max_latitude: 0.8670285
     max_longitude: 32.5168967
-  name: Luwero
+  name: Luweero
 '105':
   unofficial_names: Masaka
   translations:

--- a/lib/countries/data/subdivisions/UM.yaml
+++ b/lib/countries/data/subdivisions/UM.yaml
@@ -22,7 +22,7 @@
     min_longitude: -177.3967235
     max_latitude: 28.218655
     max_longitude: -177.3599096
-  name: Midway Islands
+  name: Midway Atoll
 '76':
   unofficial_names: Navassa Island
   translations:

--- a/lib/countries/data/subdivisions/US.yaml
+++ b/lib/countries/data/subdivisions/US.yaml
@@ -143,7 +143,7 @@ DC:
     min_longitude: -77.11974
     max_latitude: 38.995548
     max_longitude: -76.909393
-  name: District of Columbia
+  name: Washington DC
 DE:
   unofficial_names: Delaware
   translations:
@@ -627,7 +627,7 @@ UM:
     max_latitude: 28.2150965
     max_longitude: -177.3695147
   comments: see also separate entry under UM
-  name: United States Minor Outlying Islands
+  name: U.S. Outlying Islands
 UT:
   unofficial_names: Utah
   translations:
@@ -664,7 +664,7 @@ VI:
     max_latitude: 
     max_longitude: 
   comments: see also separate entry under VI
-  name: Virgin Islands, U.S.
+  name: U.S. Virgin Islands
 VT:
   unofficial_names: Vermont
   translations:

--- a/lib/countries/data/subdivisions/UY.yaml
+++ b/lib/countries/data/subdivisions/UY.yaml
@@ -46,7 +46,7 @@ CL:
     min_longitude: -53.517
     max_latitude: -32.483
     max_longitude: -54.18333
-  name: Cerro Lago
+  name: Cerro Largo
 DU:
   unofficial_names: Durazno
   translations:

--- a/lib/countries/data/subdivisions/UZ.yaml
+++ b/lib/countries/data/subdivisions/UZ.yaml
@@ -13,7 +13,7 @@ AN:
     min_longitude: 72.2175981
     max_latitude: 40.8773096
     max_longitude: 72.4216927
-  name: Andijon
+  name: Andijan
 BU:
   unofficial_names:
   - Boukhara
@@ -31,7 +31,7 @@ BU:
     min_longitude: 64.3438338
     max_latitude: 39.8241068
     max_longitude: 64.5017624
-  name: Buxoro
+  name: Bukhara
 FA:
   unofficial_names:
   - Farghona
@@ -47,7 +47,7 @@ FA:
     min_longitude: 71.7195224
     max_latitude: 40.4268914
     max_longitude: 71.8614006
-  name: Farg‘ona
+  name: Fergana
 JI:
   unofficial_names:
   - Cizah
@@ -65,7 +65,7 @@ JI:
     min_longitude: 67.7763748
     max_latitude: 40.1917254
     max_longitude: 67.9324151
-  name: Jizzax
+  name: Jizzakh
 NG:
   unofficial_names:
   - Namangan
@@ -129,7 +129,7 @@ QR:
     min_longitude: 55.996635
     max_latitude: 45.60519
     max_longitude: 62.37159389999999
-  name: Qoraqalpog‘iston Respublikasi
+  name: Karakalpakstan
 SA:
   unofficial_names:
   - Samarqand
@@ -185,7 +185,7 @@ TK:
     min_longitude: 69.1465116
     max_latitude: 41.3985579
     max_longitude: 69.41222189999999
-  name: Toshkent City
+  name: Tashkent
 TO:
   unofficial_names:
   - Taškent
@@ -203,7 +203,7 @@ TO:
     min_longitude: 69.1465116
     max_latitude: 41.3985579
     max_longitude: 69.41222189999999
-  name: Toshkent
+  name: Tashkent Province
 XO:
   unofficial_names:
   - Khorazm

--- a/lib/countries/data/subdivisions/VE.yaml
+++ b/lib/countries/data/subdivisions/VE.yaml
@@ -10,7 +10,7 @@ A:
     min_longitude: -66.8206768
     max_latitude: 10.4915618
     max_longitude: -66.8186636
-  name: Distrito Federal
+  name: Capital
 B:
   unofficial_names: Anzoátegui
   translations:
@@ -262,7 +262,7 @@ W:
     min_longitude: -67.6694946
     max_latitude: 11.9848232
     max_longitude: -63.07872800000001
-  name: Dependencias Federales
+  name: Federal Dependencies
 X:
   unofficial_names: Vargas
   translations:

--- a/lib/countries/data/subdivisions/VN.yaml
+++ b/lib/countries/data/subdivisions/VN.yaml
@@ -10,7 +10,7 @@
     min_longitude: 102.3274711
     max_latitude: 22.8214739
     max_longitude: 103.985241
-  name: Lai Chau
+  name: Lai Châu
 '02':
   unofficial_names: Lao Cai
   translations:
@@ -22,7 +22,7 @@
     min_longitude: 103.529518
     max_latitude: 22.848793
     max_longitude: 104.626443
-  name: Lao Cai
+  name: Lào Cai
 '03':
   unofficial_names: Ha Giang
   translations:
@@ -34,7 +34,7 @@
     min_longitude: 104.3361501
     max_latitude: 23.3888341
     max_longitude: 105.5752411
-  name: Ha Giang
+  name: Hà Giang
 '04':
   unofficial_names: Cao Bang
   translations:
@@ -46,7 +46,7 @@
     min_longitude: 105.2724999
     max_latitude: 23.1186219
     max_longitude: 106.826317
-  name: Cao Bang
+  name: Cao Bằng
 '05':
   unofficial_names: Son La
   translations:
@@ -58,7 +58,7 @@
     min_longitude: 103.8084413
     max_latitude: 21.4172762
     max_longitude: 104.0360641
-  name: Son La
+  name: Sơn La
 '06':
   unofficial_names: Yen Bai
   translations:
@@ -70,7 +70,7 @@
     min_longitude: 103.887402
     max_latitude: 22.291081
     max_longitude: 105.100925
-  name: Yen Bai
+  name: Yên Bái
 '07':
   unofficial_names: Tuyen Quang
   translations:
@@ -82,8 +82,8 @@
     min_longitude: 104.848572
     max_latitude: 22.694384
     max_longitude: 105.597397
-  name: Tuyen Quang
-09:
+  name: Tuyên Quang
+'09':
   unofficial_names: Lang Son
   translations:
     en: Lang Son
@@ -94,7 +94,7 @@
     min_longitude: 106.0948229
     max_latitude: 22.4613169
     max_longitude: 107.370491
-  name: Lang Son
+  name: Lạng Sơn
 '13':
   unofficial_names: Quang Ninh
   translations:
@@ -106,7 +106,7 @@
     min_longitude: 106.439682
     max_latitude: 21.6654891
     max_longitude: 108.0736009
-  name: Quang Ninh
+  name: Quảng Ninh
 '14':
   unofficial_names: Hoa Binh
   translations:
@@ -118,7 +118,7 @@
     min_longitude: 104.8349999
     max_latitude: 21.1126179
     max_longitude: 105.8611979
-  name: Hoa Binh
+  name: Hòa Bình
 '15':
   unofficial_names: Ha Tay
   translations:
@@ -142,7 +142,7 @@
     min_longitude: 105.5424731
     max_latitude: 20.4552341
     max_longitude: 106.1685398
-  name: Ninh Binh
+  name: Ninh Bình
 '20':
   unofficial_names: Thai Binh
   translations:
@@ -154,7 +154,7 @@
     min_longitude: 106.2962436
     max_latitude: 20.5060988
     max_longitude: 106.3930608
-  name: Thai Binh
+  name: Thái Bình
 '21':
   unofficial_names: Thanh Hoa
   translations:
@@ -166,7 +166,7 @@
     min_longitude: 104.378349
     max_latitude: 20.6708141
     max_longitude: 106.0758351
-  name: Thanh Hoa
+  name: Thanh Hóa
 '22':
   unofficial_names: Nghe An
   translations:
@@ -178,7 +178,7 @@
     min_longitude: 103.876259
     max_latitude: 19.999296
     max_longitude: 105.806644
-  name: Nghe An
+  name: Nghệ An
 '23':
   unofficial_names: Ha Tinh
   translations:
@@ -190,7 +190,7 @@
     min_longitude: 105.108635
     max_latitude: 18.7626158
     max_longitude: 106.5042068
-  name: Ha Tinh
+  name: Hà Tĩnh
 '24':
   unofficial_names: Quang Binh
   translations:
@@ -202,7 +202,7 @@
     min_longitude: 105.617928
     max_latitude: 18.089871
     max_longitude: 106.995214
-  name: Quang Binh
+  name: Quảng Bình
 '25':
   unofficial_names: Quang Tri
   translations:
@@ -214,7 +214,7 @@
     min_longitude: 106.553429
     max_latitude: 17.165551
     max_longitude: 107.3883289
-  name: Quang Tri
+  name: Quảng Trị
 '26':
   unofficial_names: Thua Thien-Hue
   translations:
@@ -226,7 +226,7 @@
     min_longitude: 107.0167731
     max_latitude: 16.741354
     max_longitude: 108.1925689
-  name: Thua Thien-Hue
+  name: Thừa Thiên–Huế
 '27':
   unofficial_names: Quang Nam
   translations:
@@ -238,7 +238,7 @@
     min_longitude: 107.217789
     max_latitude: 16.066077
     max_longitude: 108.7379948
-  name: Quang Nam
+  name: Quảng Nam
 '28':
   unofficial_names: Kon Tum
   translations:
@@ -262,7 +262,7 @@
     min_longitude: 108.7603999
     max_latitude: 15.216273
     max_longitude: 108.9229524
-  name: Quang Ngai
+  name: Quảng Ngãi
 '30':
   unofficial_names: Gia Lai
   translations:
@@ -286,7 +286,7 @@
     min_longitude: 109.1325188
     max_latitude: 13.899993
     max_longitude: 109.3000072
-  name: Binh Dinh
+  name: Bình Định
 '32':
   unofficial_names: Phu Yen
   translations:
@@ -298,7 +298,7 @@
     min_longitude: 108.672809
     max_latitude: 13.694343
     max_longitude: 109.4588245
-  name: Phu Yen
+  name: Phú Yên
 '33':
   unofficial_names: Dac Lac
   translations:
@@ -310,7 +310,7 @@
     min_longitude: 107.4892809
     max_latitude: 13.4162268
     max_longitude: 108.994509
-  name: Dac Lac
+  name: Đắk Lắk
 '34':
   unofficial_names: Khanh Hoa
   translations:
@@ -322,7 +322,7 @@
     min_longitude: 108.671521
     max_latitude: 12.8655891
     max_longitude: 109.4615432
-  name: Khanh Hoa
+  name: Khánh Hòa
 '35':
   unofficial_names: Lam Dong
   translations:
@@ -334,7 +334,7 @@
     min_longitude: 108.3107758
     max_latitude: 12.002635
     max_longitude: 108.5906696
-  name: Lam Dong
+  name: Lâm Đồng
 '36':
   unofficial_names: Ninh Thuan
   translations:
@@ -346,7 +346,7 @@
     min_longitude: 108.55301
     max_latitude: 12.163288
     max_longitude: 109.2379444
-  name: Ninh Thuan
+  name: Ninh Thuận
 '37':
   unofficial_names: Tay Ninh
   translations:
@@ -358,7 +358,7 @@
     min_longitude: 106.0719681
     max_latitude: 11.4389323
     max_longitude: 106.1909722
-  name: Tay Ninh
+  name: Tây Ninh
 '39':
   unofficial_names: Dong Nai
   translations:
@@ -370,7 +370,7 @@
     min_longitude: 106.7527479
     max_latitude: 11.5814941
     max_longitude: 107.5747849
-  name: Dong Nai
+  name: Đồng Nai
 '40':
   unofficial_names: Binh Thuan
   translations:
@@ -382,7 +382,7 @@
     min_longitude: 107.9904427
     max_latitude: 11.0238032
     max_longitude: 108.3558984
-  name: Binh Thuan
+  name: Bình Thuận
 '41':
   unofficial_names: Long An
   translations:
@@ -406,7 +406,7 @@
     min_longitude: 106.9980384
     max_latitude: 10.8039479
     max_longitude: 107.5830259
-  name: Ba Ria - Vung Tau
+  name: Bà Rịa–Vũng Tàu
 '44':
   unofficial_names: An Giang
   translations:
@@ -430,7 +430,7 @@
     min_longitude: 105.1887371
     max_latitude: 10.9664691
     max_longitude: 105.944197
-  name: Dong Thap
+  name: Đồng Tháp
 '46':
   unofficial_names: Tien Giang
   translations:
@@ -442,7 +442,7 @@
     min_longitude: 105.8196079
     max_latitude: 10.5871
     max_longitude: 106.788528
-  name: Tien Giang
+  name: Tiền Giang
 '47':
   unofficial_names: Kien Giang
   translations:
@@ -454,7 +454,7 @@
     min_longitude: 104.3223179
     max_latitude: 10.538596
     max_longitude: 105.538959
-  name: Kien Giang
+  name: Kiên Giang
 '48':
   unofficial_names: Can Tho
   translations:
@@ -478,7 +478,7 @@
     min_longitude: 105.8777602
     max_latitude: 10.2759884
     max_longitude: 105.9974669
-  name: Vinh Long
+  name: Vĩnh Long
 '50':
   unofficial_names: Ben Tre
   translations:
@@ -490,7 +490,7 @@
     min_longitude: 106.0147733
     max_latitude: 10.3373171
     max_longitude: 106.7976299
-  name: Ben Tre
+  name: Bến Tre
 '51':
   unofficial_names: Tra Vinh
   translations:
@@ -502,7 +502,7 @@
     min_longitude: 106.3002563
     max_latitude: 10.0126486
     max_longitude: 106.3883399
-  name: Tra Vinh
+  name: Trà Vinh
 '52':
   unofficial_names: Soc Trang
   translations:
@@ -514,7 +514,7 @@
     min_longitude: 105.5439898
     max_latitude: 9.9332116
     max_longitude: 106.293053
-  name: Soc Trang
+  name: Sóc Trăng
 '53':
   unofficial_names: Bac Can
   translations:
@@ -526,7 +526,7 @@
     min_longitude: 105.7767105
     max_latitude: 22.2115634
     max_longitude: 105.9308625
-  name: Bac Can
+  name: Bắc Kạn
 '54':
   unofficial_names: Bac Giang
   translations:
@@ -538,7 +538,7 @@
     min_longitude: 105.881726
     max_latitude: 21.6256549
     max_longitude: 107.033035
-  name: Bac Giang
+  name: Bắc Giang
 '55':
   unofficial_names: Bac Lieu
   translations:
@@ -550,7 +550,7 @@
     min_longitude: 105.2332641
     max_latitude: 9.637118899999999
     max_longitude: 106.7433943
-  name: Bac Lieu
+  name: Bạc Liêu
 '56':
   unofficial_names: Bac Ninh
   translations:
@@ -562,7 +562,7 @@
     min_longitude: 105.9041419
     max_latitude: 21.263603
     max_longitude: 106.3089509
-  name: Bac Ninh
+  name: Bắc Ninh
 '57':
   unofficial_names: Binh Duong
   translations:
@@ -574,7 +574,7 @@
     min_longitude: 106.335735
     max_latitude: 11.5000023
     max_longitude: 106.9676759
-  name: Binh Duong
+  name: Bình Dương
 '58':
   unofficial_names: Binh Phuoc
   translations:
@@ -586,7 +586,7 @@
     min_longitude: 106.417961
     max_latitude: 12.29071
     max_longitude: 107.4282521
-  name: Binh Phuoc
+  name: Bình Phước
 '59':
   unofficial_names: Ca Mau
   translations:
@@ -598,7 +598,7 @@
     min_longitude: 104.5229252
     max_latitude: 9.55968
     max_longitude: 105.4185013
-  name: Ca Mau
+  name: Cà Mau
 '60':
   unofficial_names: Da Nang, thanh pho
   translations:
@@ -622,7 +622,7 @@
     min_longitude: 106.126308
     max_latitude: 21.231167
     max_longitude: 106.6127538
-  name: Hai Duong
+  name: Hải Dương
 '62':
   unofficial_names: Hai Phong, thanh pho
   translations:
@@ -646,7 +646,7 @@
     min_longitude: 105.7697231
     max_latitude: 20.703745
     max_longitude: 106.183102
-  name: Ha Nam
+  name: Hà Nam
 '64':
   unofficial_names: Ha Noi, thu do
   translations:
@@ -682,7 +682,7 @@
     min_longitude: 105.8954829
     max_latitude: 21.006161
     max_longitude: 106.269346
-  name: Hung Yen
+  name: Hưng Yên
 '67':
   unofficial_names: Nam Dinh
   translations:
@@ -694,7 +694,7 @@
     min_longitude: 105.924061
     max_latitude: 20.4996661
     max_longitude: 106.5649637
-  name: Nam Dinh
+  name: Nam Định
 '68':
   unofficial_names: Phu Tho
   translations:
@@ -706,7 +706,7 @@
     min_longitude: 104.8163571
     max_latitude: 21.719738
     max_longitude: 105.4579171
-  name: Phu Tho
+  name: Phú Thọ
 '69':
   unofficial_names:
   - Central Highlands
@@ -719,7 +719,7 @@
     min_longitude: 105.4771269
     max_latitude: 22.047269
     max_longitude: 106.23657
-  name: Thai Nguyen
+  name: Thái Nguyên
 '70':
   unofficial_names: Vinh Phuc
   translations:
@@ -731,7 +731,7 @@
     min_longitude: 105.322971
     max_latitude: 21.573348
     max_longitude: 105.7897179
-  name: Vinh Phuc
+  name: Vĩnh Phúc
 '71':
   unofficial_names: Dien Bien
   translations:
@@ -743,7 +743,7 @@
     min_longitude: 102.1482091
     max_latitude: 22.5563429
     max_longitude: 103.6003289
-  name: Dien Bien
+  name: Điện Biên
 '72':
   unofficial_names: Dak Nong
   translations:
@@ -755,7 +755,7 @@
     min_longitude: 107.2079091
     max_latitude: 12.8117129
     max_longitude: 108.115932
-  name: Dak Nong
+  name: Đắk Nông
 '73':
   unofficial_names: Hau Giang
   translations:
@@ -767,4 +767,4 @@
     min_longitude: 105.328687
     max_latitude: 9.9928138
     max_longitude: 105.8934326
-  name: Hau Giang
+  name: Hậu Giang

--- a/lib/countries/data/subdivisions/VU.yaml
+++ b/lib/countries/data/subdivisions/VU.yaml
@@ -33,7 +33,7 @@ PAM:
     min_longitude: 167.6715374
     max_latitude: -14.89196
     max_longitude: 168.276847
-  name: Pénama
+  name: Penama
 SAM:
   unofficial_names:
   - Santo-Malo
@@ -61,7 +61,7 @@ SEE:
     min_longitude: 168.1203521
     max_latitude: -16.567901
     max_longitude: 168.6487059
-  name: Shéfa
+  name: Shefa
 TAE:
   unofficial_names: Taféa
   translations:
@@ -73,7 +73,7 @@ TAE:
     min_longitude: 168.9860777
     max_latitude: -18.6213293
     max_longitude: 170.237299
-  name: Taféa
+  name: Tafea
 TOB:
   unofficial_names:
   - Banks-Torres

--- a/lib/countries/data/subdivisions/WS.yaml
+++ b/lib/countries/data/subdivisions/WS.yaml
@@ -10,7 +10,7 @@ AA:
     min_longitude: -172.053955
     max_latitude: -13.8038838
     max_longitude: -171.887704
-  name: A'ana
+  name: A’ana
 AL:
   unofficial_names: Aiga-i-le-Tai
   translations:
@@ -46,7 +46,7 @@ FA:
     min_longitude: -172.336349
     max_latitude: -13.5512859
     max_longitude: -172.1738909
-  name: Fa'asaleleaga
+  name: Fa’asaleleaga
 GE:
   unofficial_names: Gaga'emauga
   translations:
@@ -58,7 +58,7 @@ GE:
     min_longitude: -172.419285
     max_latitude: -13.4400333
     max_longitude: -171.87703
-  name: Gaga'emauga
+  name: Gaga’emauga
 GI:
   unofficial_names: Gagaifomauga
   translations:
@@ -70,7 +70,7 @@ GI:
     min_longitude: -172.614889
     max_latitude: -13.4459932
     max_longitude: -172.3743356
-  name: Gagaifomauga
+  name: Gaga’ifomauga
 PA:
   unofficial_names: Palauli
   translations:
@@ -94,7 +94,7 @@ SA:
     min_longitude: -172.3329163
     max_latitude: -13.7511529
     max_longitude: -172.3194839
-  name: Satupa'itea
+  name: Satupa’itea
 TU:
   unofficial_names: Tuamasaga
   translations:
@@ -118,7 +118,7 @@ VF:
     min_longitude: -171.6066749
     max_latitude: -13.8730601
     max_longitude: -171.4819119
-  name: Va'a-o-Fonoti
+  name: Va’a-o-Fonoti
 VS:
   unofficial_names: Vaisigano
   translations:

--- a/lib/countries/data/subdivisions/YE.yaml
+++ b/lib/countries/data/subdivisions/YE.yaml
@@ -27,7 +27,7 @@ AD:
     min_longitude: 44.4078031
     max_latitude: 12.92427
     max_longitude: 45.0821905
-  name: ʿAdan
+  name: "’Adan"
 AM:
   unofficial_names: "'Amran"
   translations:
@@ -39,7 +39,7 @@ AM:
     min_longitude: 43.524034
     max_latitude: 16.641641
     max_longitude: 44.3594831
-  name: "'Amran"
+  name: Amran
 BA:
   unofficial_names:
   - Al Baida
@@ -52,7 +52,7 @@ BA:
     min_longitude: 44.58074209999999
     max_latitude: 14.7964711
     max_longitude: 46.0480639
-  name: Al Bay?a'
+  name: Al Bayda
 DA:
   unofficial_names: Ad¸ D¸ali'
   translations:
@@ -64,7 +64,7 @@ DA:
     min_longitude: 44.7181321
     max_latitude: 13.7195688
     max_longitude: 44.7446966
-  name: Ad¸ D¸ali'
+  name: Dhale
 DH:
   unofficial_names:
   - Dhamar
@@ -92,7 +92,7 @@ HD:
     min_longitude: 46.2974891
     max_latitude: 19.002331
     max_longitude: 54.53053990000001
-  name: Hadramawt
+  name: Hadramaut
 HJ:
   unofficial_names: Hajjah
   translations:
@@ -121,7 +121,7 @@ HU:
     min_longitude: 41.8160553
     max_latitude: 15.9224578
     max_longitude: 43.777108
-  name: Al ?udaydah
+  name: Al Hudaydah
 IB:
   unofficial_names: Ibb
   translations:
@@ -159,7 +159,7 @@ LA:
     min_longitude: 
     max_latitude: 
     max_longitude: 
-  name: La?ij
+  name: Lahij
 MA:
   unofficial_names:
   - Marab
@@ -173,7 +173,7 @@ MA:
     min_longitude: 45.2984496
     max_latitude: 15.4981702
     max_longitude: 45.3470603
-  name: Ma'rib
+  name: Ma’rib
 MR:
   unofficial_names: Al Mahrah
   translations:
@@ -210,7 +210,7 @@ SD:
     min_longitude: 43.7216377
     max_latitude: 16.9842336
     max_longitude: 43.7776101
-  name: Sa`dah
+  name: Sa’dah
 SH:
   unofficial_names:
   - Shabwah
@@ -240,7 +240,7 @@ SN:
     min_longitude: 49.64571480000001
     max_latitude: 16.0981446
     max_longitude: 49.6662712
-  name: Sanʿā
+  name: Sana’a
 TA:
   unofficial_names:
   - Taiz
@@ -253,4 +253,4 @@ TA:
     min_longitude: 43.2397839
     max_latitude: 13.887883
     max_longitude: 44.510999
-  name: Taʿizz
+  name: Taiz

--- a/lib/countries/data/subdivisions/ZA.yaml
+++ b/lib/countries/data/subdivisions/ZA.yaml
@@ -25,7 +25,7 @@ FS:
     min_longitude: 24.3466211
     max_latitude: -26.6687389
     max_longitude: 29.7851298
-  name: Free State
+  name: Free
 GT:
   unofficial_names:
   - Pretoria-Witwatersrand-Vereeniging
@@ -87,7 +87,7 @@ NL:
     min_longitude: 28.8734801
     max_latitude: -26.80442
     max_longitude: 32.8909911
-  name: Kwazulu-Natal
+  name: KwaZulu-Natal
 NW:
   unofficial_names: North-West
   translations:
@@ -99,7 +99,7 @@ NW:
     min_longitude: 22.6290299
     max_latitude: -24.6366288
     max_longitude: 28.2983488
-  name: North-West
+  name: North West
 WC:
   unofficial_names:
   - Wes Kaap

--- a/lib/countries/data/subdivisions/ZM.yaml
+++ b/lib/countries/data/subdivisions/ZM.yaml
@@ -83,7 +83,7 @@
     max_latitude: -15.293982
     max_longitude: 28.912453
   name: Southern
-08:
+'08':
   unofficial_names: Copperbelt
   translations:
     en: Copperbelt
@@ -95,7 +95,7 @@
     max_latitude: -12.218456
     max_longitude: 29.0201341
   name: Copperbelt
-09:
+'09':
   unofficial_names: Lusaka
   translations:
     en: Lusaka


### PR DESCRIPTION
This change replaces names of subdivisions with those defined in
the Unicode CLDR, if they exist in both places.  It serializes
using Ruby's built-in YAML support, so some keys will be escaped
correctly.

Closes: #436