### PR TITLE
Change the name of Macedonia to North Macedonia

### DIFF
--- a/lib/countries/data/countries/MK.yaml
+++ b/lib/countries/data/countries/MK.yaml
@@ -12,7 +12,7 @@ MK:
   international_prefix: '00'
   ioc: MKD
   gec: MK
-  name: Macedonia (the former Yugoslav Republic of)
+  name: North Macedonia
   national_destination_code_lengths:
   - 2
   national_number_lengths:


### PR DESCRIPTION
The name of `Macedonia` was changed to `North Macedonia` on the 13th of March 2019 -> https://www.iso.org/obp/ui/#iso:code:3166:MK