### PR TITLE
Update German VAT Rate with temporary reduction until the end of 2020

### DIFF
--- a/lib/countries/data/countries/DE.yaml
+++ b/lib/countries/data/countries/DE.yaml
@@ -35,11 +35,11 @@ DE:
   eu_member: true
   eea_member: true
   vat_rates:
-    standard: 19
+    standard: 16
     reduced:
-    - 7
-    super_reduced: 
-    parking: 
+    - 5
+    super_reduced:
+    parking:
   postal_code: true
   postal_code_format: "\\d{5}"
   unofficial_names:


### PR DESCRIPTION
Closes #637