### PR TITLE
add code attribute to Subdivision

### DIFF
--- a/lib/countries/subdivision.rb
+++ b/lib/countries/subdivision.rb
@@ -1,6 +1,7 @@
 module ISO3166
   Subdivision = KwargStruct.new(
     :name,
+    :code,
     :unofficial_names,
     :geo,
     :translations,


### PR DESCRIPTION
I know the subdivision files don't have codes, but it can be handy when using custom data or `ISO3166::Data.register`