### PR TITLE
Append SAR China to Hong Kong and Macao

### DIFF
--- a/lib/countries/data/countries/HK.yaml
+++ b/lib/countries/data/countries/HK.yaml
@@ -12,7 +12,7 @@ HK:
   international_prefix: '001'
   ioc: HKG
   gec: HK
-  name: Hong Kong
+  name: Hong Kong SAR China
   national_destination_code_lengths:
   - 2
   national_number_lengths:

--- a/lib/countries/data/countries/MO.yaml
+++ b/lib/countries/data/countries/MO.yaml
@@ -7,7 +7,7 @@ MO:
   international_prefix: '00'
   ioc: 
   gec: MC
-  name: Macao
+  name: Macao SAR China
   national_destination_code_lengths:
   - 2
   national_number_lengths:


### PR DESCRIPTION
👋 I think it makes sense to update "Hong Kong" and "Macao" to "Hong Kong SAR China" and "Macao SAR China" respectively as 1. those are their official names ([HK Wikipedia](https://en.wikipedia.org/wiki/Hong_Kong), [MO Wikipedia](https://en.wikipedia.org/wiki/Macau)) and 2. their non-SAR China names are still available via the `unofficial_names` key. 🇭🇰🇲🇴
https://github.com/hexorx/countries/blob/4140be00fa8820ffeedb3ec874f8df22d0a95dcf/lib/countries/data/countries/HK.yaml#L28-L29
https://github.com/hexorx/countries/blob/4140be00fa8820ffeedb3ec874f8df22d0a95dcf/lib/countries/data/countries/MO.yaml#L23-L24