### PR TITLE
Added Country#collect_countries_with along with two sample method overloads

### DIFF
--- a/lib/countries/country.rb
+++ b/lib/countries/country.rb
@@ -109,5 +109,11 @@ module ISO3166
                 ISO3166::Data.new(@country_data_or_code).call
               end
     end
+    
+    def find_state_with_name(state_name)
+      state = subdivisions.map{|k,v| [k,v.translations.values]}.to_h.select{|k,v| v.include? state_name}
+      state.empty? ? nil : state
+    end
+
   end
 end

--- a/lib/countries/country.rb
+++ b/lib/countries/country.rb
@@ -114,6 +114,10 @@ module ISO3166
       state = subdivisions.map{|k,v| [k,v.translations.values]}.to_h.select{|k,v| v.include? state_name}
       state.empty? ? nil : state
     end
+    
+    def find_state_code_with_translations(state)
+      subdivisions.map{|k,v| [k,v.translations]}.to_h.select{|k,v| state == k or state.in? v.values}
+    end
 
   end
 end

--- a/lib/countries/country/class_methods.rb
+++ b/lib/countries/country/class_methods.rb
@@ -89,6 +89,19 @@ module ISO3166
       end
     end
 
+    def collect_countries_with(query_val, query_method=:alpha2, result_method=:itself)
+      return nil unless [query_method, result_method].collect{|e| method_defined? e.to_sym}.all?
+      all.select{|i| i.send(query_method.to_sym).include? query_val}.collect{|e| e.send(result_method.to_sym)}.sort
+    end
+    
+    def collect_countries_with_state(state)
+      collect_countries_with(state, :states, :itself)
+    end
+    
+    def collect_country_codes_with_state(state)
+      collect_countries_with(state, :states, :alpha2)
+    end
+    
     def subdivisions(alpha2)
       @subdivisions ||= {}
       @subdivisions[alpha2] ||= create_subdivisions(subdivision_data(alpha2))

--- a/lib/countries/country/class_methods.rb
+++ b/lib/countries/country/class_methods.rb
@@ -102,6 +102,11 @@ module ISO3166
       collect_countries_with(state, :states, :alpha2)
     end
     
+    def collect_countries_with_state_name(state_name, result_method=:itself)
+      return nil unless method_defined? result_method.to_sym
+      ISO3166::Country.all.map{|e| e.send(result_method.to_sym) if e.find_state_with_name(state_name).try(:keys)}.compact
+    end
+    
     def subdivisions(alpha2)
       @subdivisions ||= {}
       @subdivisions[alpha2] ||= create_subdivisions(subdivision_data(alpha2))


### PR DESCRIPTION
Allows to collect countries using arbitrary methods and query values:
```
> ISO3166::Country.collect_countries_with("VR",:states,:name)
 => ["Italy", "Monaco"] 
> ISO3166::Country.collect_country_codes_with_state("VR")
 => ["IT", "MC"] 
```

Very useful to perform various Rails validations:
```
  class StateValidator < ActiveModel::EachValidator
    def validate_each(record, attribute, value)
      if ISO3166::Country.collect_countries_with(value,:states).empty?
        record.errors[attribute] << (options[:message] || "#{value} is not a ISO 3166-2 subdivision code")
      end
    end
  end
```