### PR TITLE
Write out dependence of active_support in all_names_with_codes

### DIFF
--- a/lib/countries/country/class_methods.rb
+++ b/lib/countries/country/class_methods.rb
@@ -35,7 +35,10 @@ module ISO3166
     end
 
     def all_names_with_codes(locale = 'en')
-      Country.all.map { |c| [(c.translation(locale) || c.name).html_safe, c.alpha2] }.sort
+      Country.all.map do |c|
+        lc = (c.translation(locale) || c.name)
+        [lc.respond_to?('html_safe') ? lc.html_safe : lc, c.alpha2]
+      end.sort
     end
 
     def translations(locale = 'en')

--- a/spec/country_spec.rb
+++ b/spec/country_spec.rb
@@ -324,6 +324,27 @@ describe ISO3166::Country do
       expect(countries.first[0]).to be_a(String)
       expect(countries.first[0]).to eq('Afghanistan')
       expect(countries.size).to eq(NUM_OF_COUNTRIES)
+      expect(countries.any?{|pair| !pair[0].html_safe?}).to eq(false)
+    end
+
+    it 'should return an alphabetized list of all country names translated to current locale with ISOCODE alpha2' do
+      ISO3166.configuration.locales = [:es, :de, :en]
+
+      countries = ISO3166::Country.all_names_with_codes(:es)
+      expect(countries).to be_an(Array)
+      expect(countries.first[0]).to be_a(String)
+      expect(countries.first[0]).to eq('Afganistán')
+      expect(countries.size).to eq(NUM_OF_COUNTRIES)
+    end
+  end
+
+  describe 'all_names_with_codes_without_active_support' do
+    it 'should return an alphabetized list of all country names with ISOCODE alpha2' do
+      countries = ISO3166::Country.all_names_with_codes
+      expect(countries).to be_an(Array)
+      expect(countries.first[0]).to be_a(String)
+      expect(countries.first[0]).to eq('Afghanistan')
+      expect(countries.size).to eq(NUM_OF_COUNTRIES)
     end
 
     it 'should return an alphabetized list of all country names translated to current locale with ISOCODE alpha2' do


### PR DESCRIPTION
Currently you are left with the following if you 

```
$ gem install countries 
$ irb
irb(main):001:0> require 'countries/global'
=> true
irb(main):003:0> ISO3166::Country.all_names_with_codes
NoMethodError: undefined method 'html_safe' for "Andorra":String
```

The proposed patch writes out the dependency for active_support by removing the use of html_safe with backwards compatibility, although I am unsure it was needed in the first place.

Hope it can be considered as not everyone use active_support all the time. 

Regards
Subfusc