### PR TITLE
Consistently use single-quotes in code block

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -222,11 +222,11 @@ Any country registered this way will have it's data available for searching etc.
 
 ``` ruby
 ISO3166::Data.register(
-  alpha2: "LOL",
+  alpha2: 'LOL',
   name: 'Happy Country',
   translations: {
-    'en' => "Happy Country",
-    'de' => "glückliches Land"
+    'en' => 'Happy Country',
+    'de' => 'glückliches Land'
   }
 )
 


### PR DESCRIPTION
Sort of unrelated but I was also wondering if the code example makes sense with `alpha2: 'LOL'` - because of the alpha2 country code being 3 letters and not 2.