### PR TITLE
Add caching to the parsing of values during search

### DIFF
--- a/spec/country_spec.rb
+++ b/spec/country_spec.rb
@@ -502,6 +502,19 @@ describe ISO3166::Country do
       expect(spain_data).to be_a Hash
       expect(spain_data.keys).to eq(['ES'])
     end
+
+    it 'performs reasonably' do
+      start = Time.now
+      250.times do
+        lookup = ['ZM', 'ZMB', 'Zambia', 'US', 'USA', 'United States'].sample
+        case lookup.length
+        when 2 then ISO3166::Country.find_all_by(:alpha2, lookup)
+        when 3 then ISO3166::Country.find_all_by(:alpha3, lookup)
+        else ISO3166::Country.find_all_by(:name, lookup)
+        end
+      end
+      expect(Time.now - start).to be < 1
+    end
   end
 
   describe 'hash finder methods' do


### PR DESCRIPTION
Recently we started using this gem in our project and found that our tests had slowed down by half. They went from ~4 mins to ~8 mins. One of our team traced the slowdown to the countries gem and so we started doing some investigation.

Object creations:
----------
What it seems to come down to is the fact that when `parse_value` is called, it creates many String objects each time it is called. When searching through all the countries, this method gets called _a lot_ inside of a loop. I did a check for object allocations from calling `find_by` once and it generated somewhere between 40,000 and 50,000 new String objects. 

Overall Performance:
-----------
We also created a simple test to loop 1000 times and call `find_by` and we found that it was taking more than 10 seconds to complete. In this PR I created a similar test and these are the results from before I made the change:

```
  1) ISO3166::Country find_all_by performs reasonably
     Failure/Error: expect(Time.now - start).to be < 1

       expected: < 1
            got:   1.46281
     # ./spec/country_spec.rb:516:in `block (3 levels) in <top (required)>'
```

As you can see it takes nearly 1.5s to do 250 lookups. After I added the caching, the total time to execute 250 iterations went down significantly to 0.166 (10x faster)

```
0.166623
    performs reasonably

Finished in 0.18587 seconds (files took 0.20996 seconds to load)
1 example, 0 failures
```

Garbage Collection
---------
Presumably a lot of the slowness comes down to garbage collection. These are some key `GC.stat` numbers from before and after this change. Probably the main stat is that GC has freed up 5.5 million objects during the test run:

**Before**
```
       -:count => 32,
       +:count => 194,
       -:minor_gc_count => 25,
       +:minor_gc_count => 187,
       -:total_freed_objects => 297966,
       +:total_freed_objects => 5495021,
```

**After**
```
       -:count => 32,
       +:count => 39,
       -:minor_gc_count => 25,
       +:minor_gc_count => 32,
       -:total_freed_objects => 297847,
       +:total_freed_objects => 492313,
```

Risks:
------
What are the risks of making this change? 

- Cache returns stale data?
  I'm not sure if that's possible unless the countries.json gets changed on disk without restarting the code. Perhaps you have suggestions of how to mitigate?

- Cache uses up a lot of memory?
  At most it will 2x the memory used from the loaded countries, but the performance improvement seems to more than make up for the change

Alternatives?
------
Perhaps the parsed values could be stored in the JSON file from the beginning which would remove the need to parse them during the search loop at all?

Generate a `country_lookup.json` that only has the parsed values? It would be easy enough to process the JSON and generate a secondary one with parsed values? It seems to me that the amount of memory taken up by that new set of data would be equivalent to the cache size.
