### PR TITLE
allow to register subdivisions

### DIFF
--- a/lib/countries/country.rb
+++ b/lib/countries/country.rb
@@ -56,7 +56,7 @@ module ISO3166
     end
 
     def subdivisions?
-      File.exist?(subdivision_file_path)
+      data['subdivisions'].present? || File.exist?(subdivision_file_path)
     end
 
     def subdivisions
@@ -111,7 +111,7 @@ module ISO3166
 
     def subdivision_data
       @subdivision_data ||= if subdivisions?
-                              YAML.load_file(subdivision_file_path)
+                              data['subdivisions'] || YAML.load_file(subdivision_file_path)
                             else
                               {}
                             end

--- a/lib/countries/country.rb
+++ b/lib/countries/country.rb
@@ -56,7 +56,7 @@ module ISO3166
     end
 
     def subdivisions?
-      data['subdivisions'].present? || File.exist?(subdivision_file_path)
+      !data['subdivisions'].nil? || File.exist?(subdivision_file_path)
     end
 
     def subdivisions

--- a/spec/data_spec.rb
+++ b/spec/data_spec.rb
@@ -96,6 +96,10 @@ describe ISO3166::Data do
       ISO3166::Data.register(
         alpha2: 'TW',
         name: 'NEW Taiwan',
+        subdivisions: {
+          CHA: {name: 'New Changhua'},
+          CYI: {name: 'New Municipality'}
+        },
         translations: {
           'en' => 'NEW Taiwan',
           'de' => 'NEW Taiwan'
@@ -112,6 +116,8 @@ describe ISO3166::Data do
       expect(subject.name).to eq 'NEW Taiwan'
       expect(subject.translations).to eq('en' => 'NEW Taiwan',
                                          'de' => 'NEW Taiwan')
+      expect(subject.subdivisions).to eq(CHA: ISO3166::Subdivision.new({name: 'New Changhua'}),
+                                         CYI: ISO3166::Subdivision.new({name: 'New Municipality'}))
     end
   end
 
@@ -120,6 +126,10 @@ describe ISO3166::Data do
       ISO3166::Data.register(
         alpha2: 'LOL',
         name: 'Happy Country',
+        subdivisions: {
+          LOL1: {name: 'Happy sub1'},
+          LOL2: {name: 'Happy sub2'}
+        },
         translations: {
           'en' => 'Happy Country',
           'de' => 'glückliches Land'
@@ -133,6 +143,8 @@ describe ISO3166::Data do
       data = ISO3166::Data.new('LOL').call
       expect(data['name']).to eq 'Happy Country'
       expect(subject.name).to eq 'Happy Country'
+      expect(subject.subdivisions).to eq(LOL1: ISO3166::Subdivision.new({name: 'Happy sub1'}),
+                                         LOL2: ISO3166::Subdivision.new({name: 'Happy sub2'}))
     end
 
     it 'detect a stale cache' do


### PR DESCRIPTION
At present subdivisions are always loaded from files (even if the country is custom registered). This fix enables passing subdivison data to `ISO3166::Data.register`