### PR TITLE
Fix corrupted Subdivisions

### DIFF
--- a/lib/countries/data/subdivisions/AM.yaml
+++ b/lib/countries/data/subdivisions/AM.yaml
@@ -1,16 +1,16 @@
 ---
 AG:
-  unofficial_names: Aragac?otn
+  unofficial_names: Aragacotn
   translations:
-    en: Aragac?otn
+    en: Aragacotn
   geo:
-    latitude: 
-    longitude: 
-    min_latitude: 
-    min_longitude: 
-    max_latitude: 
-    max_longitude: 
-  name: Aragac?otn
+    latitude:
+    longitude:
+    min_latitude:
+    min_longitude:
+    max_latitude:
+    max_longitude:
+  name: Aragacotn
 AR:
   unofficial_names: Ararat
   translations:
@@ -53,12 +53,12 @@ GR:
   translations:
     en: Gegark'unik'
   geo:
-    latitude: 
-    longitude: 
-    min_latitude: 
-    min_longitude: 
-    max_latitude: 
-    max_longitude: 
+    latitude:
+    longitude:
+    min_latitude:
+    min_longitude:
+    max_latitude:
+    max_longitude:
   name: Gegark'unik'
 KT:
   unofficial_names:
@@ -77,7 +77,7 @@ LO:
   unofficial_names:
   - Lorri
   translations:
-    en: Lo?y
+    en: Lory
   geo:
     latitude: 40.969845
     longitude: 44.490014
@@ -85,7 +85,7 @@ LO:
     min_longitude: 44.016761
     max_latitude: 41.299259
     max_longitude: 44.960212
-  name: Lo?y
+  name: Lory
 SH:
   unofficial_names: Širak
   translations:

--- a/lib/countries/data/subdivisions/KH.yaml
+++ b/lib/countries/data/subdivisions/KH.yaml
@@ -93,10 +93,10 @@
   geo:
     latitude: 11.485114
     longitude: 105.328098
-    min_latitude: 
-    min_longitude: 
-    max_latitude: 
-    max_longitude: 
+    min_latitude:
+    min_longitude:
+    max_latitude:
+    max_longitude:
   name: Prey Veaeng [Prey Vêng]
 '15':
   unofficial_names:
@@ -144,10 +144,10 @@
   geo:
     latitude: 13.3529103
     longitude: 103.8594171
-    min_latitude: 
-    min_longitude: 
-    max_latitude: 
-    max_longitude: 
+    min_latitude:
+    min_longitude:
+    max_latitude:
+    max_longitude:
   name: Siem Reab [Siemréab]
 '18':
   unofficial_names:
@@ -177,7 +177,7 @@
   - s.t
   - st
   translations:
-    en: Stueng Traeng [Stœ?ng Trêng]
+    en: Stueng Traeng
   geo:
     latitude: 13.576473
     longitude: 105.9699878
@@ -185,7 +185,7 @@
     min_longitude: 105.521177
     max_latitude: 14.587619
     max_longitude: 106.6629029
-  name: Stueng Traeng [Stœ?ng Trêng]
+  name: Stueng Traeng
 '2':
   unofficial_names:
   - Batdâmbâng
@@ -195,12 +195,12 @@
   translations:
     en: Baat Dambang [Batdâmbâng]
   geo:
-    latitude: 
-    longitude: 
-    min_latitude: 
-    min_longitude: 
-    max_latitude: 
-    max_longitude: 
+    latitude:
+    longitude:
+    min_latitude:
+    min_longitude:
+    max_latitude:
+    max_longitude:
   name: Baat Dambang [Batdâmbâng]
 '20':
   unofficial_names:
@@ -329,10 +329,10 @@
   geo:
     latitude: 11.45311
     longitude: 104.5202599
-    min_latitude: 
-    min_longitude: 
-    max_latitude: 
-    max_longitude: 
+    min_latitude:
+    min_longitude:
+    max_latitude:
+    max_longitude:
   name: Kampong Spueu [Kâmpóng Spœ]
 '6':
   unofficial_names:
@@ -348,10 +348,10 @@
   geo:
     latitude: 12.71197
     longitude: 104.888603
-    min_latitude: 
-    min_longitude: 
-    max_latitude: 
-    max_longitude: 
+    min_latitude:
+    min_longitude:
+    max_latitude:
+    max_longitude:
   name: Kampong Thum [Kâmpóng Thum]
 '7':
   unofficial_names:

--- a/lib/countries/data/subdivisions/LY.yaml
+++ b/lib/countries/data/subdivisions/LY.yaml
@@ -1,20 +1,9 @@
 ---
-AJ:
-  unofficial_names: Ajdabiya
-  translations:
-    en: Ajdabiya
-  geo:
-    latitude: 30.75
-    longitude: 20.216667
-    min_latitude: 29.6236087
-    min_longitude: 18.7234497
-    max_latitude: 31.2280688
-    max_longitude: 21.1074829
-  name: Ajdabiya
 BA:
   unofficial_names: Banghazi
   translations:
     en: Banghazi
+    ar: بنغازي
   geo:
     latitude: 32.116667
     longitude: 20.066667
@@ -27,6 +16,7 @@ BU:
   unofficial_names: Al Butnan
   translations:
     en: Al Butnan
+    ar: البطنان‎‎
   geo:
     latitude: 29.7579854
     longitude: 23.7632828
@@ -35,22 +25,11 @@ BU:
     max_latitude: 32.2137814
     max_longitude: 25.1495356
   name: Al Butnan
