### PR TITLE
Correcting Ash Shamālīyah's translations location

### DIFF
--- a/lib/countries/data/subdivisions/SD.yaml
+++ b/lib/countries/data/subdivisions/SD.yaml
@@ -361,8 +361,46 @@ NO:
     max_latitude: 22.225082
     max_longitude: 32.637459
   translations:
-    ar: Ash Shamālīyah
+    ar: الشمالية
+    bg: Северна провинция
+    bn: নর্দান
+    ca: Estat del Nord
+    da: Nordlige Sudan
+    de: Asch-Schamaliyya
+    el: Νόρθερν
     en: Northern
+    es: Norte
+    eu: Iparraldea
+    fa: شمالیه
+    fi: Northern
+    fr: Nord
+    gu: નોર્થન
+    hi: उत्तरी
+    id: Asy-Syamaliyah
+    it: Nord
+    ja: 北部州
+    ka: ჩრდილოეთის შტატი
+    kn: ಉತ್ತರದ
+    ko: 북부 주
+    lt: Šiaurės vilajetas
+    mr: नॉर्थर्न
+    ms: Wilayah Utara
+    nb: Nord
+    nl: Ash-Shamaliyah
+    pl: Prowincja Północna
+    pt: Estado do Norte
+    ro: Statul de Nord
+    ru: Северный штат
+    si: නොදර්න්
+    sv: Ash-Shamaliyya
+    sw: Kaskazini
+    ta: வடக்கு
+    te: ఉత్తర
+    th: รัฐซูดานเหนือ
+    tr: Kuzey Eyaleti
+    uk: Північний штат
+    ur: شمالی (ریاست)
+    vi: Khu vực Phía Bắc
   comments: 
 DW:
   name: Gharb Dārfūr
@@ -822,45 +860,3 @@ DC:
     vi: Miền Trung Darfur
     zh: 中達爾富爾
   comments: 
-'NO':
-  translations:
-    ar: الشمالية
-    bg: Северна провинция
-    bn: নর্দান
-    ca: Estat del Nord
-    da: Nordlige Sudan
-    de: Asch-Schamaliyya
-    el: Νόρθερν
-    en: Northern
-    es: Norte
-    eu: Iparraldea
-    fa: شمالیه
-    fi: Northern
-    fr: Nord
-    gu: નોર્થન
-    hi: उत्तरी
-    id: Asy-Syamaliyah
-    it: Nord
-    ja: 北部州
-    ka: ჩრდილოეთის შტატი
-    kn: ಉತ್ತರದ
-    ko: 북부 주
-    lt: Šiaurės vilajetas
-    mr: नॉर्थर्न
-    ms: Wilayah Utara
-    nb: Nord
-    nl: Ash-Shamaliyah
-    pl: Prowincja Północna
-    pt: Estado do Norte
-    ro: Statul de Nord
-    ru: Северный штат
-    si: නොදර්න්
-    sv: Ash-Shamaliyya
-    sw: Kaskazini
-    ta: வடக்கு
-    te: ఉత్తర
-    th: รัฐซูดานเหนือ
-    tr: Kuzey Eyaleti
-    uk: Північний штат
-    ur: شمالی (ریاست)
-    vi: Khu vực Phía Bắc


### PR DESCRIPTION
Correcting Sudan - Ash Shamālīyah's translations location.  Moved from bottom of file in extra "NO" key to original NO key at line 354