### PR TITLE
Drop support for Ruby < 2.4.0 and remove `unicode_utils`

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,10 +1,10 @@
 cache: bundler
 language: ruby
 rvm:
- - 1.9.3
- - 2.3.6
- - 2.4.3
- - 2.5.0
+ - 2.4.10
+ - 2.5.8
+ - 2.6.6
+ - 2.7.1
  - ruby-head
 before_install:
   - gem update --system
@@ -12,4 +12,3 @@ before_install:
 matrix:
   allow_failures:
     - rvm: ruby-head
-    - rvm: 1.9.3

--- a/countries.gemspec
+++ b/countries.gemspec
@@ -16,7 +16,6 @@ Gem::Specification.new do |gem|
   gem.license       = 'MIT'
 
   gem.add_dependency('i18n_data', '~> 0.10.0')
-  gem.add_dependency('unicode_utils', '~> 1.4')
   gem.add_dependency('sixarm_ruby_unaccent', '~> 1.1')
   gem.add_development_dependency('rspec', '>= 3')
   gem.add_development_dependency('activesupport', '>= 3')

--- a/lib/countries.rb
+++ b/lib/countries.rb
@@ -1,4 +1,3 @@
-require 'unicode_utils/downcase'
 require 'sixarm_ruby_unaccent'
 
 require 'countries/version'

--- a/lib/countries/country/class_methods.rb
+++ b/lib/countries/country/class_methods.rb
@@ -1,4 +1,3 @@
-require 'unicode_utils/downcase'
 require 'sixarm_ruby_unaccent'
 
 module ISO3166
@@ -106,7 +105,7 @@ module ISO3166
       if v.is_a?(Regexp)
         Regexp.new(v.source.unaccent, 'i')
       else
-        UnicodeUtils.downcase(v.to_s.unaccent)
+        v.to_s.unaccent.downcase
       end
     end
 


### PR DESCRIPTION
This PR is a follow up to https://github.com/hexorx/countries/pull/576, which intended to replace `unicode_utils` with the native `String#downcase`, since it supports non-ASCII from Ruby 2.4.0. 

I added a commit to it so that we also drop support for Ruby versions < 2.4.0 as we discussed in that PR, which might warrant a major version release to avoid breaking other projects. 

Thanks @torumori and @rposborne! 