### PR TITLE
remove bin/console from gemspec

### DIFF
--- a/countries.gemspec
+++ b/countries.gemspec
@@ -9,7 +9,6 @@ Gem::Specification.new do |gem|
   gem.homepage      = 'http://github.com/hexorx/countries'
 
   gem.files         = `git ls-files`.split($OUTPUT_RECORD_SEPARATOR)
-  gem.executables   = gem.files.grep(%r{^bin/}).map { |f| File.basename(f) }
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
   gem.name          = 'countries'
   gem.require_paths = ['lib']


### PR DESCRIPTION
bin/console shouldn't be packaged as an executable