### PR TITLE
Reduce VAT for Germany

### DIFF
--- a/lib/countries/data/countries/DE.yaml
+++ b/lib/countries/data/countries/DE.yaml
@@ -35,9 +35,9 @@ DE:
   eu_member: true
   eea_member: true
   vat_rates:
-    standard: 19
+    standard: 16
     reduced:
-    - 7
+    - 5
     super_reduced: 
     parking: 
   postal_code: true


### PR DESCRIPTION
Reduction of VAT for Germany following government decision from 01 July 2020