### PR TITLE
Changed the nationality of Hong Kong from Chinese to Hong Kongnese

### DIFF
--- a/lib/countries/data/countries/HK.yaml
+++ b/lib/countries/data/countries/HK.yaml
@@ -23,7 +23,7 @@ HK:
   subregion: Eastern Asia
   world_region: APAC
   un_locode: HK
-  nationality: Hong Kongnese
+  nationality: Hong Kongese
   postal_code: false
   unofficial_names:
   - Hong Kong

--- a/lib/countries/data/countries/HK.yaml
+++ b/lib/countries/data/countries/HK.yaml
@@ -23,7 +23,7 @@ HK:
   subregion: Eastern Asia
   world_region: APAC
   un_locode: HK
-  nationality: Chinese
+  nationality: Hong Kongnese
   postal_code: false
   unofficial_names:
   - Hong Kong


### PR DESCRIPTION
The demonym of Hong Kong is Hongkonger or Hong Kongnese https://en.wikipedia.org/wiki/Hong_Kong
https://en.wikipedia.org/wiki/Hong_Kong_people

Some users from Hong Kong reported this today:

> "I had a chuckle when I had to choose my nationality and Hong Kongese wasn't in the list, I chose North Korean as I found it funny how that one was there but a semi-sovereign city with 7 million people isn't. Most Hong Kong people (including myself) do no associate ourselves as being Chinese despite ethnically being one :)" - User
  
