### PR TITLE
I18ndata for translations

### DIFF
--- a/countries.gemspec
+++ b/countries.gemspec
@@ -17,7 +17,7 @@ Gem::Specification.new do |gem|
   gem.license       = 'MIT'
 
   gem.add_dependency('i18n_data', '~> 0.8.0')
-  gem.add_dependency('i18n', '~> 1.0.1')
+  gem.add_dependency('i18n', '~> 0.7.0')
   gem.add_dependency('unicode_utils', '~> 1.4')
   gem.add_dependency('sixarm_ruby_unaccent', '~> 1.1')
   gem.add_development_dependency('rspec', '>= 3')

--- a/lib/countries/data.rb
+++ b/lib/countries/data.rb
@@ -115,13 +115,13 @@ module ISO3166
       end
 
       def load_translations(locale)
-        locale_names = load_cache(['locales', "#{locale}.json"])
         internal_codes.each do |alpha2|
           @@cache[alpha2]['translations'] ||= Translations.new
-          @@cache[alpha2]['translations'][locale] = locale_names[alpha2].freeze
+          @@cache[alpha2]['translations'][locale] = I18nData.countries(locale)[alpha2]
           @@cache[alpha2]['translated_names'] = @@cache[alpha2]['translations'].values.freeze
         end
         ISO3166.configuration.loaded_locales << locale
+      rescue I18nData::NoTranslationAvailable
       end
 
       def unload_translations(locale)


### PR DESCRIPTION
Instead of maintaining the locale files, we can just use the translations from `I18nData` which is already a dependency. Most importantly, `I18nData` is more complete, it contains translations such as traditional Chinese.