### PR TITLE
UK is an unofficial name for Great Britain

### DIFF
--- a/lib/countries/data/countries/GB.yaml
+++ b/lib/countries/data/countries/GB.yaml
@@ -46,6 +46,7 @@ GB:
   - イギリス
   - Verenigd Koninkrijk
   - Great Britain (UK)
+  - UK
   - Великобритания
   languages_official:
   - en


### PR DESCRIPTION
I would also propose adding "Great Britain" and removing "Great Britain (UK)" as that is not, in my view an unofficial name but rather the conjunction of two unofficial names, which the parenthesis serving as an "AKA." But the biggest issue is that "UK" should be a name and that's what this change does.