### PR TITLE
Add russian unofficial name to GB

### DIFF
--- a/lib/countries/data/countries/GB.yaml
+++ b/lib/countries/data/countries/GB.yaml
@@ -44,6 +44,7 @@ GB:
   - イギリス
   - Verenigd Koninkrijk
   - Great Britain (UK)
+  - Великобритания
   languages_official:
   - en
   languages_spoken:


### PR DESCRIPTION
'Великобритания' is russian for 'Great Britain'
Hello, we are using your gem to match russian country names to alpha2 codes like this:

```ruby
# @param name [String]
# @return [String, nil]
def country_alpha2(name)
  (ISO3166::Country.find_by_translated_names(name) || ISO3166::Country.find_by_names(name))&.first
end
```

`country_alpha2('Великобритания')` returns nil since there can only be one translated name per locale in `i18n_data` gem and it is 'Соединенное королевство' which means 'United Kingdom'.
If I add this unofficial name which is widely used in Russia then the match will work.
I could not find if such contributions are being adopted to your data.