### PR TITLE
Add North Macedonia as alternate name

### DIFF
--- a/lib/countries/data/countries/MK.yaml
+++ b/lib/countries/data/countries/MK.yaml
@@ -34,6 +34,7 @@ MK:
   - マケドニア旧ユーゴスラビア共和国
   - Macedonië [FYROM]
   - Macedonia (The Former Yugoslav Republic of)
+  - North Macedonia
   languages_official:
   - mk
   languages_spoken:


### PR DESCRIPTION
Macedonia will soon officially be known as the Republic of North Macedonia, per https://www.bbc.com/news/world-europe-47002865

North Macedonia is an appropriate alternate name effective immediately
