### PR TITLE
Potential solution for thread safety

### DIFF
--- a/lib/countries/data.rb
+++ b/lib/countries/data.rb
@@ -5,6 +5,7 @@ module ISO3166
     @@cache_dir = [File.dirname(__FILE__), 'cache']
     @@cache = {}
     @@registered_data = {}
+    @@semaphore = Mutex.new
 
     def initialize(alpha2)
       @alpha2 = alpha2.to_s.upcase
@@ -39,7 +40,9 @@ module ISO3166
       end
 
       def cache
-        update_cache
+        @@semaphore.synchronize do
+          update_cache
+        end
       end
 
       def reset


### PR DESCRIPTION
I wouldn't call this PR ready until someone can confirm that this is a real fix.

I attempted to use the small reproduction of the thread safety issue but could not get it to fail locally.

In general, though, this puts a semaphore around access to the `ISO3166::Data.config`, ensuring that threads aren't entering this method during another thread's execution of this.