### PR TITLE
Fix state codes from being returned as false

### DIFF
--- a/lib/countries/data/subdivisions/FO.yaml
+++ b/lib/countries/data/subdivisions/FO.yaml
@@ -1,5 +1,5 @@
 ---
-NO:
+"NO":
   unofficial_names: Nordoyar
   translations:
     en: Nordoyar

--- a/lib/countries/data/subdivisions/SD.yaml
+++ b/lib/countries/data/subdivisions/SD.yaml
@@ -351,7 +351,7 @@ NB:
     ur: نیل ازرق (ریاست)
     vi: Nin Xanh
   comments: 
-NO:
+"NO":
   name: Ash Shamālīyah
   geo:
     latitude: 18.4448963

--- a/spec/subdivision_spec.rb
+++ b/spec/subdivision_spec.rb
@@ -3,6 +3,10 @@
 require 'spec_helper'
 
 describe ISO3166::Subdivision do
+  before do
+    ISO3166::Data.reset
+  end
+
   let(:countries) { ISO3166::Country.all }
   let(:available_types) { [Hash, NilClass] }
 
@@ -12,6 +16,16 @@ describe ISO3166::Subdivision do
         country.subdivisions.each do |_, region|
           expect(available_types).to include(region.translations.class)
         end
+      end
+    end
+  end
+
+  describe 'state codes' do
+    it 'should all be strings' do
+      countries.each do |country|
+        expect(country.subdivisions.keys).to all(be_a(String)), \
+          "Expected #{country.alpha2.inspect} to have string subdivision" \
+          "codes but had #{country.subdivisions.keys.inspect}"
       end
     end
   end


### PR DESCRIPTION
This bug was caused by YAML being "helpful" and parsing "NO" as false.
YAML will also parse "YES", "No", "no", "on", "off" and many other
variations as boolean.

https://makandracards.com/makandra/24809-yaml-keys-like-yes-or-no-evaluate-to-true-and-false