### PR TITLE
Update UK EU and EEA status

### DIFF
--- a/lib/countries/data/countries/GB.yaml
+++ b/lib/countries/data/countries/GB.yaml
@@ -27,8 +27,8 @@ GB:
   world_region: EMEA
   un_locode: GB
   nationality: British
-  eu_member: true
-  eea_member: true
+  eu_member: false
+  eea_member: false
   vat_rates:
     standard: 20
     reduced:


### PR DESCRIPTION
UK has left the EU and EEA. Updating the details.

https://www.gov.uk/eu-eea