### PR TITLE
Update Ireland Subdivision Formatting and Connacht and (County) Cork Data

### DIFF
--- a/lib/countries/data/subdivisions/IE.yaml
+++ b/lib/countries/data/subdivisions/IE.yaml
@@ -1,7 +1,7 @@
 ---
 C:
   unofficial_names:
-    - Corcaigh
+    - Connaught
   translations:
     en: Connacht
     ar: كوناكت
@@ -46,7 +46,7 @@ C:
     min_longitude: -8.54552
     max_latitude: 51.93586
     max_longitude: -8.380579899999999
-  name: Cork
+  name: Connacht
 CE:
   unofficial_names:
     - An Clár
@@ -1518,6 +1518,8 @@ WX:
   name: Wexford
 CO:
   unofficial_names:
+    - Corcaigh
+    - County Cork
   translations:
     ar: مقاطعة كورك
     be: Графства Корк
@@ -1570,6 +1572,7 @@ CO:
     uk: Корк
     ur: کاؤنٹی کورک
     vi: Hạt Cork
+  name: Cork
   geo:
     latitude:
     longitude:

--- a/lib/countries/data/subdivisions/IE.yaml
+++ b/lib/countries/data/subdivisions/IE.yaml
@@ -1,7 +1,7 @@
 ---
 C:
   unofficial_names:
-  - Corcaigh
+    - Corcaigh
   translations:
     en: Connacht
     ar: كوناكت
@@ -49,7 +49,7 @@ C:
   name: Cork
 CE:
   unofficial_names:
-  - An Clár
+    - An Clár
   translations:
     en: Clare
     ar: مقاطعة كلير
@@ -109,7 +109,7 @@ CE:
   name: Clare
 CN:
   unofficial_names:
-  - An Cabhán
+    - An Cabhán
   translations:
     en: Cavan
     ar: مقاطعة كافان
@@ -167,7 +167,7 @@ CN:
   name: Cavan
 CW:
   unofficial_names:
-  - Ceatharlach
+    - Ceatharlach
   translations:
     en: Carlow
     ar: مقاطعة كارلو
@@ -227,7 +227,7 @@ CW:
   name: Carlow
 D:
   unofficial_names:
-  - Átha Cliath
+    - Átha Cliath
   translations:
     en: Dublin
     ar: مقاطعة دبلن
@@ -275,7 +275,7 @@ D:
   name: Dublin
 DL:
   unofficial_names:
-  - Dún na nGall
+    - Dún na nGall
   translations:
     en: Donegal
     ar: مقاطعة دونيجال
@@ -330,14 +330,14 @@ DL:
   geo:
     latitude: 54.6541972
     longitude: -8.110546
-    min_latitude: 
-    min_longitude: 
-    max_latitude: 
-    max_longitude: 
+    min_latitude:
+    min_longitude:
+    max_latitude:
+    max_longitude:
   name: Donegal
 G:
   unofficial_names:
-  - Gaillimh
+    - Gaillimh
   translations:
     en: Galway
     ar: مقاطعة جلوي
@@ -396,7 +396,7 @@ G:
   name: Galway
 KE:
   unofficial_names:
-  - Cill Dara
+    - Cill Dara
   translations:
     en: Kildare
     ar: مقاطعة كيلدير
@@ -455,7 +455,7 @@ KE:
   name: Kildare
 KK:
   unofficial_names:
-  - Cill Chainnigh
+    - Cill Chainnigh
   translations:
     en: Kilkenny
     ar: مقاطعة كيكني
@@ -515,8 +515,8 @@ KK:
   name: Kilkenny
 KY:
   unofficial_names:
-  - Ciarraighe
-  - Ciarraí
+    - Ciarraighe
+    - Ciarraí
   translations:
     en: Kerry
     ar: مقاطعة كري
@@ -576,8 +576,8 @@ KY:
   name: Kerry
 LD:
   unofficial_names:
-  - Longphort
-  - Longphuirt
+    - Longphort
+    - Longphuirt
   translations:
     en: Longford
     ar: مقاطعة لونجفورد
@@ -636,8 +636,8 @@ LD:
   name: Longford
 LH:
   unofficial_names:
-  - Lughbhadh
-  - Lú
+    - Lughbhadh
+    - Lú
   translations:
     en: Louth
     ar: مقاطعة لاوث
@@ -695,7 +695,7 @@ LH:
   name: Louth
 LK:
   unofficial_names:
-  - Luimneach
+    - Luimneach
   translations:
     en: Limerick
     ar: مقاطعة لمريك
@@ -755,7 +755,7 @@ LK:
   name: Limerick
 LM:
   unofficial_names:
-  - Liathdroim
+    - Liathdroim
   translations:
     en: Leitrim
     ar: مقاطعة ليتريم
@@ -805,15 +805,15 @@ LM:
   geo:
     latitude: 53.9926007
     longitude: -8.0655852
-    min_latitude: 
-    min_longitude: 
-    max_latitude: 
-    max_longitude: 
+    min_latitude:
+    min_longitude:
+    max_latitude:
+    max_longitude:
   name: Leitrim
 LS:
   unofficial_names:
-  - Laoighis
-  - Queenʿs
+    - Laoighis
+    - Queenʿs
   translations:
     en: Laois
     ar: مقاطعة ليش
@@ -869,8 +869,8 @@ LS:
   name: Laois
 MH:
   unofficial_names:
