### PR TITLE
add find_all_by example to readme

### DIFF
--- a/README.markdown
+++ b/README.markdown
@@ -88,6 +88,7 @@ You can lookup a country or an array of countries using any of the data attribut
 
 ``` ruby
 c    = ISO3166::Country.find_country_by_name('united states')
+h    = ISO3166::Country.find_all_by(:translated_names, 'França')
 list = ISO3166::Country.find_all_countries_by_region('Americas')
 c    = ISO3166::Country.find_country_by_alpha3('can')
 ```


### PR DESCRIPTION
I came across this `find_all_by` method when looking at the gem's source code. It might be useful for other people to have an example on readme.