### PR TITLE
Add Ñuble region

### DIFF
--- a/lib/countries/data/subdivisions/CL.yaml
+++ b/lib/countries/data/subdivisions/CL.yaml
@@ -670,6 +670,43 @@ ML:
     max_latitude: -34.7119045
     max_longitude: -70.3260118
   name: Maule
+NB:
+  unofficial_names:
+  - Ñuble
+  translations:
+    en: Ñuble
+    bg: Ньюбле
+    ca: Regió d’Ñuble
+    cs: Region Ñuble
+    da: Ñuble-regionen
+    de: Región de Ñuble
+    es: Región de Ñuble
+    eu: Ñuble eskualdea
+    fr: Région de Ñuble
+    gl: Rexión de Ñuble
+    hu: Ñuble régió
+    id: Region Ñuble
+    it: regione di Ñuble
+    ja: ニュブレ州
+    lt: Ñuble regionas
+    ms: Ñuble Region
+    nb: Ñuble
+    nl: Ñuble
+    pl: Ñuble
+    pt: Ñuble
+    ro: Regiunea Ñuble
+    ru: Ньюбле
+    sk: Ñuble
+    sv: Región de Ñuble
+    tr: Ñuble bölgesi
+  geo:
+    latitude: -36.599985
+    longitude: -71.905225
+    min_latitude: -37.194170
+    min_longitude: -73.064033
+    max_latitude: -35.979985
+    max_longitude: -71.007955
+  name: Región de Ñuble
 RM:
   unofficial_names:
   - Metropolitana de Santiago


### PR DESCRIPTION
Closes: #592

Chile converted Ñuble province to a region. I wasn't sure what are the translations for it in these languages, feel free to comment / add:

- [ ] AR
- [ ] BE
- [ ] EL
- [ ] FA
- [ ] FI
- [ ] GU
- [ ] HI
- [ ] HR
- [ ] HY
- [ ] JA
- [ ] KA
- [ ] KN
- [ ] KO
- [ ] MR
- [ ] SI
- [ ] SW
- [ ] TA
- [ ] TE
- [ ] TH
- [ ] UR
- [ ] VI