### PR TITLE
Fixing language code for Urdu to ISO 639-2

### DIFF
--- a/lib/countries/data/countries/NP.yaml
+++ b/lib/countries/data/countries/NP.yaml
@@ -39,7 +39,7 @@ NP:
   - mai
   - bho
   - new
-  - urdf
+  - urd
   geo:
     latitude: 28.394857
     latitude_dec: '28.259138107299805'


### PR DESCRIPTION
urdf is not a valid language code, but urd is the valid code for Urdu