-BW:
-  unofficial_names: Bani Walid
-  translations:
-    en: Bani Walid
-  geo:
-    latitude: 31.766667
-    longitude: 13.983333
-    min_latitude: 31.65279689999999
-    min_longitude: 13.921051
-    max_latitude: 31.8676447
-    max_longitude: 14.1744233
-  name: Bani Walid
 DR:
   unofficial_names: Darnah
   translations:
     en: Darnah
+    ar: درنة‎‎
   geo:
     latitude: 32.766667
     longitude: 22.633333
@@ -59,34 +38,11 @@ DR:
     max_latitude: 32.7750619
     max_longitude: 22.6741272
   name: Darnah
-GD:
-  unofficial_names: Ghadamis
-  translations:
-    en: Ghadamis
-  geo:
-    latitude: 30.133333
-    longitude: 9.5
-    min_latitude: 30.1076376
-    min_longitude: 9.4765664
-    max_latitude: 30.1538108
-    max_longitude: 9.514846799999999
-  name: Ghadamis
-GR:
-  unofficial_names: Gharyan
-  translations:
-    en: Gharyan
-  geo:
-    latitude: 32.169722
-    longitude: 13.016667
-    min_latitude: 32.154324
-    min_longitude: 12.9915905
-    max_latitude: 32.1826005
-    max_longitude: 13.0399519
-  name: Gharyan
 GT:
   unofficial_names: Ghat
   translations:
     en: Ghat
+    ar: غات‎‎
   geo:
     latitude: 24.9640371
     longitude: 10.1759285
@@ -95,22 +51,11 @@ GT:
     max_latitude: 24.9905903
     max_longitude: 10.2097174
   name: Ghat
-HZ:
-  unofficial_names: Al ?izam al Akh?ar
-  translations:
-    en: Al ?izam al Akh?ar
-  geo:
-    latitude: 31.9734119
-    longitude: 20.0269411
-    min_latitude: 31.9691572
-    min_longitude: 20.0221954
-    max_latitude: 31.9820898
-    max_longitude: 20.0319863
-  name: Al ?izam al Akh?ar
 JA:
-  unofficial_names: Al Jabal al Akh?ar
+  unofficial_names: Al Jabal al Akhḑar
   translations:
-    en: Al Jabal al Akh?ar
+    en: Al Jabal al Akhḑar
+    ar: الجبل الأخضر‎‎
   geo:
     latitude: 32.4032332
     longitude: 21.6660725
@@ -118,23 +63,18 @@ JA:
     min_longitude: 21.3707509
     max_latitude: 32.9385909
     max_longitude: 22.0534001
-  name: Al Jabal al Akh?ar
-JB:
-  unofficial_names: Jaghbub
+  name: Al Jabal al Akhḑar
+JG:
+  unofficial_names: Al Jabal al Gharbī
+  name: Al Jabal al Gharbī
   translations:
-    en: Jaghbub
-  geo:
-    latitude: 29.7425
-    longitude: 24.516944
-    min_latitude: 29.7357997
-    min_longitude: 24.5040179
-    max_latitude: 29.7479472
-    max_longitude: 24.5310116
-  name: Jaghbub
+    en: Al Jabal al Gharbī
+    ar: الجبل الغربي‎‎
 JI:
   unofficial_names: Al Jifarah
   translations:
     en: Al Jifarah
+    ar: الجفارة‎‎
   geo:
     latitude: 32.4525904
     longitude: 12.9435536
@@ -144,9 +84,12 @@ JI:
     max_longitude: 13.1125019
   name: Al Jifarah
 JU:
-  unofficial_names: Al Jufrah
+  unofficial_names:
+    - Al Jufrah
+    - Jofra
   translations:
-    en: Al Jufrah
+    en: Jufrah
+    ar: الجفرة‎‎
   geo:
     latitude: 27.9835135
     longitude: 16.912251
@@ -156,9 +99,14 @@ JU:
     max_longitude: 18.9787859
   name: Al Jufrah
 KF:
-  unofficial_names: Al Kufrah
+  unofficial_names:
+    - Al Kufrah
+    - Kofra
+    - Kufra
+    - Cufra
   translations:
     en: Al Kufrah
+    ar: الكفرة‎‎
   geo:
     latitude: 23.3112389
     longitude: 21.8568586
@@ -168,9 +116,13 @@ KF:
     max_longitude: 25
   name: Al Kufrah
 MB:
-  unofficial_names: Al Marqab
+  unofficial_names:
+    - Al Murqub
+    - Al Marqab
+    - al-Morqib
   translations:
-    en: Al Marqab
+    en: Murqub
+    ar: المرقب‎‎
   geo:
     latitude: 32.4599677
     longitude: 14.1001326
@@ -178,11 +130,15 @@ MB:
     min_longitude: 13.1125019
     max_latitude: 32.783028
     max_longitude: 14.6691879
-  name: Al Marqab
+  name: Al Murqub
 MI:
-  unofficial_names: Misratah
+  unofficial_names:
+    - Mişrātah
+    - Misurata
+    - Misratah
   translations:
-    en: Misratah
+    en: Misrata
+    ar: مصراته‎‎
   geo:
     latitude: 32.377533
     longitude: 15.092017
@@ -190,11 +146,15 @@ MI:
     min_longitude: 14.9191761
     max_latitude: 32.4306869
     max_longitude: 15.2752876
-  name: Misratah
+  name: Mişrātah
 MJ:
-  unofficial_names: Al Marj
+  unofficial_names:
+    - Al Marj
+    - The Meadows
+    - Marj
   translations:
     en: Al Marj
+    ar: المرج‎‎
   geo:
     latitude: 32.486667
     longitude: 20.833889
@@ -207,6 +167,7 @@ MQ:
   unofficial_names: Murzuq
   translations:
     en: Murzuq