-  - An Mhí
-  - An Mhídhe
+    - An Mhí
+    - An Mhídhe
   translations:
     en: Meath
     ar: مقاطعة ميث
@@ -927,7 +927,7 @@ MH:
   name: Meath
 MN:
   unofficial_names:
-  - Muineachán
+    - Muineachán
   translations:
     en: Monaghan
     ar: مقاطعة موناغان
@@ -985,7 +985,7 @@ MN:
   name: Monaghan
 MO:
   unofficial_names:
-  - Maigh Eo
+    - Maigh Eo
   translations:
     en: Mayo
     ar: مقاطعة مايو
@@ -1045,10 +1045,10 @@ MO:
   name: Mayo
 OY:
   unofficial_names:
-  - Kingʿs
-  - Kingʿs County
-  - Ua Uíbh Fhailí
-  - Uí Fáilghe
+    - Kingʿs
+    - Kingʿs County
+    - Ua Uíbh Fhailí
+    - Uí Fáilghe
   translations:
     en: Offaly
     ar: مقاطعة أوفالي
@@ -1105,7 +1105,7 @@ OY:
   name: Offaly
 RN:
   unofficial_names:
-  - Ros Comáin
+    - Ros Comáin
   translations:
     en: Roscommon
     ar: مقاطعة روسكومون
@@ -1164,7 +1164,7 @@ RN:
   name: Roscommon
 SO:
   unofficial_names:
-  - Sligeach
+    - Sligeach
   translations:
     en: Sligo
     ar: مقاطعة سليجو
@@ -1225,7 +1225,7 @@ SO:
   name: Sligo
 TA:
   unofficial_names:
-  - Tiobraid Árann
+    - Tiobraid Árann
   translations:
     en: Tipperary
     ar: مقاطعة تيبيراري
@@ -1283,7 +1283,7 @@ TA:
   name: Tipperary
 WD:
   unofficial_names:
-  - Port Láirge
+    - Port Láirge
   translations:
     en: Waterford
     ar: مقاطعة وترفورد
@@ -1343,7 +1343,7 @@ WD:
   name: Waterford
 WH:
   unofficial_names:
-  - An Iarmhidhe
+    - An Iarmhidhe
   translations:
     en: Westmeath
     ar: مقاطعة وستميث
@@ -1399,8 +1399,8 @@ WH:
   name: Westmeath
 WW:
   unofficial_names:
-  - Cill Maintain
-  - Cill Mhanntáin
+    - Cill Maintain
+    - Cill Mhanntáin
   translations:
     en: Wicklow
     ar: مقاطعة ويكلاو
@@ -1460,7 +1460,7 @@ WW:
   name: Wicklow
 WX:
   unofficial_names:
-  - Loch Garman
+    - Loch Garman
   translations:
     en: Wexford
     ar: مقاطعة وكسفورد
@@ -1517,6 +1517,7 @@ WX:
     max_longitude: -6.4464301
   name: Wexford
 CO:
+  unofficial_names:
   translations:
     ar: مقاطعة كورك
     be: Графства Корк
@@ -1569,7 +1570,15 @@ CO:
     uk: Корк
     ur: کاؤنٹی کورک
     vi: Hạt Cork
+  geo:
+    latitude:
+    longitude:
+    min_latitude:
+    min_longitude:
+    max_latitude:
+    max_longitude:
 L:
+  unofficial_names:
   translations:
     ar: لاينستر
     be: Ленстэр
@@ -1605,7 +1614,15 @@ L:
     sv: Leinster
     uk: Ленстер
     ur: لینسٹر
+  geo:
+    latitude:
+    longitude:
+    min_latitude:
+    min_longitude:
+    max_latitude:
+    max_longitude:
 M:
+  unofficial_names:
   translations:
     ar: مونستر
     be: Манстэр
@@ -1641,7 +1658,15 @@ M:
     sv: Munster
     uk: Манстер
     ur: مونسٹر
+  geo:
+    latitude:
+    longitude:
+    min_latitude:
+    min_longitude:
+    max_latitude:
+    max_longitude:
 U:
+  unofficial_names:
   translations:
     ar: أولستر
     az: Olster
@@ -1684,3 +1709,10 @@ U:
     uk: Ольстер
     ur: السٹر
     vi: Ulster
+  geo:
+    latitude:
+    longitude:
+    min_latitude:
+    min_longitude:
+    max_latitude:
+    max_longitude:

--- a/lib/countries/data/subdivisions/IE.yaml
+++ b/lib/countries/data/subdivisions/IE.yaml
@@ -40,12 +40,12 @@ C:
     ur: کوناکٹ
     zh: 康諾特省
   geo:
-    latitude: 51.8968917
-    longitude: -8.4863157
-    min_latitude: 51.8561501
-    min_longitude: -8.54552
-    max_latitude: 51.93586
-    max_longitude: -8.380579899999999
+    latitude:
+    longitude:
+    min_latitude:
+    min_longitude:
+    max_latitude:
+    max_longitude:
   name: Connacht
 CE:
   unofficial_names:


### PR DESCRIPTION
This change updates the formatting of the subdivision yml file for Ireland (IE). The formatting was standardized using `rake update_yaml_structure`. 

Additionally, the information for the subdivisions `C` and `CO` have been updated to reflect information from [Wikipedia](https://en.wikipedia.org/wiki/ISO_3166-2:IE) for Connacht and (County) Cork respectfully.

Fixes: https://github.com/hexorx/countries/issues/594