### PR TITLE
Updated Switzerland VAT rates

### DIFF
--- a/lib/countries/data/countries/CH.yaml
+++ b/lib/countries/data/countries/CH.yaml
@@ -27,10 +27,10 @@ CH:
   nationality: Swiss
   eea_member: true
   vat_rates:
-    standard: 8
+    standard: 7.7
     reduced:
     - 2.5
-    - 3.8
+    - 3.7
     super_reduced: 
     parking: 
   postal_code: true


### PR DESCRIPTION
Updated Switzerland VAT rates, see https://www.ch.ch/en/vat-rates-switzerland/