+    ar: مرزق‎‎
   geo:
     latitude: 25.9182262
     longitude: 13.9260001
@@ -215,22 +176,11 @@ MQ:
     max_latitude: 25.9427651
     max_longitude: 13.9626293
   name: Murzuq
-MZ:
-  unofficial_names: Mizdah
-  translations:
-    en: Mizdah
-  geo:
-    latitude: 31.4478222
-    longitude: 12.9838564
-    min_latitude: 31.4332039
-    min_longitude: 12.9676437
-    max_latitude: 31.4714978
-    max_longitude: 13.0013803
-  name: Mizdah
 NL:
-  unofficial_names: Nalut
+  unofficial_names: Nālūt
   translations:
-    en: Nalut
+    en: Nālūt
+    ar: نالوت‎‎
   geo:
     latitude: 31.868333
     longitude: 10.9825
@@ -238,11 +188,14 @@ NL:
     min_longitude: 10.9610395
     max_latitude: 31.8966715
     max_longitude: 10.9945031
-  name: Nalut
+  name: Nālūt
 NQ:
-  unofficial_names: An Nuqat al Khams
+  unofficial_names:
+    - An Nuqaţ al Khams
+    - Nuqāṭ al Ḫams
   translations:
-    en: An Nuqat al Khams
+    en: An Nuqaţ al Khams
+    ar: النقاط الخمس‎‎
   geo:
     latitude: 32.6914909
     longitude: 11.8891721
@@ -250,35 +203,12 @@ NQ:
     min_longitude: 11.3924129
     max_latitude: 33.1688603
     max_longitude: 12.4340378
-  name: An Nuqat al Khams
-QB:
-  unofficial_names: Al Qubbah
-  translations:
-    en: Al Qubbah
-  geo:
-    latitude: 32.766667
-    longitude: 22.25
-    min_latitude: 32.7459347
-    min_longitude: 22.2100233
-    max_latitude: 32.7789498
-    max_longitude: 22.2635934
-  name: Al Qubbah
-QT:
-  unofficial_names: Al Qatrun
-  translations:
-    en: Al Qatrun
-  geo:
-    latitude: 24.933333
-    longitude: 14.633333
-    min_latitude: 
-    min_longitude: 
-    max_latitude: 
-    max_longitude: 
-  name: Al Qatrun
+  name: An Nuqaţ al Khams
 SB:
-  unofficial_names: Sabha
+  unofficial_names: Sabhā
   translations:
-    en: Sabha
+    en: Sabhā
+    ar: سبها‎‎
   geo:
     latitude: 27.038889
     longitude: 14.426389
@@ -286,23 +216,14 @@ SB:
     min_longitude: 14.3821335
     max_latitude: 27.0898485
     max_longitude: 14.5361138
-  name: Sabha
-SH:
-  unofficial_names: Ash Shati'
-  translations:
-    en: Ash Shati'
-  geo:
-    latitude: 27.7351468
-    longitude: 12.4380581
-    min_latitude: 26.210706
-    min_longitude: 9.8335011
-    max_latitude: 29.4850249
-    max_longitude: 15.7525989
-  name: Ash Shati'
+  name: Sabhā
 SR:
-  unofficial_names: Surt
+  unofficial_names:
+    - Sirt
+    - Surt
   translations:
-    en: Surt
+    en: Sirte
+    ar: سرت‎‎
   geo:
     latitude: 31.205314
     longitude: 16.588936
@@ -310,26 +231,15 @@ SR:
     min_longitude: 16.5155527
     max_latitude: 31.2135519
     max_longitude: 16.6286411
-  name: Surt
-SS:
-  unofficial_names: Sabratah Surman
-  translations:
-    en: Sabratah Surman
-  geo:
-    latitude: 32.787993
-    longitude: 12.3807553
-    min_latitude: 32.7199989
-    min_longitude: 12.3548125
-    max_latitude: 32.8207489
-    max_longitude: 12.5376195
-  name: Sabratah Surman
+  name: Sirte
 TB:
   unofficial_names:
   - Ţarābulus
   - Tripoli
   - Tripoli
   translations:
-    en: Tarabulus
+    en: Tripoli
+    ar: طرابلس عروس البحر‎‎,
   geo:
     latitude: 32.8829369
     longitude: 13.1883359
@@ -338,34 +248,15 @@ TB:
     max_latitude: 32.9019297
     max_longitude: 13.2234836
   name: Tarabulus
-TM:
-  unofficial_names: Tarhunah-Masallatah
-  translations:
-    en: Tarhunah-Masallatah
-  geo:
-    latitude: 32.433889
-    longitude: 13.634444
-    min_latitude: 32.4135885
-    min_longitude: 13.6146784
-    max_latitude: 32.4491584
-    max_longitude: 13.6608982
-  name: Tarhunah-Masallatah
-TN:
-  unofficial_names: Tajura' wa an Nawa?i Arba?
-  translations:
-    en: Tajura' wa an Nawa?i Arba?
-  geo:
-    latitude: 
-    longitude: 
-    min_latitude: 
-    min_longitude: 
-    max_latitude: 
-    max_longitude: 
-  name: Tajura' wa an Nawa?i Arba?
 WA:
-  unofficial_names: Al Wa?ah
+  unofficial_names:
+    - Al Wahat
+    - The Oases
+    - Al Wahad
+    - Al Wahah
   translations:
-    en: Al Wa?ah
+    en: Al Wahat
+    ar: الواحات‎‎
   geo:
     latitude: 32.3147011
     longitude: 14.5032835
@@ -373,11 +264,12 @@ WA:
     min_longitude: 14.4937963
     max_latitude: 32.3185818
     max_longitude: 14.5151013
