### PR TITLE
Fixed incorrect flag emoji in Readme example

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -270,7 +270,7 @@ end
 
 ``` ruby
 c = Country['MY']
-c.emoji_flag # => "🇺🇸"
+c.emoji_flag # => "🇲🇾"
 ```
 
 ## Note on Patches/Pull Requests


### PR DESCRIPTION
The wrong flag was in there! :)

```
irb(main):006:0> c = ISO3166::Country.new('MY').emoji_flag
=> "🇲🇾"
```