### PR TITLE
Add Czechia as unofficial name for Czech Republic

### DIFF
--- a/lib/countries/data/countries/CZ.yaml
+++ b/lib/countries/data/countries/CZ.yaml
@@ -40,6 +40,7 @@ CZ:
   - República Checa
   - チェコ
   - Tsjechië
+  - Czechia
   languages_official:
   - cs
   - sk


### PR DESCRIPTION
Recently, Czech Republic accepted to add a shorter variation of the country name, which is Czechia, in order to provide better recognition, similar to 'France' (The French Republic) and Turkey (Republic of Turkey). However, they will retain the full name (Czech Republic), and Czechia will become the official short geographic name. This PR adds 'Czechia' to the name catalog.

- https://www.bbc.com/news/world-europe-36048186
- https://www.daytranslations.com/blog/2018/03/czechia-why-did-they-change-their-name-10935/

This PR Closes #560 