-  name: Al Wa?ah
+  name: Al Wahat
 WD:
-  unofficial_names: Wadi al ?ayat
+  unofficial_names: Wādī al Ḩayāt
   translations:
-    en: Wadi al ?ayat
+    en: Wadi al Hayaa
+    ar: وادي الحياة‎‎
   geo:
     latitude: 29.5240753
     longitude: 31.2912463
@@ -385,23 +277,18 @@ WD:
     min_longitude: 31.2627233
     max_latitude: 29.5447935
     max_longitude: 31.305119
-  name: Wadi al ?ayat
-YJ:
-  unofficial_names: Yafran-Jadu
+  name: Wādī al Ḩayāt
+WS:
+  unofficial_names: Wādī ash Shāţiʾ
   translations:
-    en: Yafran-Jadu
-  geo:
-    latitude: 31.9536097
-    longitude: 12.0285809
-    min_latitude: 
-    min_longitude: 
-    max_latitude: 
-    max_longitude: 
-  name: Yafran-Jadu
+    en: Wādī ash Shāţiʾ
+    ar: وادي الشاطئ‎‎
+  name: Wādī ash Shāţiʾ
 ZA:
   unofficial_names: Az Zawiyah
   translations:
     en: Az Zawiyah
+    ar: مدينة الزاوية
   geo:
     latitude: 32.5394906
     longitude: 12.5298028

--- a/lib/countries/data/subdivisions/SA.yaml
+++ b/lib/countries/data/subdivisions/SA.yaml
@@ -7,7 +7,8 @@
   - Riyadh
   - Riad
   translations:
-    en: Ar Riya?
+    en: Ar Riyāḑ
+    ar: منطقة الرياض
   geo:
     latitude: 24.633333
     longitude: 46.716667
@@ -15,12 +16,14 @@
     min_longitude: 46.2981033
     max_latitude: 25.1564724
     max_longitude: 47.34695430000001
-  name: Ar Riya?
+  name: Ar Riyāḑ
 '02':
   unofficial_names:
   - La Meca
+  - Mecca
   translations:
     en: Makkah
+    ar: مكة المكرمة
   geo:
     latitude: 21.416667
     longitude: 39.816667
@@ -28,7 +31,7 @@
     min_longitude: 39.6902353
     max_latitude: 21.5930031
     max_longitude: 40.0028579
-  name: Makkah
+  name: Makkah al Mukarramah
 '03':
   unofficial_names:
   - Medina
@@ -36,6 +39,7 @@
   - al-Madinah
   translations:
     en: Al Madinah
+    ar: المدينة المنورة‎‎
   geo:
     latitude: 24.466667
     longitude: 39.6
@@ -50,6 +54,7 @@
   - ash-Sharqiyah
   translations:
     en: Ash Sharqiyah
+    ar: الشرقية‎‎
   geo:
     latitude: 22.2954496
     longitude: 50.6793759
@@ -63,6 +68,7 @@
   - Qaseem
   translations:
     en: Al Qasim
+    ar: منطقة القصيم‎‎
   geo:
     latitude: 25.8274886
     longitude: 42.8637875
@@ -75,7 +81,8 @@
   unofficial_names:
   - Hail
   translations:
-    en: "?a'il"
+    en: Ha'il
+    ar: حائل‎‎
   geo:
     latitude: 27.516667
     longitude: 41.683333
@@ -83,12 +90,13 @@
     min_longitude: 41.5061761
     max_latitude: 27.6987282
     max_longitude: 41.8434906
-  name: "?a'il"
+  name: "Ḩā'il"
 '07':
   unofficial_names:
   - Tabook
   translations:
     en: Tabuk
+    ar: تبوك‎‎
   geo:
     latitude: 28.383333
     longitude: 36.583333
@@ -96,13 +104,14 @@
     min_longitude: 36.4326624
     max_latitude: 28.4718602
     max_longitude: 36.6991425
-  name: Tabuk
+  name: Tabūk
 08:
   unofficial_names:
   - Northern
   - al-Hudud ash-Shamaliyah
   translations:
-    en: Al ?udud ash Shamaliyah
+    en: Northern Borders
+    ar: نطقة الحدود الشمالية‎‎
   geo:
     latitude: 29.7248676
     longitude: 42.2362435
@@ -110,12 +119,13 @@
     min_longitude: 37.8584141
     max_latitude: 32.158333
     max_longitude: 45.92311
-  name: Al ?udud ash Shamaliyah
+  name: Al Ḩudūd ash Shamālīyah
 09:
   unofficial_names:
   - Jizan
   translations:
     en: Jizan
+    ar: جيزان‎‎
   geo:
     latitude: 16.889167
     longitude: 42.561111
@@ -123,11 +133,12 @@
     min_longitude: 42.5295783
     max_latitude: 16.9898154
     max_longitude: 42.64789589999999
-  name: Jizan
+  name: Jāzān
 '10':
   unofficial_names: Najran
   translations:
     en: Najran
+    ar: نجران‎‎
   geo:
     latitude: 17.491667
     longitude: 44.132222
@@ -135,12 +146,13 @@
     min_longitude: 44.0930793
     max_latitude: 17.6004129
     max_longitude: 44.2933307
-  name: Najran
+  name: Najrān
 '11':
   unofficial_names:
   - Baha
   translations:
-    en: Al Ba?ah
+    en: Al Bahah
+    ar: الباحة‎‎
   geo:
     latitude: 21.4556901
     longitude: 39.2133847
@@ -148,11 +160,13 @@
     min_longitude: 39.21315860000001
     max_latitude: 21.4561942
     max_longitude: 39.2135471
