### PR TITLE
Remove the `unicode_utils` gem dependency

### DIFF
--- a/countries.gemspec
+++ b/countries.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |gem|
   gem.license       = 'MIT'
 
   gem.add_dependency('i18n_data', '~> 0.10.0')
-  gem.add_dependency('unicode_utils', '~> 1.4')
   gem.add_dependency('sixarm_ruby_unaccent', '~> 1.1')
   gem.add_development_dependency('rspec', '>= 3')
   gem.add_development_dependency('activesupport', '>= 3')

--- a/lib/countries.rb
+++ b/lib/countries.rb
@@ -1,4 +1,3 @@
-require 'unicode_utils/downcase'
 require 'sixarm_ruby_unaccent'
 
 require 'countries/version'

--- a/lib/countries/country/class_methods.rb
+++ b/lib/countries/country/class_methods.rb
@@ -1,4 +1,3 @@
-require 'unicode_utils/downcase'
 require 'sixarm_ruby_unaccent'
 
 module ISO3166
@@ -106,7 +105,7 @@ module ISO3166
       if v.is_a?(Regexp)
         Regexp.new(v.source.unaccent, 'i')
       else
-        UnicodeUtils.downcase(v.to_s.unaccent)
+        v.to_s.unaccent.downcase
       end
     end
 


### PR DESCRIPTION
Given that [Ruby 2.3 EOL is scheduled for 2019-03-31](https://www.ruby-lang.org/en/downloads/branches/), I propose that we should remove the `unicode_utils` gem dependency since it's just used only for `UnicodeUtils.downcase` method. Instead, `String#downcase` should be able to replace it.

- The String#downcase supports non-ASCII from Ruby 2.4.0
- `unicode_utils` gem is no longer maintained, we should rely on more on Ruby core