### PR TITLE
Add address_format for Vietnam, fixes #652

### DIFF
--- a/lib/countries/data/countries/VN.yaml
+++ b/lib/countries/data/countries/VN.yaml
@@ -1,6 +1,12 @@
 ---
 VN:
   continent: Asia
+  address_format: |-
+    {{recipient}}
+    {{street}}
+    {{city}}
+    {{region}}
+    {{country}}
   alpha2: VN
   alpha3: VNM
   country_code: '84'


### PR DESCRIPTION
Based on the source provided in #652, I added the format as:

```
address_format: |-
    {{recipient}}
    {{street}}
    {{city}}
    {{region}}
    {{country}}
```