-  name: Al Ba?ah
+  name: Al Bāḩah
 '12':
-  unofficial_names: Al Jawf
+  unofficial_names:
+    - Al-Jouf
   translations:
     en: Al Jawf
+    ar: الجوف‎‎
   geo:
     latitude: 29.887356
     longitude: 39.3206241
@@ -165,7 +179,8 @@
   unofficial_names:
   - Aseer
   translations:
-    en: "?Asir"
+    en: "'Asīr"
+    ar: عسير‎‎
   geo:
     latitude: 19.0969062
     longitude: 42.8637875
@@ -173,4 +188,4 @@
     min_longitude: 41.38029
     max_latitude: 20.970846
     max_longitude: 44.528442
-  name: "?Asir"
+  name: "'Asīr"

--- a/lib/countries/data/subdivisions/SD.yaml
+++ b/lib/countries/data/subdivisions/SD.yaml
@@ -1,354 +1,6 @@
 ---
-'01':
-  unofficial_names:
-  - Northern
-  - Shamaliyah
-  translations:
-    en: Ash Shamaliyah
-  geo:
-    latitude: 18.4448963
-    longitude: 30.1589303
-    min_latitude: 16.511393
-    min_longitude: 25
-    max_latitude: 22.1765288
-    max_longitude: 32.637459
-  name: Ash Shamaliyah
-'02':
-  unofficial_names:
-  - North Darfur
-  - Shimal Darfur
-  translations:
-    en: Shamal Darfur
-  geo:
-    latitude: 15.7661969
-    longitude: 24.9042208
-    min_latitude: 11.7224969
-    min_longitude: 22.75691
-    max_latitude: 20.0064945
-    max_longitude: 27.532602
-  name: Shamal Darfur
-'03':
-  unofficial_names:
-  - al-Khartum
-  - al-H̱arţūm
-  - Khartum
-  - Khartoum
-  - Jartum
-  translations:
-    en: Al Khartum
-  geo:
-    latitude: 15.5006544
-    longitude: 32.5598994
-    min_latitude: 15.3870932
-    min_longitude: 32.4592475
-    max_latitude: 15.615997
-    max_longitude: 32.6859455
-  name: Al Khartum
-'04':
-  unofficial_names:
-  - River Nile
-  translations:
-    en: An Nil
-  geo:
-    latitude: 17.1142529
-    longitude: 33.7964613
-    min_latitude: 15.9642631
-    min_longitude: 31.8534791
-    max_latitude: 22.006193
-    max_longitude: 35.69729090000001
-  name: An Nil
-'05':
-  unofficial_names: Kassala
-  translations:
-    en: Kassala
-  geo:
-    latitude: 15.45
-    longitude: 36.4
-    min_latitude: 15.4122089
-    min_longitude: 36.3763976
-    max_latitude: 15.4994253
-    max_longitude: 36.4511558
-  name: Kassala
-'06':
-  unofficial_names:
-  - Gadaref
-  - Gedaref
-  - Qadārif
-  - al-Qadarif
-  translations:
-    en: Al Qa?arif
-  geo:
-    latitude: 
-    longitude: 
-    min_latitude: 
-    min_longitude: 
-    max_latitude: 
-    max_longitude: 
-  name: Al Qa?arif
-'07':
-  unofficial_names:
-  - Al Jazira
-  - Gezira
-  translations:
-    en: Al Jazirah
-  geo:
-    latitude: 14.8859611
-    longitude: 33.438353
-    min_latitude: 13.604472
-    min_longitude: 32.415869
-    max_latitude: 15.4767249
-    max_longitude: 34.3057649
-  name: Al Jazirah
-08:
-  unofficial_names:
-  - White Nile
-  translations:
-    en: An Nil al Abya?
-  geo:
-    latitude: 13.2403881
-    longitude: 32.5372741
-    min_latitude: 11.9465411
-    min_longitude: 31.525822
-    max_latitude: 15.250874
-    max_longitude: 33.2549571
-  name: An Nil al Abya?
-09:
-  unofficial_names:
-  - North Kordofan
-  - Shimal Kurdufan
-  translations:
-    en: Shamal Kurdufan
-  geo:
-    latitude: 13.8306441
-    longitude: 29.4179324
-    min_latitude: 11.338815
-    min_longitude: 26.9496901
-    max_latitude: 16.606044
-    max_longitude: 32.3568399
-  name: Shamal Kurdufan
-'10':
-  unofficial_names:
-  - Gharb al Kurdufan
-  - West Kordofan
-  translations:
-    en: Gharb Kurdufan
-  geo:
-    latitude: 
-    longitude: 
-    min_latitude: 
-    min_longitude: 
-    max_latitude: 
-    max_longitude: 
-  name: Gharb Kurdufan
-'11':
-  unofficial_names:
-  - South Darfur
-  translations:
-    en: Janub Darfur
-  geo:
-    latitude: 11.6488639
-    longitude: 24.9042208
-    min_latitude: 8.6366421
-    min_longitude: 23.047403
-    max_latitude: 13.133373
-    max_longitude: 27.908629
-  name: Janub Darfur
-'12':
-  unofficial_names:
-  - West Darfur
-  translations:
-    en: Gharb Darfur
-  geo:
-    latitude: 12.8463561
-    longitude: 23.0011989
-    min_latitude: 10.694536
-    min_longitude: 21.838947
-    max_latitude: 14.972213
-    max_longitude: 24.720192
-  name: Gharb Darfur
-'13':
-  unofficial_names:
-  - South Kordofan
-  translations:
-    en: Janub Kurdufan
-  geo:
-    latitude: 11.1990192
-    longitude: 29.4179324
-    min_latitude: 9.345832
-    min_longitude: 27.2556731
-    max_latitude: 12.7500066
-    max_longitude: 32.473745
-  name: Janub Kurdufan
-'14':
-  unofficial_names:
-  - West Bahr al Ghazal
-  translations:
-    en: Gharb Ba?r al Ghazal
-  geo:
-    latitude: 8.6452399
-    longitude: 25.2837585
-    min_latitude: 6.6438239
-    min_longitude: 24.151928
-    max_latitude: 10.438414
-    max_longitude: 28.536482
-  name: Gharb Ba?r al Ghazal
-'15':
-  unofficial_names:
-  - North Bahr al Ghazal
-  translations:
-    en: Shamal Ba?r al Ghazal
-  geo:
-    latitude: 
-    longitude: 
-    min_latitude: 
-    min_longitude: 
-    max_latitude: 
-    max_longitude: 
-  name: Shamal Ba?r al Ghazal
-'16':
-  unofficial_names:
-  - Garb-al-Istiwaiyyah
-  - Gharb al Istiwaiyya
-  - West Equatoria
-  translations:
-    en: Gharb al Istiwa'iyah
-  geo:
-    latitude: 5.3471799
-    longitude: 28.299435
-    min_latitude: 4.271712
-    min_longitude: 26.2865889
-    max_latitude: 6.799301
-    max_longitude: 30.997554
-  name: Gharb al Istiwa'iyah
-'17':
-  unofficial_names:
-  - Bahr al Jebel
-  translations:
-    en: Ba?r al Jabal
-  geo:
-    latitude: 15.9522222
-    longitude: 26.9688889
-    min_latitude: 
-    min_longitude: 
-    max_latitude: 
-    max_longitude: 
-  name: Ba?r al Jabal
-'18':
-  unofficial_names:
-  - Bihār
-  - Lakes
-  translations:
-    en: Al Bu?ayrat
-  geo:
-    latitude: 29.9333333
-    longitude: 31.3833333
-    min_latitude: 
-    min_longitude: 
-    max_latitude: 
-    max_longitude: 
-  name: Al Bu?ayrat
-'19':
-  unofficial_names:
-  - East Equatoria
-  - Sharq al Istiwaiyya
-  - Šarq-al-Istiwaiyyah
-  translations:
-    en: Sharq al Istiwa'iyah
-  geo:
-    latitude: 5.0692995
-    longitude: 33.438353
-    min_latitude: 3.5150319
-    min_longitude: 31.7221889
-    max_latitude: 6.0001959
-    max_longitude: 35.2981791
-  name: Sharq al Istiwa'iyah
-'20':
-  unofficial_names:
-  - Jonglei
-  - Jongli
-  translations:
-    en: Junqali
-  geo:
-    latitude: 7.181961899999999
-    longitude: 32.3560952
-    min_latitude: 5.7242131
-    min_longitude: 30.209986
-    max_latitude: 9.51895
-    max_longitude: 35.0195689
-  name: Junqali
-'21':
-  unofficial_names:
-  - Warap
-  translations:
-    en: Warab
-  geo:
-    latitude: 8.2209308
-    longitude: 28.8596804
-    min_latitude: 6.3896089
-    min_longitude: 27.740973
-    max_latitude: 9.34868
-    max_longitude: 29.6992101
-  name: Warab
-'22':
-  unofficial_names:
-  - Ittihād
-  - Unity
-  translations:
-    en: Al Wa?dah
-  geo:
-    latitude: 8.9277211
-    longitude: 29.7889248
-    min_latitude: 7.067644
-    min_longitude: 28.64084
-    max_latitude: 10.2898218
-    max_longitude: 30.781871
-  name: Al Wa?dah
-'23':
-  unofficial_names:
-  - Upper Nile
-  - ʿAli an Nil
-  translations:
-    en: A?ali an Nil
-  geo:
-    latitude: 9.8894202
-    longitude: 32.7181375
-    min_latitude: 7.980180000000001
-    min_longitude: 30.7607
-    max_latitude: 12.238068
-    max_longitude: 34.1444019
-  name: A?ali an Nil
-'24':
-  unofficial_names:
-  - Blue Nile
-  translations:
-    en: An Nil al Azraq
-  geo:
-    latitude: 11.5860078
-    longitude: 34.1531947
-    min_latitude: 9.500347999999999
-    min_longitude: 33.1359769
-    max_latitude: 12.56568
-    max_longitude: 35.09243
-  name: An Nil al Azraq
-'25':
-  unofficial_names:
-  - Sannar
-  - Sennar
-  translations:
-    en: Sinnar
-  geo:
-    latitude: 13.567469
-    longitude: 33.5672045
-    min_latitude: 13.5523013
-    min_longitude: 33.5470104
-    max_latitude: 13.5839232
-    max_longitude: 33.5792828
-  name: Sinnar
-'26':
-  unofficial_names:
-  - Red Sea
-  translations:
-    en: Al Ba?r al A?mar
+RS:
+  name: Al Baḩr al Aḩmar
   geo:
     latitude: 19.4556063
     longitude: 35.2148469
