### PR TITLE
Support older rubies

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -2,6 +2,7 @@ sudo: false
 cache: bundler
 language: ruby
 rvm:
+ - 1.9.3
  - 2.2.6
  - 2.3.3
  - 2.4.0

--- a/.travis.yml
+++ b/.travis.yml
@@ -13,3 +13,4 @@ before_install:
 matrix:
   allow_failures:
     - rvm: ruby-head
+    - rvm: 1.9.3

--- a/countries.gemspec
+++ b/countries.gemspec
@@ -13,7 +13,7 @@ Gem::Specification.new do |gem|
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.name          = 'countries'
   gem.require_paths = ['lib']
-  gem.version       = Countries::VERSION
+  gem.version       = Countries::VERSION.dup
   gem.license       = 'MIT'
 
   gem.add_dependency('i18n_data', '~> 0.7.0')

--- a/lib/countries/country/emoji.rb
+++ b/lib/countries/country/emoji.rb
@@ -1,3 +1,6 @@
+#!/bin/env ruby
+# encoding: utf-8
+
 module ISO3166
   module Emoji
     CODE_POINTS = {


### PR DESCRIPTION
https://rubygems.org/gems/countries/versions/2.0.8 seems to suggest that the latest version of the gems works with any Ruby, however, when trying to install on anything lower than 2.0.0 *, the UTF-8 characters in emojis.rb caused a `invalid multibyte char (US-ASCII)` as older rubies don't autodetect the encoding.

This is easily fixed by adding a magic comment to the file in question, and the tests now happily pass on 1.9.3. I've also had to add a slight tweak the the gemfile, as the VERSION constant is a frozen string, but this doesn't affect the functionality of the gem.

For good measure, I've added `1.9.3` to the Travis setup just to make doubly sure everything passes ongoing.

\* I know 1.9.x is EOL, but we're on legacy infrastructure at the moment, so need to struggle along, at least in the short to medium term.