### PR TITLE
Allow to override cache dir

### DIFF
--- a/lib/countries/data.rb
+++ b/lib/countries/data.rb
@@ -2,6 +2,7 @@ module ISO3166
   ##
   # Handles building the in memory store of countries data
   class Data
+    @@cache_dir = [File.dirname(__FILE__), 'cache']
     @@cache = {}
     @@registered_data = {}
 
@@ -14,6 +15,14 @@ module ISO3166
     end
 
     class << self
+      def cache_dir
+        @@cache_dir
+      end
+
+      def cache_dir=(value)
+        @@cache_dir = value
+      end
+
       def register(data)
         alpha2 = data[:alpha2].upcase
         @@registered_data[alpha2] = \
@@ -52,7 +61,7 @@ module ISO3166
 
       def load_data!
         return @@cache unless load_required?
-        @@cache = load_cache %w(cache countries.json)
+        @@cache = load_cache %w(countries.json)
         @@_country_codes = @@cache.keys
         @@cache = @@cache.merge(@@registered_data)
         @@cache
@@ -106,7 +115,7 @@ module ISO3166
       end
 
       def load_translations(locale)
-        locale_names = load_cache(['cache', 'locales', "#{locale}.json"])
+        locale_names = load_cache(['locales', "#{locale}.json"])
         internal_codes.each do |alpha2|
           @@cache[alpha2]['translations'] ||= Translations.new
           @@cache[alpha2]['translations'][locale] = locale_names[alpha2].freeze
@@ -129,7 +138,7 @@ module ISO3166
       end
 
       def datafile_path(file_array)
-        File.join([File.dirname(__FILE__)] + file_array)
+        File.join([@@cache_dir] + file_array)
       end
     end
   end

--- a/spec/data_spec.rb
+++ b/spec/data_spec.rb
@@ -81,12 +81,12 @@ describe ISO3166::Data do
 
   describe '#load_cache' do
     it 'will return an empty hash for an unsupported locale' do
-      file_array = %w(cache locales unsupported.json)
+      file_array = %w(locales unsupported.json)
       expect(ISO3166::Data.send(:load_cache, file_array)).to eql({})
     end
 
     it 'will return json for a supported locale' do
-      file_array = %w(cache locales en.json)
+      file_array = %w(locales en.json)
       expect(ISO3166::Data.send(:load_cache, file_array)).not_to be_empty
     end
   end


### PR DESCRIPTION
e.g. in config/initializers/countries.rb:
`ISO3166::Data.cache_dir = [Rails.root, "config"]`