@@ -356,4 +8,204 @@
     min_longitude: 33.2534589
     max_latitude: 22.0063784
     max_longitude: 38.580036
-  name: Al Ba?r al A?mar
+  translations:
+    ar: Al Baḩr al Aḩmar
+    en: Red Sea
+  comments:
+GZ:
+  name: Al Jazīrah
+  geo:
+    latitude: 14.8859611
+    longitude: 33.438353
+    min_latitude: 13.604472
+    min_longitude: 32.415869
+    max_latitude: 15.4767249
+    max_longitude: 34.3057649
+  translations:
+    ar: Al Jazīrah
+    en: Gezira
+  comments:
+KH:
+  name: Al Kharţūm
+  geo:
+    latitude: 15.5006544
+    longitude: 32.5598994
+    min_latitude: 15.3870932
+    min_longitude: 32.4592475
+    max_latitude: 15.615997
+    max_longitude: 32.6859455
+  translations:
+    ar: Al Kharţūm
+    en: Khartoum
+  comments:
+GD:
+  name: Al Qaḑārif
+  geo:
+    latitude: 14.024307
+    longitude: 35.3685679
+    min_latitude: 13.9824623
+    min_longitude: 35.3189849
+    max_latitude: 14.0808871
+    max_longitude: 35.4345988
+  translations:
+    ar: Al Qaḑārif
+    en: Gedaref
+  comments:
+NR:
+  name: Nahr an Nīl
+  geo:
+    latitude: 17.1142529
+    longitude: 33.7964613
+    min_latitude: 15.9642631
+    min_longitude: 31.8534791
+    max_latitude: 22.006193
+    max_longitude: 35.69729090000001
+  translations:
+    ar: Nahr an Nīl
+    en: River Nile
+  comments:
+NW:
+  name: An Nīl al Abyaḑ
+  geo:
+    latitude: 13.2403881
+    longitude: 32.5372741
+    min_latitude: 11.9465411
+    min_longitude: 31.525822
+    max_latitude: 15.250874
+    max_longitude: 33.2549571
+  translations:
+    ar: An Nīl al Abyaḑ
+    en: White Nile
+  comments:
+NB:
+  name: An Nīl al Azraq
+  geo:
+    latitude: 11.5860078
+    longitude: 34.1531947
+    min_latitude: 9.500347999999999
+    min_longitude: 33.1359769
+    max_latitude: 12.56568
+    max_longitude: 35.09243
+  translations:
+    ar: An Nīl al Azraq
+    en: Blue Nile
+  comments:
+false:
+  name: Ash Shamālīyah
+  geo:
+    latitude: 18.4448963
+    longitude: 30.1589303
+    min_latitude: 16.511393
+    min_longitude: 25
+    max_latitude: 22.225082
+    max_longitude: 32.637459
+  translations:
+    ar: Ash Shamālīyah
+    en: Northern
+  comments:
+DW:
+  name: Gharb Dārfūr
+  geo:
+    latitude: 12.8463561
+    longitude: 23.0011989
+    min_latitude: 10.694536
+    min_longitude: 21.838947
+    max_latitude: 14.972213
+    max_longitude: 24.720192
+  translations:
+    ar: Gharb Dārfūr
+    en: West Darfur
+  comments:
+GK:
+  name: Gharb Kurdufān
+  geo:
+  translations:
+    ar: Gharb Kurdufān
+    en: West Kordofan
+  comments:
+DS:
+  name: Janūb Dārfūr
+  geo:
+    latitude: 11.6488639
+    longitude: 24.9042208
+    min_latitude: 8.6366421
+    min_longitude: 23.047403
+    max_latitude: 13.133373
+    max_longitude: 27.908629
+  translations:
+    ar: Janūb Dārfūr
+    en: South Darfur
+  comments:
+KS:
+  name: Janūb Kurdufān
+  geo:
+    latitude: 11.1990192
+    longitude: 29.4179324
+    min_latitude: 9.345832
+    min_longitude: 27.2556731
+    max_latitude: 12.7500065
+    max_longitude: 32.473745
+  translations:
+    ar: Janūb Kurdufān
+    en: South Kordofan
+  comments:
+KA:
+  name: Kassalā
+  geo:
+    latitude: 15.4581332
+    longitude: 36.4039629
+    min_latitude: 15.4122089
+    min_longitude: 36.3763976
+    max_latitude: 15.4994253
+    max_longitude: 36.4511558
+  translations:
+    ar: Kassalā
+    en: Kassala
+  comments:
+DN:
+  name: Shamāl Dārfūr
+  geo:
+    latitude: 15.7661969
+    longitude: 24.9042208
+    min_latitude: 11.7224969
+    min_longitude: 22.75691
+    max_latitude: 20.0064945
+    max_longitude: 27.532602
+  translations:
+    ar: Shamāl Dārfūr
+    en: North Darfur
+  comments:
+KN:
+  name: Shiamāl Kurdufān
+  geo:
+  translations:
+    ar: Shiamāl Kurdufān
+    en: North Kordofan
+  comments:
+DE:
+  name: Sharq Dārfūr
+  geo:
+  translations:
+    ar: Sharq Dārfūr
+    en: East Darfur
+  comments:
+SI:
+  name: Sinnār
+  geo:
+    latitude: 13.0317108
+    longitude: 33.9750018
+    min_latitude: 11.7343758
+    min_longitude: 32.924994
+    max_latitude: 14.106393
+    max_longitude: 35.70768
+  translations:
+    ar: Sinnār
+    en: Sennar
+  comments:
+DC:
+  name: Wasaţ Dārfūr Zālinjay
+  geo:
+  translations:
+    ar: Wasaţ Dārfūr Zālinjay
+    en: Central Darfur
+  comments:

