### PR TITLE
Corrected VAT rates of Greece

### DIFF
--- a/lib/countries/data/countries/GR.yaml
+++ b/lib/countries/data/countries/GR.yaml
@@ -27,9 +27,9 @@ GR:
   eu_member: true
   eea_member: true
   vat_rates:
-    standard: 23
+    standard: 24
     reduced:
-    - 6.5
+    - 6
     - 13
     super_reduced: 
     parking: 


### PR DESCRIPTION
Standard from 23% to 24%
Reduced from [6.5, 13] to [6, 13]

Sources:
http://www.vatlive.com/vat-rates/european-vat-rates/eu-vat-rates/
http://www.vatlive.com/european-news/greece-new-vat-rises-in-creditor-talks/