### PR TITLE
Memoize subdivision YAML loading

### DIFF
--- a/lib/countries/country.rb
+++ b/lib/countries/country.rb
@@ -56,13 +56,15 @@ module ISO3166
     end
 
     def subdivisions?
-      !data['subdivisions'].nil? || File.exist?(subdivision_file_path)
+      !subdivisions.empty?
     end
 
     def subdivisions
-      @subdivisions ||= subdivision_data.inject({}) do |hash, (k, v)|
-        hash.merge(k => Subdivision.new(v))
-      end
+      @subdivisions ||= if data['subdivisions']
+                          self.class.create_subdivisions(data['subdivisions'])
+                        else
+                          self.class.subdivisions(alpha2)
+                        end
     end
 
     def subdivision_names_with_codes(locale = 'en')
@@ -109,20 +111,6 @@ module ISO3166
               else
                 ISO3166::Data.new(@country_data_or_code).call
               end
-    end
-
-    private
-
-    def subdivision_data
-      @subdivision_data ||= if subdivisions?
-                              data['subdivisions'] || YAML.load_file(subdivision_file_path)
-                            else
-                              {}
-                            end
-    end
-
-    def subdivision_file_path
-      File.join(File.dirname(__FILE__), 'data', 'subdivisions', "#{alpha2}.yaml")
     end
   end
 end

--- a/lib/countries/country/class_methods.rb
+++ b/lib/countries/country/class_methods.rb
@@ -84,6 +84,17 @@ module ISO3166
       end
     end
 
+    def subdivisions(alpha2)
+      @subdivisions ||= {}
+      @subdivisions[alpha2] ||= create_subdivisions(subdivision_data(alpha2))
+    end
+
+    def create_subdivisions(subdivision_data)
+      subdivision_data.each_with_object({}) do |(k, v), hash|
+        hash[k] = Subdivision.new(v)
+      end
+    end
+
     protected
 
     def strip_accents(v)
@@ -124,6 +135,15 @@ module ISO3166
     def parse_value(value)
       value = value.gsub(SEARCH_TERM_FILTER_REGEX, '') if value.respond_to?(:gsub)
       strip_accents(value)
+    end
+
+    def subdivision_data(alpha2)
+      file = subdivision_file_path(alpha2)
+      File.exist?(file) ? YAML.load_file(file) : {}
+    end
+
+    def subdivision_file_path(alpha2)
+      File.join(File.dirname(__FILE__), '..', 'data', 'subdivisions', "#{alpha2}.yaml")
     end
   end
 end


### PR DESCRIPTION
Currently the subdivision YAML files are being loaded for every new `Country` instance. This PR memoizes the loaded YAML file on a class instance variable.

Also replaced the `inject` -> `merge` pattern with a more performant version.

Performance changes:
From:
```ruby
pry(main)> Benchmark.realtime { 10000.times { Country['US'].subdivisions } }
=> 17.20118099998217
```
To:
```ruby
pry(main)> Benchmark.realtime { 10000.times { Country['US'].subdivisions } }
=> 0.6878289999440312
```