--- a/lib/countries/data/subdivisions/SY.yaml
+++ b/lib/countries/data/subdivisions/SY.yaml
@@ -23,7 +23,8 @@ DR:
   - Deraa
   - Dārayyā
   translations:
-    en: Dar?a
+    en: Daraa
+    ar: مُحافظة درعا‎‎
   geo:
     latitude: 32.625278
     longitude: 36.106111
@@ -31,7 +32,7 @@ DR:
     min_longitude: 36.0721494
     max_latitude: 32.6466746
     max_longitude: 36.1277676
-  name: Dar?a
+  name: Dar'ā
 DY:
   unofficial_names:
   - Deir El-Zor
@@ -53,7 +54,8 @@ HA:
   - H̨asakah
   - al-Hasakah
   translations:
-    en: Al ?asakah
+    en: Al-Hasakah
+    ar: محافظة الحسكة‎,
   geo:
     latitude: 36.405515
     longitude: 40.7969149
@@ -61,21 +63,22 @@ HA:
     min_longitude: 39.452599
     max_latitude: 37.319145
     max_longitude: 42.3850397
-  name: Al ?asakah
+  name: Al Ḩasakah
 HI:
   unofficial_names:
   - Hims
   - Homs
   translations:
-    en: "?ims"
+    en: Homs
+    ar: مُحافظة حمص‎‎
   geo:
     latitude: 33.7348116
     longitude: -117.9947778
