### PR TITLE
especify that there are no executables in gemfile

### DIFF
--- a/countries.gemspec
+++ b/countries.gemspec
@@ -10,6 +10,7 @@ Gem::Specification.new do |gem|
 
   gem.files         = `git ls-files`.split($OUTPUT_RECORD_SEPARATOR)
   gem.test_files    = gem.files.grep(%r{^(test|spec|features)/})
+  gem.executables   = []
   gem.name          = 'countries'
   gem.require_paths = ['lib']
   gem.version       = Countries::VERSION.dup


### PR DESCRIPTION
This addresses https://github.com/hexorx/countries/issues/627

Adding this will remove `bin/console` from the built gem, since it's not meant to be used outside of it, thus preventing name clashes with other gems.