-    min_latitude: 
-    min_longitude: 
-    max_latitude: 
-    max_longitude: 
-  name: "?ims"
+    min_latitude:
+    min_longitude:
+    max_latitude:
+    max_longitude:
+  name: Ḩimş
 HL:
   unofficial_names:
   - Halab
@@ -83,29 +86,31 @@ HL:
   - H̨alab
   - Alep
   translations:
-    en: "?alab"
+    en: Aleppo
+    ar: محافظة حلب
   geo:
     latitude: 33.9166667
     longitude: 38.3
-    min_latitude: 
-    min_longitude: 
-    max_latitude: 
-    max_longitude: 
-  name: "?alab"
+    min_latitude:
+    min_longitude:
+    max_latitude:
+    max_longitude:
+  name: Ḩalab
 HM:
   unofficial_names:
   - Hama
   - Hamah
   translations:
-    en: "?amah"
+    en: Hama
+    ar: مُحافظة حماة
   geo:
     latitude: 32.8947222
     longitude: 37.12527780000001
-    min_latitude: 
-    min_longitude: 
-    max_latitude: 
-    max_longitude: 
-  name: "?amah"
+    min_latitude:
+    min_longitude:
+    max_latitude:
+    max_longitude:
+  name: Ḩamāh
 ID:
   unofficial_names: Idlib
   translations:

--- a/lib/countries/data/subdivisions/YE.yaml
+++ b/lib/countries/data/subdivisions/YE.yaml
@@ -44,7 +44,8 @@ BA:
   unofficial_names:
   - Al Baida
   translations:
-    en: Al Bay?a'
+    en: Al Bayda
+    ar: البيضاء‎‎
   geo:
     latitude: 14.3588662
     longitude: 45.4498065
@@ -52,7 +53,7 @@ BA:
     min_longitude: 44.58074209999999
     max_latitude: 14.7964711
     max_longitude: 46.0480639
-  name: Al Bay?a'
+  name: Al Bayḑā’
 DA:
   unofficial_names: Ad¸ D¸ali'
   translations:
@@ -113,7 +114,8 @@ HU:
   - H̨udaydah
   - al-Hudaydah
   translations:
-    en: Al ?udaydah
+    en: Al Hudaydah
+    ar: الحديدة‎‎
   geo:
     latitude: 15.3053072
     longitude: 43.0194897
@@ -121,7 +123,7 @@ HU:
     min_longitude: 41.8160553
     max_latitude: 15.9224578
     max_longitude: 43.777108
-  name: Al ?udaydah
+  name: Al Ḩudaydah
 IB:
   unofficial_names: Ibb
   translations:
@@ -151,15 +153,16 @@ LA:
   - Lahej
   - Lahj
   translations:
-    en: La?ij
+    en: Lahij
+    ar: لحج‎‎
   geo:
     latitude: 16.4022222
     longitude: 44.3238889
-    min_latitude: 
-    min_longitude: 
-    max_latitude: 
-    max_longitude: 
-  name: La?ij
+    min_latitude:
+    min_longitude:
+    max_latitude:
+    max_longitude:
+  name: Laḩij
 MA:
   unofficial_names:
   - Marab

--- a/lib/countries/tasks/geocoding.rake
+++ b/lib/countries/tasks/geocoding.rake
@@ -32,7 +32,7 @@ def country_codes
 end
 
 namespace :geocode do
-  desc 'Retrieve and store subdivisions coordinates'
+  desc 'Retrieve and store countries coordinates'
   task :fetch_countries do
     require 'countries'
     # Iterate over countries
@@ -70,12 +70,12 @@ namespace :geocode do
 
   desc 'Retrieve and store subdivisions coordinates'
   task :fetch_subdivisions do
-    require 'countries'
+    require_relative '../../countries'
     # Iterate all countries with subdivisions
     ISO3166::Country.all.select(&:subdivisions?).each do |c|
       # Iterate subdivisions
       state_data = c.subdivisions.dup
-      state_data.reject { |_, data| data['latitude'] }.each do |code, data|
+      state_data.reject { |_, data| data['geo'] }.each do |code, data|
         location = "#{data['name']}, #{c.name}"
 
         # Handle special geocoding cases where Google defaults to well known
@@ -87,6 +87,7 @@ namespace :geocode do
         next unless (result = geocode(location))
         geometry = result.geometry
         if geometry['location']
+          state_data[code]['geo'] ||= {}
           state_data[code]['geo']['latitude'] = geometry['location']['lat']
           state_data[code]['geo']['longitude'] = geometry['location']['lng']
         end


### PR DESCRIPTION
Fixes #436 This is a by hand correction to prevent noise of the CLDR import.   It includes handful of updates to incorrect data sets and adds some Arabic translations.

Source Wikipedia.